### PR TITLE
Add caller provided output stream support to blocking, single sample ADC sample interactive test helper

### DIFF
--- a/include/picolibrary/testing/interactive/adc.h
+++ b/include/picolibrary/testing/interactive/adc.h
@@ -26,6 +26,7 @@
 #include <utility>
 
 #include "picolibrary/format.h"
+#include "picolibrary/stream.h"
 
 /**
  * \brief Analog-to-Digital Converter (ADC) interactive testing facilities.
@@ -35,31 +36,20 @@ namespace picolibrary::Testing::Interactive::ADC {
 /**
  * \brief Blocking, single sample ADC sample interactive test helper.
  *
- * \tparam Output_Stream The type of asynchronous serial output stream to use to output
- *         information to the user.
- * \tparam Transmitter The type of asynchronous serial transmitter to use to transmit
- *         information to the user.
  * \tparam Blocking_Single_Sample_Converter The type of blocking, single sample ADC to
  *         test.
  * \tparam Delayer A nullary functor called to introduce a delay each time an ADC sample
  *         is gotten.
  *
- * \param[in] transmitter The asynchronous serial transmitter to use to transmit
- *            information to the user.
+ * \param[in] stream The output stream to use to output information to the user.
  * \param[in] adc The blocking, single sample ADC to test.
  * \param[in] delay The nullary functor called to introduce a delay each time an ADC
  *            sample is gotten.
  */
-template<template<typename> typename Output_Stream, typename Transmitter, typename Blocking_Single_Sample_Converter, typename Delayer>
-void sample_blocking_single_sample_converter( Transmitter transmitter, Blocking_Single_Sample_Converter adc, Delayer delay ) noexcept
+template<typename Blocking_Single_Sample_Converter, typename Delayer>
+void sample_blocking_single_sample_converter( Output_Stream & stream, Blocking_Single_Sample_Converter adc, Delayer delay ) noexcept
 {
     // #lizard forgives the length
-
-    auto stream = Output_Stream{ std::move( transmitter ) };
-
-    if ( stream.initialize().is_error() ) {
-        return;
-    } // if
 
     {
         auto const result = adc.initialize();
@@ -93,6 +83,36 @@ void sample_blocking_single_sample_converter( Transmitter transmitter, Blocking_
             return;
         } // if
     }     // for
+}
+
+/**
+ * \brief Blocking, single sample ADC sample interactive test helper.
+ *
+ * \tparam Output_Stream The type of asynchronous serial output stream to use to output
+ *         information to the user.
+ * \tparam Transmitter The type of asynchronous serial transmitter to use to transmit
+ *         information to the user.
+ * \tparam Blocking_Single_Sample_Converter The type of blocking, single sample ADC to
+ *         test.
+ * \tparam Delayer A nullary functor called to introduce a delay each time an ADC sample
+ *         is gotten.
+ *
+ * \param[in] transmitter The asynchronous serial transmitter to use to transmit
+ *            information to the user.
+ * \param[in] adc The blocking, single sample ADC to test.
+ * \param[in] delay The nullary functor called to introduce a delay each time an ADC
+ *            sample is gotten.
+ */
+template<template<typename> typename Output_Stream, typename Transmitter, typename Blocking_Single_Sample_Converter, typename Delayer>
+void sample_blocking_single_sample_converter( Transmitter transmitter, Blocking_Single_Sample_Converter adc, Delayer delay ) noexcept
+{
+    auto stream = Output_Stream{ std::move( transmitter ) };
+
+    if ( stream.initialize().is_error() ) {
+        return;
+    } // if
+
+    sample_blocking_single_sample_converter( stream, std::move( adc ), std::move( delay ) );
 }
 
 } // namespace picolibrary::Testing::Interactive::ADC


### PR DESCRIPTION
Resolves #373.