### PR TITLE
Add pseudo-random WIZnet W5500 socket ID generation

### DIFF
--- a/include/picolibrary/testing/unit/wiznet/w5500.h
+++ b/include/picolibrary/testing/unit/wiznet/w5500.h
@@ -23,6 +23,28 @@
 #ifndef PICOLIBRARY_TESTING_UNIT_WIZNET_W5500_H
 #define PICOLIBRARY_TESTING_UNIT_WIZNET_W5500_H
 
+#include <cstdint>
+
+#include "picolibrary/testing/unit/random.h"
+#include "picolibrary/wiznet/w5500.h"
+
+namespace picolibrary::Testing::Unit {
+
+/**
+ * \brief Generate a pseudo-random WIZnet W5500 socket ID.
+ *
+ * \return A pseudo-randomly generated WIZnet W5500 socket ID.
+ */
+template<>
+inline auto random<WIZnet::W5500::Socket_ID>()
+{
+    return static_cast<WIZnet::W5500::Socket_ID>( random<std::uint8_t>(
+        static_cast<std::uint8_t>( WIZnet::W5500::Socket_ID::_0 ),
+        static_cast<std::uint8_t>( WIZnet::W5500::Socket_ID::_7 ) ) );
+}
+
+} // namespace picolibrary::Testing::Unit
+
 /**
  * \brief WIZnet W5500 unit testing facilities.
  */


### PR DESCRIPTION
Resolves #495 (Add pseudo-random WIZnet W5500 socket ID generation).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
