### PR TITLE
Fix indicator facilities source file is not built

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -37,6 +37,7 @@ set(
     "picolibrary/format.cc"
     "picolibrary/gpio.cc"
     "picolibrary/i2c.cc"
+    "picolibrary/indicator.cc"
     "picolibrary/iterator.cc"
     "picolibrary/microchip.cc"
     "picolibrary/microchip/mcp23008.cc"


### PR DESCRIPTION
Resolves #336.

'source/picolibrary/indicator.cc' was not being built since it had not
been added to the library source file list in 'source/CMakeLists.txt'.