### PR TITLE
Update submodule URLs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -24,9 +24,9 @@
 # Google Test
 [submodule "googletest"]
 	path = googletest
-	url = ../google-googletest
+	url = ../googletest
 
 # lizard
 [submodule "lizard"]
 	path = lizard
-	url = ../terryyin-lizard
+	url = ../lizard


### PR DESCRIPTION
Resolves #395.

The lizard submodule URL pointed to a "mirror" (terryyin-lizard) instead
of a fork (lizard).

The googletest submodule URL currently pointed to a "mirror"
(google-googletest) instead of a fork (googletest).