### PR TITLE
Allow constexpr integer highest bit set lookup

### DIFF
--- a/include/picolibrary/bit_manipulation.h
+++ b/include/picolibrary/bit_manipulation.h
@@ -38,7 +38,7 @@ namespace picolibrary {
  * \return The value's highest bit set.
  */
 template<typename Integer>
-auto highest_bit_set( Integer value ) noexcept
+constexpr auto highest_bit_set( Integer value ) noexcept
 {
     auto bit = std::uint_fast8_t{ 0 };
 


### PR DESCRIPTION
Resolves #446 (Allow constexpr integer highest bit set lookup).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
