### PR TITLE
Remove Microchip MCP23008 register cache initialization access protection

### DIFF
--- a/include/picolibrary/microchip/mcp23008.h
+++ b/include/picolibrary/microchip/mcp23008.h
@@ -257,6 +257,14 @@ class Register_Cache {
     ~Register_Cache() noexcept = default;
 
     /**
+     * \brief Reset all cached register valies to the register POR values.
+     */
+    constexpr void initialize() noexcept
+    {
+        *this = {};
+    }
+
+    /**
      * \brief Get the cached IODIR register value.
      *
      * \return The cached IODIR register value.
@@ -388,14 +396,6 @@ class Register_Cache {
      */
     constexpr auto operator =( Register_Cache const & expression ) noexcept
         -> Register_Cache & = default;
-
-    /**
-     * \brief Reset all cached register valies to the register POR values.
-     */
-    constexpr void initialize() noexcept
-    {
-        *this = {};
-    }
 
     /**
      * \brief Update the cached IODIR register value.

--- a/test/unit/picolibrary/microchip/mcp23008/register_cache/main.cc
+++ b/test/unit/picolibrary/microchip/mcp23008/register_cache/main.cc
@@ -46,7 +46,6 @@ class Cache : public ::picolibrary::Microchip::MCP23008::Register_Cache {
     using ::picolibrary::Microchip::MCP23008::Register_Cache::cache_iodir;
     using ::picolibrary::Microchip::MCP23008::Register_Cache::cache_ipol;
     using ::picolibrary::Microchip::MCP23008::Register_Cache::cache_olat;
-    using ::picolibrary::Microchip::MCP23008::Register_Cache::initialize;
 };
 
 } // namespace


### PR DESCRIPTION
Resolves #328.

The Microchip MCP23008 driver assumes the MCP23008 registers are
initially in their POR resets states. Therefore, all a driver
initialization function would do is call the register cache's
initialization function. Making the register cache's initialization
function public removed the need to write and test a driver
initialization function.