### PR TITLE
Remove custom pull request templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/bug.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bug.md
@@ -1,5 +1,0 @@
-Resolves #.
-
-Please describe the bug that is being fixed by this pull request in detail.
-
-@apcountryman

--- a/.github/PULL_REQUEST_TEMPLATE/enhancement.md
+++ b/.github/PULL_REQUEST_TEMPLATE/enhancement.md
@@ -1,6 +1,0 @@
-Resolves #.
-
-Please provide additional context for why this enhancement for an existing feature is
-beneficial (unless the pull request title makes it obvious).
-
-@apcountryman

--- a/.github/PULL_REQUEST_TEMPLATE/feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature.md
@@ -1,3 +1,0 @@
-Resolves #.
-
-@apcountryman

--- a/.github/PULL_REQUEST_TEMPLATE/refactoring.md
+++ b/.github/PULL_REQUEST_TEMPLATE/refactoring.md
@@ -1,6 +1,0 @@
-Resolves #.
-
-Please provide additional context for why this refactoring is beneficial (unless the pull
-request title makes it obvious).
-
-@apcountryman


### PR DESCRIPTION
Resolves #389.

GitHub does not currently have a UI for selecting pull request
templates. To use a custom pull request template, the pull request
author must manually add the 'template' query parameter to the pull
request creation URL. This effectively renders custom pull request
templates useless at this time.

All information that was captured in this project's custom pull request
templates has been copied to the default pull request template.

@apcountryman
