### PR TITLE
Fix I2C bus scan interactive test helper devices found report

### DIFF
--- a/include/picolibrary/testing/interactive/i2c.h
+++ b/include/picolibrary/testing/interactive/i2c.h
@@ -72,6 +72,8 @@ void scan( Transmitter transmitter, Controller controller ) noexcept
 
         auto const result = ::picolibrary::I2C::scan(
             controller, [ &stream, &devices_found ]( auto address, auto operation ) noexcept {
+                devices_found = true;
+
                 return stream.print(
                     "device found: {} ({})\n",
                     Format::Hexadecimal{ address.numeric() },


### PR DESCRIPTION
Resolves #291.

The I2C bus scan interactive test helper previously did not set
'devices_found' to 'true' when a device was found. This resulted in "no
devices found" being reported to the user even if devices were found.