### PR TITLE
Add caller provided output stream support to GPIO output pin toggle interactive test helper

### DIFF
--- a/include/picolibrary/testing/interactive/gpio.h
+++ b/include/picolibrary/testing/interactive/gpio.h
@@ -25,6 +25,8 @@
 
 #include <utility>
 
+#include "picolibrary/stream.h"
+
 /**
  * \brief General Purpose Input/Output (GPIO) interactive testing facilities.
  */
@@ -86,31 +88,18 @@ void state( Transmitter transmitter, Input_Pin pin, Delayer delay ) noexcept
 /**
  * \brief GPIO output pin toggle interactive test helper.
  *
- * \tparam Output_Stream The type of asynchronous serial output stream to use to output
- *         information to the user.
- * \tparam Transmitter The type of asynchronous serial transmitter to use to transmit
- *         information to the user.
  * \tparam Output_Pin The type of output pin to toggle.
  * \tparam Delayer A nullary functor called to introduce a delay each time the pin is
  *         toggled.
  *
- * \param[in] transmitter The asynchronous serial transmitter to use to transmit
- *            information to the user.
+ * \param[in] stream The output stream to use to output information to the user.
  * \param[in] pin The pin to toggle.
  * \param[in] delay The nullary functor called to introduce a delay each time the pin is
  *            toggled.
  */
-template<template<typename> typename Output_Stream, typename Transmitter, typename Output_Pin, typename Delayer>
-void toggle( Transmitter transmitter, Output_Pin pin, Delayer delay ) noexcept
+template<typename Output_Pin, typename Delayer>
+void toggle( Output_Stream & stream, Output_Pin pin, Delayer delay ) noexcept
 {
-    // #lizard forgives the length
-
-    auto stream = Output_Stream{ std::move( transmitter ) };
-
-    if ( stream.initialize().is_error() ) {
-        return;
-    } // if
-
     {
         auto const result = pin.initialize();
         if ( result.is_error() ) {
@@ -130,6 +119,35 @@ void toggle( Transmitter transmitter, Output_Pin pin, Delayer delay ) noexcept
             return;
         } // if
     }     // for
+}
+
+/**
+ * \brief GPIO output pin toggle interactive test helper.
+ *
+ * \tparam Output_Stream The type of asynchronous serial output stream to use to output
+ *         information to the user.
+ * \tparam Transmitter The type of asynchronous serial transmitter to use to transmit
+ *         information to the user.
+ * \tparam Output_Pin The type of output pin to toggle.
+ * \tparam Delayer A nullary functor called to introduce a delay each time the pin is
+ *         toggled.
+ *
+ * \param[in] transmitter The asynchronous serial transmitter to use to transmit
+ *            information to the user.
+ * \param[in] pin The pin to toggle.
+ * \param[in] delay The nullary functor called to introduce a delay each time the pin is
+ *            toggled.
+ */
+template<template<typename> typename Output_Stream, typename Transmitter, typename Output_Pin, typename Delayer>
+void toggle( Transmitter transmitter, Output_Pin pin, Delayer delay ) noexcept
+{
+    auto stream = Output_Stream{ std::move( transmitter ) };
+
+    if ( stream.initialize().is_error() ) {
+        return;
+    } // if
+
+    toggle( stream, std::move( pin ), std::move( delay ) );
 }
 
 } // namespace picolibrary::Testing::Interactive::GPIO


### PR DESCRIPTION
Resolves #371.

Adding caller provided output stream support to the interactive test
helper allows an interactive test to report errors that occur before the
helper is called to the user.