### PR TITLE
Move Void definition to its own header

### DIFF
--- a/include/picolibrary/adc.h
+++ b/include/picolibrary/adc.h
@@ -27,7 +27,7 @@
 
 #include "picolibrary/error.h"
 #include "picolibrary/result.h"
-#include "picolibrary/utility.h"
+#include "picolibrary/void.h"
 
 /**
  * \brief Analog-to-Digital Converter (ADC) facilities.

--- a/include/picolibrary/algorithm.h
+++ b/include/picolibrary/algorithm.h
@@ -27,7 +27,7 @@
 #include <utility>
 
 #include "picolibrary/result.h"
-#include "picolibrary/utility.h"
+#include "picolibrary/void.h"
 
 namespace picolibrary {
 

--- a/include/picolibrary/asynchronous_serial.h
+++ b/include/picolibrary/asynchronous_serial.h
@@ -28,6 +28,7 @@
 #include "picolibrary/algorithm.h"
 #include "picolibrary/error.h"
 #include "picolibrary/result.h"
+#include "picolibrary/void.h"
 
 /**
  * \brief Asynchronous serial facilities.

--- a/include/picolibrary/asynchronous_serial/stream.h
+++ b/include/picolibrary/asynchronous_serial/stream.h
@@ -29,7 +29,7 @@
 #include "picolibrary/error.h"
 #include "picolibrary/result.h"
 #include "picolibrary/stream.h"
-#include "picolibrary/utility.h"
+#include "picolibrary/void.h"
 
 namespace picolibrary::Asynchronous_Serial {
 

--- a/include/picolibrary/error.h
+++ b/include/picolibrary/error.h
@@ -26,7 +26,7 @@
 #include <cstdint>
 #include <type_traits>
 
-#include "picolibrary/utility.h"
+#include "picolibrary/void.h"
 
 namespace picolibrary {
 

--- a/include/picolibrary/format.h
+++ b/include/picolibrary/format.h
@@ -32,7 +32,7 @@
 #include "picolibrary/fixed_size_array.h"
 #include "picolibrary/result.h"
 #include "picolibrary/stream.h"
-#include "picolibrary/utility.h"
+#include "picolibrary/void.h"
 
 /**
  * \brief Formatting facilities.

--- a/include/picolibrary/gpio.h
+++ b/include/picolibrary/gpio.h
@@ -27,7 +27,7 @@
 
 #include "picolibrary/error.h"
 #include "picolibrary/result.h"
-#include "picolibrary/utility.h"
+#include "picolibrary/void.h"
 
 /**
  * \brief General Purpose Input/Output (GPIO) facilities.

--- a/include/picolibrary/i2c.h
+++ b/include/picolibrary/i2c.h
@@ -29,7 +29,7 @@
 #include "picolibrary/algorithm.h"
 #include "picolibrary/error.h"
 #include "picolibrary/result.h"
-#include "picolibrary/utility.h"
+#include "picolibrary/void.h"
 
 /**
  * \brief Inter-Integrated Circuit (I2C) facilities.

--- a/include/picolibrary/microchip/mcp3008.h
+++ b/include/picolibrary/microchip/mcp3008.h
@@ -31,7 +31,7 @@
 #include "picolibrary/fixed_size_array.h"
 #include "picolibrary/result.h"
 #include "picolibrary/spi.h"
-#include "picolibrary/utility.h"
+#include "picolibrary/void.h"
 
 /**
  * \brief Microchip MCP3008 facilities.

--- a/include/picolibrary/result.h
+++ b/include/picolibrary/result.h
@@ -28,7 +28,7 @@
 #include <utility>
 
 #include "picolibrary/error.h"
-#include "picolibrary/utility.h"
+#include "picolibrary/void.h"
 
 namespace picolibrary {
 

--- a/include/picolibrary/spi.h
+++ b/include/picolibrary/spi.h
@@ -29,7 +29,7 @@
 #include "picolibrary/algorithm.h"
 #include "picolibrary/error.h"
 #include "picolibrary/result.h"
-#include "picolibrary/utility.h"
+#include "picolibrary/void.h"
 
 /**
  * \brief Serial Peripheral Interface (SPI) facilities.

--- a/include/picolibrary/stream.h
+++ b/include/picolibrary/stream.h
@@ -30,7 +30,7 @@
 #include "picolibrary/algorithm.h"
 #include "picolibrary/error.h"
 #include "picolibrary/result.h"
-#include "picolibrary/utility.h"
+#include "picolibrary/void.h"
 
 namespace picolibrary {
 

--- a/include/picolibrary/testing/unit/adc.h
+++ b/include/picolibrary/testing/unit/adc.h
@@ -27,7 +27,7 @@
 #include "picolibrary/adc.h"
 #include "picolibrary/error.h"
 #include "picolibrary/result.h"
-#include "picolibrary/utility.h"
+#include "picolibrary/void.h"
 
 /**
  * \brief Analog-to-Digital Converter (ADC) unit testing facilities.

--- a/include/picolibrary/testing/unit/gpio.h
+++ b/include/picolibrary/testing/unit/gpio.h
@@ -28,7 +28,7 @@
 #include "picolibrary/gpio.h"
 #include "picolibrary/result.h"
 #include "picolibrary/testing/unit/random.h"
-#include "picolibrary/utility.h"
+#include "picolibrary/void.h"
 
 namespace picolibrary::Testing::Unit {
 

--- a/include/picolibrary/testing/unit/i2c.h
+++ b/include/picolibrary/testing/unit/i2c.h
@@ -33,7 +33,7 @@
 #include "picolibrary/i2c.h"
 #include "picolibrary/result.h"
 #include "picolibrary/testing/unit/random.h"
-#include "picolibrary/utility.h"
+#include "picolibrary/void.h"
 
 namespace picolibrary::Testing::Unit {
 

--- a/include/picolibrary/testing/unit/microchip/mcp3008.h
+++ b/include/picolibrary/testing/unit/microchip/mcp3008.h
@@ -31,7 +31,7 @@
 #include "picolibrary/result.h"
 #include "picolibrary/testing/unit/random.h"
 #include "picolibrary/testing/unit/spi.h"
-#include "picolibrary/utility.h"
+#include "picolibrary/void.h"
 
 namespace picolibrary::Testing::Unit {
 

--- a/include/picolibrary/testing/unit/spi.h
+++ b/include/picolibrary/testing/unit/spi.h
@@ -30,7 +30,7 @@
 #include "gmock/gmock.h"
 #include "picolibrary/error.h"
 #include "picolibrary/result.h"
-#include "picolibrary/utility.h"
+#include "picolibrary/void.h"
 
 /**
  * \brief Serial Peripheral Interface (SPI) unit testing facilities.

--- a/include/picolibrary/testing/unit/stream.h
+++ b/include/picolibrary/testing/unit/stream.h
@@ -33,7 +33,7 @@
 #include "picolibrary/result.h"
 #include "picolibrary/stream.h"
 #include "picolibrary/testing/unit/random.h"
-#include "picolibrary/utility.h"
+#include "picolibrary/void.h"
 
 namespace picolibrary::Testing::Unit {
 

--- a/include/picolibrary/void.h
+++ b/include/picolibrary/void.h
@@ -17,13 +17,20 @@
 
 /**
  * \file
- * \brief picolibrary::Utility interface.
+ * \brief picolibrary::Void interface.
  */
 
