### PR TITLE
Binary integer output formatter array sizes are incorrect

### DIFF
--- a/include/picolibrary/format.h
+++ b/include/picolibrary/format.h
@@ -259,14 +259,18 @@ class Output_Formatter<Format::Binary<Integer>> {
      */
     auto print( Output_Stream & stream, Integer value ) noexcept
     {
-        std::make_unsigned_t<Integer> u;
+        using U = std::make_unsigned_t<Integer>;
+
+        U u;
         static_assert( sizeof( u ) == sizeof( value ) );
         std::memcpy( &u, &value, sizeof( value ) );
 
-        Fixed_Size_Array<char, 2 + std::numeric_limits<Integer>::digits> binary;
+        constexpr auto bits = std::numeric_limits<U>::digits;
+
+        Fixed_Size_Array<char, 2 + bits> binary;
 
         auto i = binary.rbegin();
-        for ( auto bit = 0; bit < std::numeric_limits<Integer>::digits; ++bit ) {
+        for ( auto bit = 0; bit < bits; ++bit ) {
             *i = ( u & 0b1 ) + '0';
 
             ++i;

--- a/test/unit/picolibrary/format/binary/main.cc
+++ b/test/unit/picolibrary/format/binary/main.cc
@@ -59,8 +59,10 @@ using ::testing::Return;
 template<typename Integer>
 auto binary( Integer value )
 {
+    using U = std::make_unsigned_t<Integer>;
+
     auto const unsigned_value = [value]() {
-        auto u = std::make_unsigned_t<Integer>{};
+        U u;
         static_assert( sizeof( value ) == sizeof( u ) );
         std::memcpy( &u, &value, sizeof( value ) );
 
@@ -69,7 +71,7 @@ auto binary( Integer value )
 
     auto stream = std::ostringstream{};
 
-    stream << "0b" << std::bitset<std::numeric_limits<Integer>::digits>{ unsigned_value };
+    stream << "0b" << std::bitset<std::numeric_limits<U>::digits>{ unsigned_value };
 
     return stream.str();
 }


### PR DESCRIPTION
Resolves #152.