### PR TITLE
Fix I2C device ping bus lock up

### DIFF
--- a/include/picolibrary/i2c.h
+++ b/include/picolibrary/i2c.h
@@ -800,7 +800,21 @@ auto ping( Controller & controller, Address address, Operation operation ) noexc
         guard = std::move( result ).value();
     }
 
-    return controller.address( address, operation );
+    {
+        auto result = controller.address( address, operation );
+        if ( result.is_error() ) {
+            return result.error();
+        } // if
+    }
+
+    if ( operation == Operation::READ ) {
+        auto result = controller.read( Response::NACK );
+        if ( result.is_error() ) {
+            return result.error();
+        } // if
+    }     // if
+
+    return {};
 }
 
 /**


### PR DESCRIPTION
Resolves #292.

Successfully addressing a device for a read operation results in the
device taking control of the SDA signal. The device will retain control
of the SDA signal until a NACK terminated read is performed.

The ping function previously attempted to transmit a stop condition
after it had attempted to address a device. This caused the bus to lock
up when a device was successfully addressed for a read operation. The
pin function now performs a NACK terminated read when a device is
successfully addressed for a read operation to avoid bus lock up.