### PR TITLE
Simplify ADC sample value access

### DIFF
--- a/include/picolibrary/adc.h
+++ b/include/picolibrary/adc.h
@@ -135,7 +135,7 @@ class Sample {
      *
      * \return The sample value.
      */
-    constexpr operator Value() const noexcept
+    constexpr auto value() const noexcept
     {
         return m_value;
     }
@@ -165,7 +165,7 @@ class Sample {
 template<typename Value, Value MIN, Value MAX>
 constexpr auto operator==( Sample<Value, MIN, MAX> lhs, Sample<Value, MIN, MAX> rhs ) noexcept
 {
-    return static_cast<Value>( lhs ) == static_cast<Value>( rhs );
+    return lhs.value() == rhs.value();
 }
 
 /**

--- a/include/picolibrary/testing/interactive/adc.h
+++ b/include/picolibrary/testing/interactive/adc.h
@@ -79,7 +79,8 @@ void sample_blocking_single_sample_converter( Output_Stream & stream, Blocking_S
             return;
         } // if
 
-        if ( stream.print( "{}\n", Format::Decimal{ result.value() } ).is_error() ) {
+        auto const sample = result.value();
+        if ( stream.print( "{}\n", Format::Decimal{ sample.value() } ).is_error() ) {
             return;
         } // if
     }     // for

--- a/test/unit/picolibrary/adc/sample/main.cc
+++ b/test/unit/picolibrary/adc/sample/main.cc
@@ -80,7 +80,7 @@ TYPED_TEST( constructorDefault, worksProperly )
 
     EXPECT_EQ( sample.min(), Sample::MIN );
     EXPECT_EQ( sample.max(), Sample::MAX );
-    EXPECT_EQ( static_cast<Value>( sample ), Value{} );
+    EXPECT_EQ( sample.value(), Value{} );
 }
 
 /**
@@ -111,7 +111,7 @@ TYPED_TEST( constructorValue, worksProperly )
 
     EXPECT_EQ( sample.min(), Sample::MIN );
     EXPECT_EQ( sample.max(), Sample::MAX );
-    EXPECT_EQ( static_cast<Value>( sample ), value );
+    EXPECT_EQ( sample.value(), value );
 }
 
 /**

--- a/test/unit/picolibrary/microchip/mcp3008/blocking_single_sample_converter/main.cc
+++ b/test/unit/picolibrary/microchip/mcp3008/blocking_single_sample_converter/main.cc
@@ -96,7 +96,7 @@ TEST( sample, worksProperly )
     auto const result = adc.sample();
 
     EXPECT_TRUE( result.is_value() );
-    EXPECT_EQ( result.value(), sample );
+    EXPECT_EQ( result.value().value(), sample );
 }
 
 /**

--- a/test/unit/picolibrary/microchip/mcp3008/driver/main.cc
+++ b/test/unit/picolibrary/microchip/mcp3008/driver/main.cc
@@ -207,7 +207,7 @@ TEST( sample, worksProperly )
     auto const result = mcp3008.sample( input );
 
     EXPECT_TRUE( result.is_value() );
-    EXPECT_EQ( result.value(), sample );
+    EXPECT_EQ( result.value().value(), sample );
 }
 
 /**


### PR DESCRIPTION
Resolves #416.

To get an ADC sample value, a user previously had to get the ADC sample
value type and then cast the ADC sample to that type. Using a named
member function instead of a user defined implicit conversion operator
to get the ADC sample value simplifies usage.

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