-#ifndef PICOLIBRARY_UTILITY_H
-#define PICOLIBRARY_UTILITY_H
+#ifndef PICOLIBRARY_VOID_H
+#define PICOLIBRARY_VOID_H
 
 namespace picolibrary {
+
+/**
+ * \brief Replacement for void in contexts that require construction.
+ */
+struct Void {
+};
+
 } // namespace picolibrary
 
-#endif // PICOLIBRARY_UTILITY_H
+#endif // PICOLIBRARY_VOID_H

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -44,6 +44,7 @@ set(
     "picolibrary/spi.cc"
     "picolibrary/stream.cc"
     "picolibrary/utility.cc"
+    "picolibrary/void.cc"
 )
 set( PICOLIBRARY_LINK_LIBRARIES )
 

--- a/source/picolibrary/utility.cc
+++ b/source/picolibrary/utility.cc
@@ -21,11 +21,3 @@
  */
 
 #include "picolibrary/utility.h"
-
-#include <type_traits>
-
-namespace picolibrary {
-
-static_assert( std::is_trivially_destructible_v<Void> );
-
-} // namespace picolibrary

--- a/source/picolibrary/void.cc
+++ b/source/picolibrary/void.cc
@@ -17,13 +17,15 @@
 
 /**
  * \file
- * \brief picolibrary::Utility interface.
+ * \brief picolibrary::Void implementation.
  */
 
