### PR TITLE
Add WIZnet W5500 socket UDP unicast blocking configuration

### DIFF
--- a/include/picolibrary/wiznet/w5500.h
+++ b/include/picolibrary/wiznet/w5500.h
@@ -1609,6 +1609,14 @@ enum class Broadcast_Blocking : std::uint8_t {
 };
 
 /**
+ * \brief WIZnet W5500 socket UDP unicast blocking configuration.
+ */
+enum class UDP_Unicast_Blocking : std::uint8_t {
+    DISABLED = 0b0 << SN_MR::Bit::UCASTB, ///< Disabled.
+    ENABLED  = 0b1 << SN_MR::Bit::UCASTB, ///< Enabled.
+};
+
+/**
  * \brief WIZnet W5500 socket UDP multicast IGMP version.
  */
 enum class UDP_Multicast_IGMP_Version : std::uint8_t {


### PR DESCRIPTION
Resolves #530 (Add WIZnet W5500 socket UDP unicast blocking
configuration).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
