### PR TITLE
Add WIZnet W5500 socket MACRAW/UDP broadcast blocking configuration

### DIFF
--- a/include/picolibrary/wiznet/w5500.h
+++ b/include/picolibrary/wiznet/w5500.h
@@ -1593,6 +1593,14 @@ enum class Protocol : std::uint8_t {
 };
 
 /**
+ * \brief WIZnet W5500 socket MACRAW/UDP broadcast blocking configuration.
+ */
+enum class Broadcast_Blocking : std::uint8_t {
+    DISABLED = 0b0 << SN_MR::Bit::BCASTB, ///< Disabled.
+    ENABLED  = 0b1 << SN_MR::Bit::BCASTB, ///< Enabled.
+};
+
+/**
  * \brief WIZnet W5500 socket MACRAW IPv6 packet blocking configuration.
  */
 enum class MACRAW_IPv6_Packet_Blocking : std::uint8_t {


### PR DESCRIPTION
Resolves #525 (Add WIZnet W5500 socket MACRAW/UDP broadcast blocking
configuration).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
