### PR TITLE
Fix mock 8-bit register address space I2C device read register constness

### DIFF
--- a/include/picolibrary/testing/unit/i2c.h
+++ b/include/picolibrary/testing/unit/i2c.h
@@ -672,7 +672,7 @@ class Mock_Device<std::uint8_t> {
 
     MOCK_METHOD( (Result<Void, Error_Code>), ping, (), ( const ) );
 
-    MOCK_METHOD( (Result<std::uint8_t, Error_Code>), read, ( std::uint8_t ) );
+    MOCK_METHOD( (Result<std::uint8_t, Error_Code>), read, ( std::uint8_t ), ( const ) );
 
     MOCK_METHOD(
         (Result<std::vector<std::uint8_t>, Error_Code>),


### PR DESCRIPTION
Resolves #325.

'::picolibrary::Testing::Unit::I2C::Mock_Device<std::uint8_t>::read(
std::uint8_t )' was not const which did not match the constness of the
function being mocked.