### PR TITLE
Update WIZnet W5500 driver to repeatedly read unstable registers until a stable value is obtained

### DIFF
--- a/include/picolibrary/wiznet/w5500.h
+++ b/include/picolibrary/wiznet/w5500.h
@@ -2950,6 +2950,8 @@ class Driver : public Communication_Controller {
     auto read_unstable( Socket_ID socket_id, std::uint16_t offset, std::uint16_t ) const noexcept
         -> Result<std::uint16_t, Error_Code>
     {
+        // #lizard forgives the length
+
         std::uint16_t previous;
 
         {

--- a/include/picolibrary/wiznet/w5500.h
+++ b/include/picolibrary/wiznet/w5500.h
@@ -2451,7 +2451,7 @@ class Driver : public Communication_Controller {
      */
     auto read_sn_tx_fsr( Socket_ID socket_id ) const noexcept
     {
-        return read<SN_TX_FSR::Type>( socket_id, SN_TX_FSR::OFFSET );
+        return read_unstable<SN_TX_FSR::Type>( socket_id, SN_TX_FSR::OFFSET );
     }
 
     /**
@@ -2505,7 +2505,7 @@ class Driver : public Communication_Controller {
      */
     auto read_sn_rx_rsr( Socket_ID socket_id ) const noexcept
     {
-        return read<SN_RX_RSR::Type>( socket_id, SN_RX_RSR::OFFSET );
+        return read_unstable<SN_RX_RSR::Type>( socket_id, SN_RX_RSR::OFFSET );
     }
 
     /**
@@ -2919,6 +2919,60 @@ class Driver : public Communication_Controller {
         } // if
 
         return buffer;
+    }
+
+    /**
+     * \brief Read an unstable socket register.
+     *
+     * \tparam Register The type of register to read.
+     *
+     * \param[in] socket_id The ID of the socket whose register is to be read.
+     * \param[in] offset The offset of the register to read.
+     *
+     * \return The data read from the register if the read succeeded.
+     * \return An error code if the read failed.
+     */
+    template<typename Register>
+    auto read_unstable( Socket_ID socket_id, std::uint16_t offset ) const noexcept
+    {
+        return read_unstable( socket_id, offset, Register{} );
+    }
+
+    /**
+     * \brief Read an unstable socket register.
+     *
+     * \param[in] socket_id The ID of the socket whose register is to be read.
+     * \param[in] offset The offset of the register to read.
+     *
+     * \return The data read from the register if the read succeeded.
+     * \return An error code if the read failed.
+     */
+    auto read_unstable( Socket_ID socket_id, std::uint16_t offset, std::uint16_t ) const noexcept
+        -> Result<std::uint16_t, Error_Code>
+    {
+        std::uint16_t previous;
+
+        {
+            auto result = read<std::uint16_t>( socket_id, offset );
+            if ( result.is_error() ) {
+                return result.error();
+            } // if
+
+            previous = result.value();
+        }
+
+        for ( ;; ) {
+            auto result = read<std::uint16_t>( socket_id, offset );
+            if ( result.is_error() ) {
+                return result.error();
+            } // if
+
+            if ( result.value() == previous ) {
+                return result.value();
+            } // if
+
+            previous = result.value();
+        } // for
     }
 
     /**


### PR DESCRIPTION
Resolves #517 (Update WIZnet W5500 driver to repeatedly read unstable
registers until a stable value is obtained).

The WIZnet W5500's SN_TX_FSR and SN_RX_RSR registers are not guaranteed
to be stable when read and thus the datasheet recommends reading them
repeatedly until a stable value is obtained.

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