-#ifndef PICOLIBRARY_UTILITY_H
-#define PICOLIBRARY_UTILITY_H
+#include "picolibrary/void.h"
+
+#include <type_traits>
 
 namespace picolibrary {
-} // namespace picolibrary
 
-#endif // PICOLIBRARY_UTILITY_H
+static_assert( std::is_trivially_destructible_v<Void> );
+
+} // namespace picolibrary

--- a/test/unit/picolibrary/algorithm/main.cc
+++ b/test/unit/picolibrary/algorithm/main.cc
@@ -31,7 +31,7 @@
 #include "picolibrary/result.h"
 #include "picolibrary/testing/unit/error.h"
 #include "picolibrary/testing/unit/random.h"
-#include "picolibrary/utility.h"
+#include "picolibrary/void.h"
 
 namespace {
 

--- a/test/unit/picolibrary/asynchronous_serial/transmitter/main.cc
+++ b/test/unit/picolibrary/asynchronous_serial/transmitter/main.cc
@@ -31,7 +31,7 @@
 #include "picolibrary/testing/unit/asynchronous_serial.h"
 #include "picolibrary/testing/unit/error.h"
 #include "picolibrary/testing/unit/random.h"
-#include "picolibrary/utility.h"
+#include "picolibrary/void.h"
 
 namespace {
 

--- a/test/unit/picolibrary/asynchronous_serial/unbuffered_output_stream/main.cc
+++ b/test/unit/picolibrary/asynchronous_serial/unbuffered_output_stream/main.cc
@@ -31,7 +31,7 @@
 #include "picolibrary/testing/unit/asynchronous_serial.h"
 #include "picolibrary/testing/unit/error.h"
 #include "picolibrary/testing/unit/random.h"
-#include "picolibrary/utility.h"
+#include "picolibrary/void.h"
 
 namespace {
 

--- a/test/unit/picolibrary/asynchronous_serial/unbuffered_output_stream_buffer/main.cc
+++ b/test/unit/picolibrary/asynchronous_serial/unbuffered_output_stream_buffer/main.cc
@@ -32,7 +32,7 @@
 #include "picolibrary/testing/unit/asynchronous_serial.h"
 #include "picolibrary/testing/unit/error.h"
 #include "picolibrary/testing/unit/random.h"
-#include "picolibrary/utility.h"
+#include "picolibrary/void.h"
 
 namespace {
 

--- a/test/unit/picolibrary/error_code/main.cc
+++ b/test/unit/picolibrary/error_code/main.cc
@@ -28,7 +28,7 @@
 #include "picolibrary/error.h"
 #include "picolibrary/testing/unit/error.h"
 #include "picolibrary/testing/unit/random.h"
-#include "picolibrary/utility.h"
+#include "picolibrary/void.h"
 
 namespace {
 

--- a/test/unit/picolibrary/gpio/active_low_output_pin/main.cc
+++ b/test/unit/picolibrary/gpio/active_low_output_pin/main.cc
@@ -28,7 +28,7 @@
 #include "picolibrary/testing/unit/error.h"
 #include "picolibrary/testing/unit/gpio.h"
 #include "picolibrary/testing/unit/random.h"
-#include "picolibrary/utility.h"
+#include "picolibrary/void.h"
 
 namespace {
 

--- a/test/unit/picolibrary/i2c/bus_control_guard/main.cc
+++ b/test/unit/picolibrary/i2c/bus_control_guard/main.cc
@@ -30,7 +30,7 @@
 #include "picolibrary/testing/unit/error.h"
 #include "picolibrary/testing/unit/i2c.h"
 #include "picolibrary/testing/unit/random.h"
-#include "picolibrary/utility.h"
+#include "picolibrary/void.h"
 
 namespace {
 

--- a/test/unit/picolibrary/i2c/controller/main.cc
+++ b/test/unit/picolibrary/i2c/controller/main.cc
@@ -31,7 +31,7 @@
 #include "picolibrary/testing/unit/error.h"
 #include "picolibrary/testing/unit/i2c.h"
 #include "picolibrary/testing/unit/random.h"
-#include "picolibrary/utility.h"
+#include "picolibrary/void.h"
 
 namespace {
 

--- a/test/unit/picolibrary/i2c/device/uint8_t/main.cc
+++ b/test/unit/picolibrary/i2c/device/uint8_t/main.cc
@@ -34,7 +34,7 @@
 #include "picolibrary/testing/unit/error.h"
 #include "picolibrary/testing/unit/i2c.h"
 #include "picolibrary/testing/unit/random.h"
-#include "picolibrary/utility.h"
+#include "picolibrary/void.h"
 
 namespace {
 

--- a/test/unit/picolibrary/i2c/main.cc
+++ b/test/unit/picolibrary/i2c/main.cc
@@ -28,7 +28,7 @@
 #include "picolibrary/testing/unit/error.h"
 #include "picolibrary/testing/unit/i2c.h"
 #include "picolibrary/testing/unit/random.h"
-#include "picolibrary/utility.h"
+#include "picolibrary/void.h"
 
 namespace {
 

--- a/test/unit/picolibrary/microchip/mcp3008/driver/main.cc
+++ b/test/unit/picolibrary/microchip/mcp3008/driver/main.cc
@@ -33,7 +33,7 @@
 #include "picolibrary/testing/unit/microchip/mcp3008.h"
 #include "picolibrary/testing/unit/random.h"
 #include "picolibrary/testing/unit/spi.h"
-#include "picolibrary/utility.h"
+#include "picolibrary/void.h"
 
 namespace {
 

--- a/test/unit/picolibrary/output_stream/main.cc
+++ b/test/unit/picolibrary/output_stream/main.cc
@@ -33,7 +33,7 @@
 #include "picolibrary/testing/unit/error.h"
 #include "picolibrary/testing/unit/random.h"
 #include "picolibrary/testing/unit/stream.h"
-#include "picolibrary/utility.h"
+#include "picolibrary/void.h"
 
 namespace {
 

--- a/test/unit/picolibrary/spi/device/main.cc
+++ b/test/unit/picolibrary/spi/device/main.cc
@@ -32,7 +32,7 @@
 #include "picolibrary/testing/unit/error.h"
 #include "picolibrary/testing/unit/random.h"
 #include "picolibrary/testing/unit/spi.h"
-#include "picolibrary/utility.h"
+#include "picolibrary/void.h"
 
 namespace {
 

--- a/test/unit/picolibrary/spi/device_selection_guard/main.cc
+++ b/test/unit/picolibrary/spi/device_selection_guard/main.cc
@@ -30,7 +30,7 @@
 #include "picolibrary/testing/unit/error.h"
 #include "picolibrary/testing/unit/random.h"
 #include "picolibrary/testing/unit/spi.h"
-#include "picolibrary/utility.h"
+#include "picolibrary/void.h"
 
 namespace {
 

--- a/test/unit/picolibrary/spi/gpio_output_pin_device_selector/main.cc
+++ b/test/unit/picolibrary/spi/gpio_output_pin_device_selector/main.cc
@@ -28,7 +28,7 @@
 #include "picolibrary/testing/unit/error.h"
 #include "picolibrary/testing/unit/gpio.h"
 #include "picolibrary/testing/unit/random.h"
-#include "picolibrary/utility.h"
+#include "picolibrary/void.h"
 
 namespace {
 

--- a/test/unit/picolibrary/stream/main.cc
+++ b/test/unit/picolibrary/stream/main.cc
@@ -28,7 +28,7 @@
 #include "picolibrary/testing/unit/error.h"
 #include "picolibrary/testing/unit/random.h"
 #include "picolibrary/testing/unit/stream.h"
-#include "picolibrary/utility.h"
+#include "picolibrary/void.h"
 
 namespace {
 

--- a/test/unit/picolibrary/stream_buffer/main.cc
+++ b/test/unit/picolibrary/stream_buffer/main.cc
@@ -32,7 +32,7 @@
 #include "picolibrary/testing/unit/error.h"
 #include "picolibrary/testing/unit/random.h"
 #include "picolibrary/testing/unit/stream.h"
-#include "picolibrary/utility.h"
+#include "picolibrary/void.h"
 
 namespace {
 


### PR DESCRIPTION
Resolves #314.

Defining 'picolibrary::Void' in 'include/picolibrary/utility.h'
effectively prevented the header from being used for utilities since
many utilities will depend on '::picolibrary::Result' and
'::picolibrary::Error_Code', both of which use '::picolibrary::Void' and
are defined in their own header files. Moving '::picolibrary::Void' to
its own header file allows 'include/picolibrary/utility.h' to be used
for utilities.