### PR TITLE
Add WIZnet W5500 socket interrupt masks

### DIFF
--- a/include/picolibrary/wiznet/w5500.h
+++ b/include/picolibrary/wiznet/w5500.h
@@ -1628,6 +1628,17 @@ enum class Socket_Status : std::uint8_t {
 };
 
 /**
+ * \brief WIZnet W5500 socket interrupt masks.
+ */
+struct Socket_Interrupt {
+    static constexpr auto PEER_CONNECTED    = SN_IR::Mask::CON;    ///< Peer connected.
+    static constexpr auto PEER_DISCONNECTED = SN_IR::Mask::DISCON; ///< Peer disconnected.
+    static constexpr auto DATA_RECEIVED     = SN_IR::Mask::RECV;   ///< Data received.
+    static constexpr auto TIMEOUT   = SN_IR::Mask::TIMEOUT; ///< ARP/TCP timeout occurred.
+    static constexpr auto DATA_SENT = SN_IR::Mask::SEND_OK; ///< SEND command completed.
+};
+
+/**
  * \brief WIZnet W5500 driver.
  *
  * \tparam Controller_Type The type of SPI controller used to communicate with the W5500.

--- a/source/picolibrary/wiznet/w5500.cc
+++ b/source/picolibrary/wiznet/w5500.cc
@@ -43,4 +43,10 @@ static_assert( SN_MR::Bit::MFEN == 7 ); // NOLINT(cppcoreguidelines-avoid-magic-
 static_assert( SN_IR::Bit::RESERVED5 == 5 ); // NOLINT(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
 static_assert( SN_IMR::Bit::RESERVED5 == 5 ); // NOLINT(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
 
+static_assert( SN_IR::Bit::CON == SN_IMR::Bit::CON );
+static_assert( SN_IR::Bit::DISCON == SN_IMR::Bit::DISCON );
+static_assert( SN_IR::Bit::RECV == SN_IMR::Bit::RECV );
+static_assert( SN_IR::Bit::TIMEOUT == SN_IMR::Bit::TIMEOUT );
+static_assert( SN_IR::Bit::SEND_OK == SN_IMR::Bit::SEND_OK );
+
 } // namespace picolibrary::WIZnet::W5500


### PR DESCRIPTION
Resolves #521 (Add WIZnet W5500 socket interrupt masks).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
