### PR TITLE
Reduce unit testing build time

### DIFF
--- a/include/picolibrary/testing/unit/error.h
+++ b/include/picolibrary/testing/unit/error.h
@@ -71,7 +71,7 @@ class Mock_Error_Category : public Error_Category {
     /**
      * \brief Constructor.
      */
-    Mock_Error_Category() = default;
+    Mock_Error_Category();
 
     Mock_Error_Category( Mock_Error_Category && ) = delete;
 
@@ -80,7 +80,7 @@ class Mock_Error_Category : public Error_Category {
     /**
      * \brief Destructor.
      */
-    ~Mock_Error_Category() noexcept = default;
+    ~Mock_Error_Category() noexcept;
 
     auto operator=( Mock_Error_Category && ) = delete;
 

--- a/include/picolibrary/testing/unit/gpio.h
+++ b/include/picolibrary/testing/unit/gpio.h
@@ -167,7 +167,7 @@ class Mock_Input_Pin {
     /**
      * \brief Constructor.
      */
-    Mock_Input_Pin() = default;
+    Mock_Input_Pin();
 
     Mock_Input_Pin( Mock_Input_Pin && ) = delete;
 
@@ -176,7 +176,7 @@ class Mock_Input_Pin {
     /**
      * \brief Destructor.
      */
-    ~Mock_Input_Pin() noexcept = default;
+    ~Mock_Input_Pin() noexcept;
 
     auto operator=( Mock_Input_Pin && ) = delete;
 
@@ -329,7 +329,7 @@ class Mock_Internally_Pulled_Up_Input_Pin {
     /**
      * \brief Constructor.
      */
-    Mock_Internally_Pulled_Up_Input_Pin() = default;
+    Mock_Internally_Pulled_Up_Input_Pin();
 
     Mock_Internally_Pulled_Up_Input_Pin( Mock_Internally_Pulled_Up_Input_Pin && ) = delete;
 
@@ -338,7 +338,7 @@ class Mock_Internally_Pulled_Up_Input_Pin {
     /**
      * \brief Destructor.
      */
-    ~Mock_Internally_Pulled_Up_Input_Pin() noexcept = default;
+    ~Mock_Internally_Pulled_Up_Input_Pin() noexcept;
 
     auto operator=( Mock_Internally_Pulled_Up_Input_Pin && ) = delete;
 
@@ -494,7 +494,7 @@ class Mock_Output_Pin {
     /**
      * \brief Constructor.
      */
-    Mock_Output_Pin() = default;
+    Mock_Output_Pin();
 
     Mock_Output_Pin( Mock_Output_Pin && ) = delete;
 
@@ -503,7 +503,7 @@ class Mock_Output_Pin {
     /**
      * \brief Destructor.
      */
-    ~Mock_Output_Pin() noexcept = default;
+    ~Mock_Output_Pin() noexcept;
 
     auto operator=( Mock_Output_Pin && ) = delete;
 
@@ -669,7 +669,7 @@ class Mock_IO_Pin {
     /**
      * \brief Constructor.
      */
-    Mock_IO_Pin() = default;
+    Mock_IO_Pin();
 
     Mock_IO_Pin( Mock_IO_Pin && ) = delete;
 
@@ -678,7 +678,7 @@ class Mock_IO_Pin {
     /**
      * \brief Destructor.
      */
-    ~Mock_IO_Pin() noexcept = default;
+    ~Mock_IO_Pin() noexcept;
 
     auto operator=( Mock_IO_Pin && ) = delete;
 

--- a/include/picolibrary/testing/unit/hsm.h
+++ b/include/picolibrary/testing/unit/hsm.h
@@ -56,7 +56,7 @@ class Mock_Event_Category : public ::picolibrary::HSM::Event_Category {
     /**
      * \brief Constructor.
      */
-    Mock_Event_Category() = default;
+    Mock_Event_Category();
 
     Mock_Event_Category( Mock_Event_Category && ) = delete;
 
@@ -65,7 +65,7 @@ class Mock_Event_Category : public ::picolibrary::HSM::Event_Category {
     /**
      * \brief Destructor.
      */
-    ~Mock_Event_Category() noexcept = default;
+    ~Mock_Event_Category() noexcept;
 
     auto operator=( Mock_Event_Category && ) = delete;
 
@@ -83,16 +83,13 @@ class Mock_Event : public ::picolibrary::HSM::Event {
   public:
     Mock_Event(
         Mock_Event_Category const &  category = Mock_Event_Category::instance(),
-        ::picolibrary::HSM::Event_ID id       = random<::picolibrary::HSM::Event_ID>() ) :
-        ::picolibrary::HSM::Event{ category, id }
-    {
-    }
+        ::picolibrary::HSM::Event_ID id       = random<::picolibrary::HSM::Event_ID>() );
 
     Mock_Event( Mock_Event && ) = delete;
 
     Mock_Event( Mock_Event const & ) = delete;
 
-    virtual ~Mock_Event() noexcept override = default;
+    virtual ~Mock_Event() noexcept override;
 
     auto operator=( Mock_Event && ) = delete;
 

--- a/include/picolibrary/testing/unit/i2c.h
+++ b/include/picolibrary/testing/unit/i2c.h
@@ -295,7 +295,7 @@ class Mock_Basic_Controller {
     /**
      * \brief Constructor.
      */
-    Mock_Basic_Controller() = default;
+    Mock_Basic_Controller();
 
     Mock_Basic_Controller( Mock_Basic_Controller && ) = delete;
 
@@ -304,7 +304,7 @@ class Mock_Basic_Controller {
     /**
      * \brief Destructor.
      */
-    ~Mock_Basic_Controller() noexcept = default;
+    ~Mock_Basic_Controller() noexcept;
 
     auto operator=( Mock_Basic_Controller && ) = delete;
 
@@ -533,7 +533,7 @@ class Mock_Controller {
     /**
      * \brief Constructor.
      */
-    Mock_Controller() = default;
+    Mock_Controller();
 
     Mock_Controller( Mock_Controller && ) = delete;
 
@@ -542,7 +542,7 @@ class Mock_Controller {
     /**
      * \brief Destructor.
      */
-    ~Mock_Controller() noexcept = default;
+    ~Mock_Controller() noexcept;
 
     auto operator=( Mock_Controller && ) = delete;
 
@@ -636,7 +636,7 @@ class Mock_Device<std::uint8_t> {
     /**
      * \brief Constructor.
      */
-    Mock_Device() = default;
+    Mock_Device();
 
     /**
      * \brief Constructor.
@@ -652,7 +652,7 @@ class Mock_Device<std::uint8_t> {
     /**
      * \brief Destructor.
      */
-    ~Mock_Device() noexcept = default;
+    ~Mock_Device() noexcept;
 
     auto operator=( Mock_Device && ) = delete;
 

--- a/include/picolibrary/testing/unit/indicator.h
+++ b/include/picolibrary/testing/unit/indicator.h
@@ -182,7 +182,7 @@ class Mock_Fixed_Intensity_Indicator {
     /**
      * \brief Constructor.
      */
-    Mock_Fixed_Intensity_Indicator() = default;
+    Mock_Fixed_Intensity_Indicator();
 
     Mock_Fixed_Intensity_Indicator( Mock_Fixed_Intensity_Indicator && ) = delete;
 
@@ -191,7 +191,7 @@ class Mock_Fixed_Intensity_Indicator {
     /**
      * \brief Destructor.
      */
-    ~Mock_Fixed_Intensity_Indicator() noexcept = default;
+    ~Mock_Fixed_Intensity_Indicator() noexcept;
 
     auto operator=( Mock_Fixed_Intensity_Indicator && ) = delete;
 

--- a/include/picolibrary/testing/unit/microchip/mcp23008.h
+++ b/include/picolibrary/testing/unit/microchip/mcp23008.h
@@ -90,7 +90,7 @@ class Mock_Register_Cache {
     /**
      * \brief Constructor.
      */
-    Mock_Register_Cache() = default;
+    Mock_Register_Cache();
 
     Mock_Register_Cache( Mock_Register_Cache && ) = delete;
 
@@ -99,7 +99,7 @@ class Mock_Register_Cache {
     /**
      * \brief Destructor.
      */
-    ~Mock_Register_Cache() noexcept = default;
+    ~Mock_Register_Cache() noexcept;
 
     auto operator=( Mock_Register_Cache && ) = delete;
 
@@ -152,7 +152,7 @@ class Mock_Driver : public I2C::Mock_Device<std::uint8_t>, public Mock_Register_
     /**
      * \brief Constructor.
      */
-    Mock_Driver() = default;
+    Mock_Driver();
 
     Mock_Driver( Mock_Driver && ) = delete;
 
@@ -161,7 +161,7 @@ class Mock_Driver : public I2C::Mock_Device<std::uint8_t>, public Mock_Register_
     /**
      * \brief Destructor.
      */
-    ~Mock_Driver() noexcept = default;
+    ~Mock_Driver() noexcept;
 
     auto operator=( Mock_Driver && ) = delete;
 

--- a/include/picolibrary/testing/unit/microchip/mcp3008.h
+++ b/include/picolibrary/testing/unit/microchip/mcp3008.h
@@ -96,7 +96,7 @@ class Mock_Driver {
     /**
      * \brief Constructor.
      */
-    Mock_Driver() = default;
+    Mock_Driver();
 
     /**
      * \brief Constructor.
@@ -112,7 +112,7 @@ class Mock_Driver {
     /**
      * \brief Destructor.
      */
-    ~Mock_Driver() noexcept = default;
+    ~Mock_Driver() noexcept;
 
     auto operator=( Mock_Driver && ) = delete;
 

--- a/include/picolibrary/testing/unit/spi.h
+++ b/include/picolibrary/testing/unit/spi.h
@@ -169,7 +169,7 @@ class Mock_Basic_Controller {
     /**
      * \brief Constructor.
      */
-    Mock_Basic_Controller() = default;
+    Mock_Basic_Controller();
 
     Mock_Basic_Controller( Mock_Basic_Controller && ) = delete;
 
@@ -178,7 +178,7 @@ class Mock_Basic_Controller {
     /**
      * \brief Destructor.
      */
-    ~Mock_Basic_Controller() noexcept = default;
+    ~Mock_Basic_Controller() noexcept;
 
     auto operator=( Mock_Basic_Controller && ) = delete;
 
@@ -404,7 +404,7 @@ class Mock_Controller {
     /**
      * \brief Constructor.
      */
-    Mock_Controller() = default;
+    Mock_Controller();
 
     Mock_Controller( Mock_Controller && ) = delete;
 
@@ -413,7 +413,7 @@ class Mock_Controller {
     /**
      * \brief Destructor.
      */
-    ~Mock_Controller() noexcept = default;
+    ~Mock_Controller() noexcept;
 
     auto operator=( Mock_Controller && ) = delete;
 
@@ -638,7 +638,7 @@ class Mock_Device_Selector {
     /**
      * \brief Constructor.
      */
-    Mock_Device_Selector() = default;
+    Mock_Device_Selector();
 
     Mock_Device_Selector( Mock_Device_Selector && ) = delete;
 
@@ -647,7 +647,7 @@ class Mock_Device_Selector {
     /**
      * \brief Destructor.
      */
-    ~Mock_Device_Selector() noexcept = default;
+    ~Mock_Device_Selector() noexcept;
 
     auto operator=( Mock_Device_Selector && ) = delete;
 
@@ -688,7 +688,7 @@ class Mock_Device {
     /**
      * \brief Constructor.
      */
-    Mock_Device() = default;
+    Mock_Device();
 
     /**
      * \brief Constructor.
@@ -704,7 +704,7 @@ class Mock_Device {
     /**
      * \brief Destructor.
      */
-    ~Mock_Device() noexcept = default;
+    ~Mock_Device() noexcept;
 
     auto operator=( Mock_Device && ) = delete;
 

--- a/include/picolibrary/testing/unit/stream.h
+++ b/include/picolibrary/testing/unit/stream.h
@@ -45,7 +45,7 @@ class Mock_Stream_Buffer : public Stream_Buffer {
     /**
      * \brief Constructor.
      */
-    Mock_Stream_Buffer() = default;
+    Mock_Stream_Buffer();
 
     Mock_Stream_Buffer( Mock_Stream_Buffer && ) = delete;
 
@@ -54,7 +54,7 @@ class Mock_Stream_Buffer : public Stream_Buffer {
     /**
      * \brief Destructor.
      */
-    ~Mock_Stream_Buffer() noexcept = default;
+    ~Mock_Stream_Buffer() noexcept;
 
     auto operator=( Mock_Stream_Buffer && ) = delete;
 
@@ -187,10 +187,7 @@ class Mock_Output_Stream : public Output_Stream {
     /**
      * \brief Constructor.
      */
-    Mock_Output_Stream()
-    {
-        set_buffer( &m_buffer );
-    }
+    Mock_Output_Stream();
 
     Mock_Output_Stream( Mock_Output_Stream && ) = delete;
 
@@ -199,7 +196,7 @@ class Mock_Output_Stream : public Output_Stream {
     /**
      * \brief Destructor.
      */
-    ~Mock_Output_Stream() noexcept = default;
+    ~Mock_Output_Stream() noexcept;
 
     auto operator=( Mock_Output_Stream && ) = delete;
 

--- a/include/picolibrary/testing/unit/wiznet/w5500.h
+++ b/include/picolibrary/testing/unit/wiznet/w5500.h
@@ -98,7 +98,7 @@ class Mock_Communication_Controller : public SPI::Mock_Device {
     /**
      * \brief Constructor.
      */
-    Mock_Communication_Controller() = default;
+    Mock_Communication_Controller();
 
     /**
      * \brief Constructor.
@@ -114,7 +114,7 @@ class Mock_Communication_Controller : public SPI::Mock_Device {
     /**
      * \brief Destructor.
      */
-    ~Mock_Communication_Controller() noexcept = default;
+    ~Mock_Communication_Controller() noexcept;
 
     auto operator=( Mock_Communication_Controller && ) = delete;
 
@@ -264,7 +264,7 @@ class Mock_Driver : public Mock_Communication_Controller {
     /**
      * \brief Constructor.
      */
-    Mock_Driver() = default;
+    Mock_Driver();
 
     /**
      * \brief Constructor.
@@ -280,7 +280,7 @@ class Mock_Driver : public Mock_Communication_Controller {
     /**
      * \brief Destructor.
      */
-    ~Mock_Driver() noexcept = default;
+    ~Mock_Driver() noexcept;
 
     auto operator=( Mock_Driver && ) = delete;
 

--- a/source/picolibrary/testing/unit/error.cc
+++ b/source/picolibrary/testing/unit/error.cc
@@ -21,3 +21,15 @@
  */
 
 #include "picolibrary/testing/unit/error.h"
+
+namespace picolibrary::Testing::Unit {
+
+Mock_Error_Category::Mock_Error_Category()
+{
+}
+
+Mock_Error_Category::~Mock_Error_Category() noexcept
+{
+}
+
+} // namespace picolibrary::Testing::Unit

--- a/source/picolibrary/testing/unit/gpio.cc
+++ b/source/picolibrary/testing/unit/gpio.cc
@@ -21,3 +21,39 @@
  */
 
 #include "picolibrary/testing/unit/gpio.h"
+
+namespace picolibrary::Testing::Unit::GPIO {
+
+Mock_Input_Pin::Mock_Input_Pin()
+{
+}
+
+Mock_Input_Pin::~Mock_Input_Pin() noexcept
+{
+}
+
+Mock_Internally_Pulled_Up_Input_Pin::Mock_Internally_Pulled_Up_Input_Pin()
+{
+}
+
+Mock_Internally_Pulled_Up_Input_Pin::~Mock_Internally_Pulled_Up_Input_Pin() noexcept
+{
+}
+
+Mock_Output_Pin::Mock_Output_Pin()
+{
+}
+
+Mock_Output_Pin::~Mock_Output_Pin() noexcept
+{
+}
+
+Mock_IO_Pin::Mock_IO_Pin()
+{
+}
+
+Mock_IO_Pin::~Mock_IO_Pin() noexcept
+{
+}
+
+} // namespace picolibrary::Testing::Unit::GPIO

--- a/source/picolibrary/testing/unit/hsm.cc
+++ b/source/picolibrary/testing/unit/hsm.cc
@@ -21,3 +21,26 @@
  */
 
 #include "picolibrary/testing/unit/hsm.h"
+
+#include "picolibrary/hsm.h"
+
+namespace picolibrary::Testing::Unit::HSM {
+
+Mock_Event_Category::Mock_Event_Category()
+{
+}
+
+Mock_Event_Category::~Mock_Event_Category() noexcept
+{
+}
+
+Mock_Event::Mock_Event( Mock_Event_Category const & category, ::picolibrary::HSM::Event_ID id ) :
+    ::picolibrary::HSM::Event{ category, id }
+{
+}
+
+Mock_Event::~Mock_Event() noexcept
+{
+}
+
+} // namespace picolibrary::Testing::Unit::HSM

--- a/source/picolibrary/testing/unit/i2c.cc
+++ b/source/picolibrary/testing/unit/i2c.cc
@@ -21,3 +21,31 @@
  */
 
 #include "picolibrary/testing/unit/i2c.h"
+
+namespace picolibrary::Testing::Unit::I2C {
+
+Mock_Basic_Controller::Mock_Basic_Controller()
+{
+}
+
+Mock_Basic_Controller::~Mock_Basic_Controller() noexcept
+{
+}
+
+Mock_Controller::Mock_Controller()
+{
+}
+
+Mock_Controller::~Mock_Controller() noexcept
+{
+}
+
+Mock_Device<std::uint8_t>::Mock_Device()
+{
+}
+
+Mock_Device<std::uint8_t>::~Mock_Device() noexcept
+{
+}
+
+} // namespace picolibrary::Testing::Unit::I2C

--- a/source/picolibrary/testing/unit/indicator.cc
+++ b/source/picolibrary/testing/unit/indicator.cc
@@ -21,3 +21,15 @@
  */
 
 #include "picolibrary/testing/unit/indicator.h"
+
+namespace picolibrary::Testing::Unit::Indicator {
+
+Mock_Fixed_Intensity_Indicator::Mock_Fixed_Intensity_Indicator()
+{
+}
+
+Mock_Fixed_Intensity_Indicator::~Mock_Fixed_Intensity_Indicator() noexcept
+{
+}
+
+} // namespace picolibrary::Testing::Unit::Indicator

--- a/source/picolibrary/testing/unit/microchip/mcp23008.cc
+++ b/source/picolibrary/testing/unit/microchip/mcp23008.cc
@@ -21,3 +21,23 @@
  */
 
 #include "picolibrary/testing/unit/microchip/mcp23008.h"
+
+namespace picolibrary::Testing::Unit::Microchip::MCP23008 {
+
+Mock_Register_Cache::Mock_Register_Cache()
+{
+}
+
+Mock_Register_Cache::~Mock_Register_Cache() noexcept
+{
+}
+
+Mock_Driver::Mock_Driver()
+{
+}
+
+Mock_Driver::~Mock_Driver() noexcept
+{
+}
+
+} // namespace picolibrary::Testing::Unit::Microchip::MCP23008

--- a/source/picolibrary/testing/unit/microchip/mcp3008.cc
+++ b/source/picolibrary/testing/unit/microchip/mcp3008.cc
@@ -21,3 +21,15 @@
  */
 
 #include "picolibrary/testing/unit/microchip/mcp3008.h"
+
+namespace picolibrary::Testing::Unit::Microchip::MCP3008 {
+
+Mock_Driver::Mock_Driver()
+{
+}
+
+Mock_Driver::~Mock_Driver() noexcept
+{
+}
+
+} // namespace picolibrary::Testing::Unit::Microchip::MCP3008

--- a/source/picolibrary/testing/unit/spi.cc
+++ b/source/picolibrary/testing/unit/spi.cc
@@ -21,3 +21,39 @@
  */
 
 #include "picolibrary/testing/unit/spi.h"
+
+namespace picolibrary::Testing::Unit::SPI {
+
+Mock_Basic_Controller::Mock_Basic_Controller()
+{
+}
+
+Mock_Basic_Controller::~Mock_Basic_Controller() noexcept
+{
+}
+
+Mock_Controller::Mock_Controller()
+{
+}
+
+Mock_Controller::~Mock_Controller() noexcept
+{
+}
+
+Mock_Device_Selector::Mock_Device_Selector()
+{
+}
+
+Mock_Device_Selector::~Mock_Device_Selector() noexcept
+{
+}
+
+Mock_Device::Mock_Device()
+{
+}
+
+Mock_Device::~Mock_Device() noexcept
+{
+}
+
+} // namespace picolibrary::Testing::Unit::SPI

--- a/source/picolibrary/testing/unit/stream.cc
+++ b/source/picolibrary/testing/unit/stream.cc
@@ -21,3 +21,24 @@
  */
 
 #include "picolibrary/testing/unit/stream.h"
+
+namespace picolibrary::Testing::Unit {
+
+Mock_Stream_Buffer::Mock_Stream_Buffer()
+{
+}
+
+Mock_Stream_Buffer::~Mock_Stream_Buffer() noexcept
+{
+}
+
+Mock_Output_Stream::Mock_Output_Stream()
+{
+    set_buffer( &m_buffer );
+}
+
+Mock_Output_Stream::~Mock_Output_Stream() noexcept
+{
+}
+
+} // namespace picolibrary::Testing::Unit

--- a/source/picolibrary/testing/unit/wiznet/w5500.cc
+++ b/source/picolibrary/testing/unit/wiznet/w5500.cc
@@ -21,3 +21,23 @@
  */
 
 #include "picolibrary/testing/unit/wiznet/w5500.h"
+
+namespace picolibrary::Testing::Unit::WIZnet::W5500 {
+
+Mock_Communication_Controller::Mock_Communication_Controller()
+{
+}
+
+Mock_Communication_Controller::~Mock_Communication_Controller() noexcept
+{
+}
+
+Mock_Driver::Mock_Driver()
+{
+}
+
+Mock_Driver::~Mock_Driver() noexcept
+{
+}
+
+} // namespace picolibrary::Testing::Unit::WIZnet::W5500


### PR DESCRIPTION
Resolves #559 (Reduce unit testing build time).

According to
http://google.github.io/googletest/gmock_cook_book.html#making-the-compilation-faster,
moving mock class constructor and destructor definitions out of header
files and into source files can reduce build times.

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
