### PR TITLE
Add WIZnet W5500 socket TCP no delayed ACK configuration

### DIFF
--- a/include/picolibrary/wiznet/w5500.h
+++ b/include/picolibrary/wiznet/w5500.h
@@ -1593,6 +1593,14 @@ enum class Protocol : std::uint8_t {
 };
 
 /**
+ * \brief WIZnet W5500 socket TCP no delayed ACK configuration.
+ */
+enum class No_Delayed_ACK : std::uint8_t {
+    DISABLED = 0b0 << SN_MR::Bit::ND, ///< Disabled.
+    ENABLED  = 0b1 << SN_MR::Bit::ND, ///< Enabled.
+};
+
+/**
  * \brief WIZnet W5500 socket MACRAW/UDP broadcast blocking configuration.
  */
 enum class Broadcast_Blocking : std::uint8_t {


### PR DESCRIPTION
Resolves #527 (Add WIZnet W5500 socket TCP no delayed ACK
configuration).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
