### PR TITLE
Remove disable interrupts interrupt guard action on destruction

### DIFF
--- a/include/picolibrary/interrupt_guard.h
+++ b/include/picolibrary/interrupt_guard.h
@@ -41,12 +41,6 @@ struct Enable_Interrupts {
 };
 
 /**
- * \brief When a picolibrary::Interrupt_Guard is destructed, disable interrupts.
- */
-struct Disable_Interrupts {
-};
-
-/**
  * \biref Interrupt guard.
  *
  * The default interrupt guard implementation does nothing. The default implementation can
@@ -76,8 +70,7 @@ namespace picolibrary {
 template<typename Action_On_Destruction>
 class Interrupt_Guard {
   public:
-    static_assert(
-        std::is_same_v<Action_On_Destruction, Restore_Interrupt_Enable_State> or std::is_same_v<Action_On_Destruction, Enable_Interrupts> or std::is_same_v<Action_On_Destruction, Disable_Interrupts> );
+    static_assert( std::is_same_v<Action_On_Destruction, Restore_Interrupt_Enable_State> or std::is_same_v<Action_On_Destruction, Enable_Interrupts> );
 
     /**
      * \brief Constructor.


### PR DESCRIPTION
Resolves #504 (Remove disable interrupts interrupt guard action on
destruction).

Disabling interrupts was not a sensible action to take when an interrupt
guard is destroyed.

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
