### PR TITLE
Treat I2C bus control guard stop condition transmission failure as a fatal error

### DIFF
--- a/include/picolibrary/i2c.h
+++ b/include/picolibrary/i2c.h
@@ -28,6 +28,7 @@
 
 #include "picolibrary/algorithm.h"
 #include "picolibrary/error.h"
+#include "picolibrary/fatal_error.h"
 #include "picolibrary/result.h"
 #include "picolibrary/void.h"
 
@@ -675,9 +676,7 @@ class Controller : public Basic_Controller {
  * \tparam[in] Controller The type of I2C controller that is used to interact with the
  *             bus.
  *
- * \warning Stop condition transmission failures are ignored. A controller wrapper class
- *          can be used to add stop condition transmission failure error handling to the
- *          controller's stop condition transmission function.
+ * \warning Stop condition transmission failure is treated as a fatal error.
  */
 template<typename Controller>
 class Bus_Control_Guard;
@@ -790,8 +789,11 @@ class Bus_Control_Guard {
     constexpr void stop() noexcept
     {
         if ( m_controller ) {
-            static_cast<void>( m_controller->stop() );
-        } // if
+            auto result = m_controller->stop();
+            if ( result.is_error() ) {
+                trap_fatal_error();
+            } // if
+        }     // if
     }
 };
 

--- a/test/unit/picolibrary/i2c/bus_control_guard/main.cc
+++ b/test/unit/picolibrary/i2c/bus_control_guard/main.cc
@@ -145,6 +145,23 @@ TEST( assignmentOperatorMoveDeathTest, stopError )
 {
     EXPECT_DEATH(
         {
+            auto controller = Mock_Controller{};
+
+            EXPECT_CALL( controller, start() ).WillOnce( Return( Result<Void, Error_Code>{} ) );
+
+            auto expression = Bus_Control_Guard{};
+            auto object     = make_bus_control_guard( controller );
+
+            EXPECT_FALSE( object.is_error() );
+
+            EXPECT_CALL( controller, stop() ).WillOnce( Return( random<Mock_Error>() ) );
+
+            object.value() = std::move( expression );
+        },
+        "" );
+
+    EXPECT_DEATH(
+        {
             auto controller_expression = Mock_Controller{};
             auto controller_object     = Mock_Controller{};
 

--- a/test/unit/picolibrary/i2c/bus_control_guard/main.cc
+++ b/test/unit/picolibrary/i2c/bus_control_guard/main.cc
@@ -119,17 +119,21 @@ TEST( constructorMove, worksProperly )
  * \brief Verify picolibrary::I2C::Bus_Control_Guard::~Bus_Control_Guard() properly
  *        handles a stop condition transmission error.
  */
-TEST( destructor, stopError )
+TEST( destructorDeathTest, stopError )
 {
-    auto controller = Mock_Controller{};
+    EXPECT_DEATH(
+        {
+            auto controller = Mock_Controller{};
 
-    EXPECT_CALL( controller, start() ).WillOnce( Return( Result<Void, Error_Code>{} ) );
+            EXPECT_CALL( controller, start() ).WillOnce( Return( Result<Void, Error_Code>{} ) );
 
-    auto const result = make_bus_control_guard( controller );
+            auto const result = make_bus_control_guard( controller );
 
-    EXPECT_FALSE( result.is_error() );
+            EXPECT_FALSE( result.is_error() );
 
-    EXPECT_CALL( controller, stop() ).WillOnce( Return( random<Mock_Error>() ) );
+            EXPECT_CALL( controller, stop() ).WillOnce( Return( random<Mock_Error>() ) );
+        },
+        "" );
 }
 
 /**

--- a/test/unit/picolibrary/i2c/device/uint8_t/main.cc
+++ b/test/unit/picolibrary/i2c/device/uint8_t/main.cc
@@ -300,30 +300,6 @@ TEST( pingOperation, readError )
 
 /**
  * \brief Verify picolibrary::I2C::Device<Bus_Multiplexer_Aligner, Controller,
- *        std::uint8_t>::ping( picolibrary::I2C::Operation ) properly handles a stop
- *        condition transmission error.
- */
-TEST( pingOperation, stopError )
-{
-    auto bus_multiplexer_aligner = MockFunction<Result<Void, Error_Code>()>{};
-    auto controller              = Mock_Controller{};
-
-    auto const device = Device{ bus_multiplexer_aligner.AsStdFunction(),
-                                controller,
-                                random<Address>(),
-                                random<Mock_Error>() };
-
-    EXPECT_CALL( bus_multiplexer_aligner, Call() ).WillOnce( Return( Result<Void, Error_Code>{} ) );
-    EXPECT_CALL( controller, start() ).WillOnce( Return( Result<Void, Error_Code>{} ) );
-    EXPECT_CALL( controller, address( _, _ ) ).WillOnce( Return( Result<Void, Error_Code>{} ) );
-    EXPECT_CALL( controller, read( _ ) ).WillRepeatedly( Return( random<std::uint8_t>() ) );
-    EXPECT_CALL( controller, stop() ).WillOnce( Return( random<Mock_Error>() ) );
-
-    EXPECT_FALSE( device.ping( random<Operation>() ).is_error() );
-}
-
-/**
- * \brief Verify picolibrary::I2C::Device<Bus_Multiplexer_Aligner, Controller,
  *        std::uint8_t>::ping( picolibrary::I2C::Operation ) works properly.
  */
 TEST( pingOperation, worksProperly )
@@ -497,29 +473,6 @@ TEST( ping, readError )
 
     EXPECT_TRUE( result.is_error() );
     EXPECT_EQ( result.error(), error );
-}
-
-/**
- * \brief Verify picolibrary::I2C::Device<Bus_Multiplexer_Aligner, Controller,
- *        std::uint8_t>::ping() properly handles a stop condition transmission error.
- */
-TEST( ping, stopError )
-{
-    auto bus_multiplexer_aligner = MockFunction<Result<Void, Error_Code>()>{};
-    auto controller              = Mock_Controller{};
-
-    auto const device = Device{ bus_multiplexer_aligner.AsStdFunction(),
-                                controller,
-                                random<Address>(),
-                                random<Mock_Error>() };
-
-    EXPECT_CALL( bus_multiplexer_aligner, Call() ).WillRepeatedly( Return( Result<Void, Error_Code>{} ) );
-    EXPECT_CALL( controller, start() ).WillRepeatedly( Return( Result<Void, Error_Code>{} ) );
-    EXPECT_CALL( controller, address( _, _ ) ).WillRepeatedly( Return( Result<Void, Error_Code>{} ) );
-    EXPECT_CALL( controller, read( _ ) ).WillRepeatedly( Return( random<std::uint8_t>() ) );
-    EXPECT_CALL( controller, stop() ).WillRepeatedly( Return( random<Mock_Error>() ) );
-
-    EXPECT_FALSE( device.ping().is_error() );
 }
 
 /**
@@ -832,32 +785,6 @@ TEST( readRegister, readError )
 
     EXPECT_TRUE( result.is_error() );
     EXPECT_EQ( result.error(), error );
-}
-
-/**
- * \brief Verify picolibrary::I2C::Device<Bus_Multiplexer_Aligner, Controller,
- *        std::uint8_t>::read( std::uint8_t ) properly handles a stop condition
- *        transmission error.
- */
-TEST( readRegister, stopError )
-{
-    auto bus_multiplexer_aligner = MockFunction<Result<Void, Error_Code>()>{};
-    auto controller              = Mock_Controller{};
-
-    auto const device = Device{ bus_multiplexer_aligner.AsStdFunction(),
-                                controller,
-                                random<Address>(),
-                                random<Mock_Error>() };
-
-    EXPECT_CALL( bus_multiplexer_aligner, Call() ).WillOnce( Return( Result<Void, Error_Code>{} ) );
-    EXPECT_CALL( controller, start() ).WillOnce( Return( Result<Void, Error_Code>{} ) );
-    EXPECT_CALL( controller, address( _, _ ) ).WillRepeatedly( Return( Result<Void, Error_Code>{} ) );
-    EXPECT_CALL( controller, write( A<std::uint8_t>() ) ).WillOnce( Return( Result<Void, Error_Code>{} ) );
-    EXPECT_CALL( controller, repeated_start() ).WillOnce( Return( Result<Void, Error_Code>{} ) );
-    EXPECT_CALL( controller, read( _ ) ).WillOnce( Return( random<std::uint8_t>() ) );
-    EXPECT_CALL( controller, stop() ).WillOnce( Return( random<Mock_Error>() ) );
-
-    EXPECT_FALSE( device.read( random<std::uint8_t>() ).is_error() );
 }
 
 /**
@@ -1192,36 +1119,6 @@ TEST( readRegisterBlock, readError )
 
 /**
  * \brief Verify picolibrary::I2C::Device<Bus_Multiplexer_Aligner, Controller,
- *        std::uint8_t>::read( std::uint8_t, std::uint8_t *, std::uint8_t * ) properly
- *        handles a stop condition transmission error.
- */
-TEST( readRegisterBlock, stopError )
-{
-    auto bus_multiplexer_aligner = MockFunction<Result<Void, Error_Code>()>{};
-    auto controller              = Mock_Controller{};
-
-    auto const device = Device{ bus_multiplexer_aligner.AsStdFunction(),
-                                controller,
-                                random<Address>(),
-                                random<Mock_Error>() };
-
-    auto const size = random<std::uint_fast8_t>( 1 );
-
-    EXPECT_CALL( bus_multiplexer_aligner, Call() ).WillOnce( Return( Result<Void, Error_Code>{} ) );
-    EXPECT_CALL( controller, start() ).WillOnce( Return( Result<Void, Error_Code>{} ) );
-    EXPECT_CALL( controller, address( _, _ ) ).WillRepeatedly( Return( Result<Void, Error_Code>{} ) );
-    EXPECT_CALL( controller, write( A<std::uint8_t>() ) ).WillOnce( Return( Result<Void, Error_Code>{} ) );
-    EXPECT_CALL( controller, repeated_start() ).WillOnce( Return( Result<Void, Error_Code>{} ) );
-    EXPECT_CALL( controller, read( A<std::vector<std::uint8_t>>(), _ ) )
-        .WillOnce( Return( random_container<std::vector<std::uint8_t>>( size ) ) );
-    EXPECT_CALL( controller, stop() ).WillOnce( Return( random<Mock_Error>() ) );
-
-    auto data = std::vector<std::uint8_t>( size );
-    EXPECT_FALSE( device.read( random<std::uint8_t>(), &*data.begin(), &*data.end() ).is_error() );
-}
-
-/**
- * \brief Verify picolibrary::I2C::Device<Bus_Multiplexer_Aligner, Controller,
  *        std::uint8_t>::read( std::uint8_t, std::uint8_t *, std::uint8_t * ) works
  *        properly.
  */
@@ -1479,30 +1376,6 @@ TEST( writeRegister, nonresponsiveDeviceErrorWriteData )
 
 /**
  * \brief Verify picolibrary::I2C::Device<Bus_Multiplexer_Aligner, Controller,
- *        std::uint8_t>::write( std::uint8_t, std::uint8_t ) properly handles a stop
- *        condition transmission error.
- */
-TEST( writeRegister, stopError )
-{
-    auto bus_multiplexer_aligner = MockFunction<Result<Void, Error_Code>()>{};
-    auto controller              = Mock_Controller{};
-
-    auto device = Device{ bus_multiplexer_aligner.AsStdFunction(),
-                          controller,
-                          random<Address>(),
-                          random<Mock_Error>() };
-
-    EXPECT_CALL( bus_multiplexer_aligner, Call() ).WillOnce( Return( Result<Void, Error_Code>{} ) );
-    EXPECT_CALL( controller, start() ).WillOnce( Return( Result<Void, Error_Code>{} ) );
-    EXPECT_CALL( controller, address( _, _ ) ).WillOnce( Return( Result<Void, Error_Code>{} ) );
-    EXPECT_CALL( controller, write( A<std::uint8_t>() ) ).WillRepeatedly( Return( Result<Void, Error_Code>{} ) );
-    EXPECT_CALL( controller, stop() ).WillOnce( Return( random<Mock_Error>() ) );
-
-    EXPECT_FALSE( device.write( random<std::uint8_t>(), random<std::uint8_t>() ).is_error() );
-}
-
-/**
- * \brief Verify picolibrary::I2C::Device<Bus_Multiplexer_Aligner, Controller,
  *        std::uint8_t>::write( std::uint8_t, std::uint8_t ) works properly.
  */
 TEST( writeRegister, worksProperly )
@@ -1756,33 +1629,6 @@ TEST( writeRegisterBlock, nonresponsiveDeviceErrorWriteData )
 
     EXPECT_TRUE( result.is_error() );
     EXPECT_EQ( result.error(), nonresponsive_device_error );
-}
-
-/**
- * \brief Verify picolibrary::I2C::Device<Bus_Multiplexer_Aligner, Controller,
- *        std::uint8_t>::write( std::uint8_t, std::uint8_t const *, std::uint8_t const * )
- *        properly handles a stop condition transmission error.
- */
-TEST( writeRegisterBlock, stopError )
-{
-    auto bus_multiplexer_aligner = MockFunction<Result<Void, Error_Code>()>{};
-    auto controller              = Mock_Controller{};
-
-    auto device = Device{ bus_multiplexer_aligner.AsStdFunction(),
-                          controller,
-                          random<Address>(),
-                          random<Mock_Error>() };
-
-    EXPECT_CALL( bus_multiplexer_aligner, Call() ).WillOnce( Return( Result<Void, Error_Code>{} ) );
-    EXPECT_CALL( controller, start() ).WillOnce( Return( Result<Void, Error_Code>{} ) );
-    EXPECT_CALL( controller, address( _, _ ) ).WillOnce( Return( Result<Void, Error_Code>{} ) );
-    EXPECT_CALL( controller, write( A<std::uint8_t>() ) ).WillOnce( Return( Result<Void, Error_Code>{} ) );
-    EXPECT_CALL( controller, write( A<std::vector<std::uint8_t>>() ) )
-        .WillOnce( Return( Result<Void, Error_Code>{} ) );
-    EXPECT_CALL( controller, stop() ).WillOnce( Return( random<Mock_Error>() ) );
-
-    auto const data = random_container<std::vector<std::uint8_t>>();
-    auto const result = device.write( random<std::uint8_t>(), &*data.begin(), &*data.end() );
 }
 
 /**

--- a/test/unit/picolibrary/i2c/device/uint8_t/main.cc
+++ b/test/unit/picolibrary/i2c/device/uint8_t/main.cc
@@ -300,6 +300,34 @@ TEST( pingOperation, readError )
 
 /**
  * \brief Verify picolibrary::I2C::Device<Bus_Multiplexer_Aligner, Controller,
+ *        std::uint8_t>::ping( picolibrary::I2C::Operation ) properly handles a stop
+ *        condition transmission error.
+ */
+TEST( pingOperationDeathTest, stopError )
+{
+    EXPECT_DEATH(
+        ( {
+            auto bus_multiplexer_aligner = MockFunction<Result<Void, Error_Code>()>{};
+            auto controller              = Mock_Controller{};
+
+            auto const device = Device{ bus_multiplexer_aligner.AsStdFunction(),
+                                        controller,
+                                        random<Address>(),
+                                        random<Mock_Error>() };
+
+            EXPECT_CALL( bus_multiplexer_aligner, Call() ).WillOnce( Return( Result<Void, Error_Code>{} ) );
+            EXPECT_CALL( controller, start() ).WillOnce( Return( Result<Void, Error_Code>{} ) );
+            EXPECT_CALL( controller, address( _, _ ) ).WillOnce( Return( Result<Void, Error_Code>{} ) );
+            EXPECT_CALL( controller, read( _ ) ).WillRepeatedly( Return( random<std::uint8_t>() ) );
+            EXPECT_CALL( controller, stop() ).WillOnce( Return( random<Mock_Error>() ) );
+
+            static_cast<void>( device.ping( random<Operation>() ) );
+        } ),
+        "" );
+}
+
+/**
+ * \brief Verify picolibrary::I2C::Device<Bus_Multiplexer_Aligner, Controller,
  *        std::uint8_t>::ping( picolibrary::I2C::Operation ) works properly.
  */
 TEST( pingOperation, worksProperly )
@@ -473,6 +501,33 @@ TEST( ping, readError )
 
     EXPECT_TRUE( result.is_error() );
     EXPECT_EQ( result.error(), error );
+}
+
+/**
+ * \brief Verify picolibrary::I2C::Device<Bus_Multiplexer_Aligner, Controller,
+ *        std::uint8_t>::ping() properly handles a stop condition transmission error.
+ */
+TEST( pingDeathTest, stopError )
+{
+    EXPECT_DEATH(
+        ( {
+            auto bus_multiplexer_aligner = MockFunction<Result<Void, Error_Code>()>{};
+            auto controller              = Mock_Controller{};
+
+            auto const device = Device{ bus_multiplexer_aligner.AsStdFunction(),
+                                        controller,
+                                        random<Address>(),
+                                        random<Mock_Error>() };
+
+            EXPECT_CALL( bus_multiplexer_aligner, Call() ).WillRepeatedly( Return( Result<Void, Error_Code>{} ) );
+            EXPECT_CALL( controller, start() ).WillRepeatedly( Return( Result<Void, Error_Code>{} ) );
+            EXPECT_CALL( controller, address( _, _ ) ).WillRepeatedly( Return( Result<Void, Error_Code>{} ) );
+            EXPECT_CALL( controller, read( _ ) ).WillRepeatedly( Return( random<std::uint8_t>() ) );
+            EXPECT_CALL( controller, stop() ).WillRepeatedly( Return( random<Mock_Error>() ) );
+
+            static_cast<void>( device.ping() );
+        } ),
+        "" );
 }
 
 /**
@@ -785,6 +840,36 @@ TEST( readRegister, readError )
 
     EXPECT_TRUE( result.is_error() );
     EXPECT_EQ( result.error(), error );
+}
+
+/**
+ * \brief Verify picolibrary::I2C::Device<Bus_Multiplexer_Aligner, Controller,
+ *        std::uint8_t>::read( std::uint8_t ) properly handles a stop condition
+ *        transmission error.
+ */
+TEST( readRegisterDeathTest, stopError )
+{
+    EXPECT_DEATH(
+        ( {
+            auto bus_multiplexer_aligner = MockFunction<Result<Void, Error_Code>()>{};
+            auto controller              = Mock_Controller{};
+
+            auto const device = Device{ bus_multiplexer_aligner.AsStdFunction(),
+                                        controller,
+                                        random<Address>(),
+                                        random<Mock_Error>() };
+
+            EXPECT_CALL( bus_multiplexer_aligner, Call() ).WillOnce( Return( Result<Void, Error_Code>{} ) );
+            EXPECT_CALL( controller, start() ).WillOnce( Return( Result<Void, Error_Code>{} ) );
+            EXPECT_CALL( controller, address( _, _ ) ).WillRepeatedly( Return( Result<Void, Error_Code>{} ) );
+            EXPECT_CALL( controller, write( A<std::uint8_t>() ) ).WillOnce( Return( Result<Void, Error_Code>{} ) );
+            EXPECT_CALL( controller, repeated_start() ).WillOnce( Return( Result<Void, Error_Code>{} ) );
+            EXPECT_CALL( controller, read( _ ) ).WillOnce( Return( random<std::uint8_t>() ) );
+            EXPECT_CALL( controller, stop() ).WillOnce( Return( random<Mock_Error>() ) );
+
+            static_cast<void>( device.read( random<std::uint8_t>() ) );
+        } ),
+        "" );
 }
 
 /**
@@ -1119,6 +1204,40 @@ TEST( readRegisterBlock, readError )
 
 /**
  * \brief Verify picolibrary::I2C::Device<Bus_Multiplexer_Aligner, Controller,
+ *        std::uint8_t>::read( std::uint8_t, std::uint8_t *, std::uint8_t * ) properly
+ *        handles a stop condition transmission error.
+ */
+TEST( readRegisterBlockDeathTest, stopError )
+{
+    EXPECT_DEATH(
+        ( {
+            auto bus_multiplexer_aligner = MockFunction<Result<Void, Error_Code>()>{};
+            auto controller              = Mock_Controller{};
+
+            auto const device = Device{ bus_multiplexer_aligner.AsStdFunction(),
+                                        controller,
+                                        random<Address>(),
+                                        random<Mock_Error>() };
+
+            auto const size = random<std::uint_fast8_t>( 1 );
+
+            EXPECT_CALL( bus_multiplexer_aligner, Call() ).WillOnce( Return( Result<Void, Error_Code>{} ) );
+            EXPECT_CALL( controller, start() ).WillOnce( Return( Result<Void, Error_Code>{} ) );
+            EXPECT_CALL( controller, address( _, _ ) ).WillRepeatedly( Return( Result<Void, Error_Code>{} ) );
+            EXPECT_CALL( controller, write( A<std::uint8_t>() ) ).WillOnce( Return( Result<Void, Error_Code>{} ) );
+            EXPECT_CALL( controller, repeated_start() ).WillOnce( Return( Result<Void, Error_Code>{} ) );
+            EXPECT_CALL( controller, read( A<std::vector<std::uint8_t>>(), _ ) )
+                .WillOnce( Return( random_container<std::vector<std::uint8_t>>( size ) ) );
+            EXPECT_CALL( controller, stop() ).WillOnce( Return( random<Mock_Error>() ) );
+
+            auto data = std::vector<std::uint8_t>( size );
+            static_cast<void>( device.read( random<std::uint8_t>(), &*data.begin(), &*data.end() ) );
+        } ),
+        "" );
+}
+
+/**
+ * \brief Verify picolibrary::I2C::Device<Bus_Multiplexer_Aligner, Controller,
  *        std::uint8_t>::read( std::uint8_t, std::uint8_t *, std::uint8_t * ) works
  *        properly.
  */
@@ -1376,6 +1495,35 @@ TEST( writeRegister, nonresponsiveDeviceErrorWriteData )
 
 /**
  * \brief Verify picolibrary::I2C::Device<Bus_Multiplexer_Aligner, Controller,
+ *        std::uint8_t>::write( std::uint8_t, std::uint8_t ) properly handles a stop
+ *        condition transmission error.
+ */
+TEST( writeRegisterDeathTest, stopError )
+{
+    EXPECT_DEATH(
+        ( {
+            auto bus_multiplexer_aligner = MockFunction<Result<Void, Error_Code>()>{};
+            auto controller              = Mock_Controller{};
+
+            auto device = Device{ bus_multiplexer_aligner.AsStdFunction(),
+                                  controller,
+                                  random<Address>(),
+                                  random<Mock_Error>() };
+
+            EXPECT_CALL( bus_multiplexer_aligner, Call() ).WillOnce( Return( Result<Void, Error_Code>{} ) );
+            EXPECT_CALL( controller, start() ).WillOnce( Return( Result<Void, Error_Code>{} ) );
+            EXPECT_CALL( controller, address( _, _ ) ).WillOnce( Return( Result<Void, Error_Code>{} ) );
+            EXPECT_CALL( controller, write( A<std::uint8_t>() ) )
+                .WillRepeatedly( Return( Result<Void, Error_Code>{} ) );
+            EXPECT_CALL( controller, stop() ).WillOnce( Return( random<Mock_Error>() ) );
+
+            static_cast<void>( device.write( random<std::uint8_t>(), random<std::uint8_t>() ) );
+        } ),
+        "" );
+}
+
+/**
+ * \brief Verify picolibrary::I2C::Device<Bus_Multiplexer_Aligner, Controller,
  *        std::uint8_t>::write( std::uint8_t, std::uint8_t ) works properly.
  */
 TEST( writeRegister, worksProperly )
@@ -1629,6 +1777,37 @@ TEST( writeRegisterBlock, nonresponsiveDeviceErrorWriteData )
 
     EXPECT_TRUE( result.is_error() );
     EXPECT_EQ( result.error(), nonresponsive_device_error );
+}
+
+/**
+ * \brief Verify picolibrary::I2C::Device<Bus_Multiplexer_Aligner, Controller,
+ *        std::uint8_t>::write( std::uint8_t, std::uint8_t const *, std::uint8_t const * )
+ *        properly handles a stop condition transmission error.
+ */
+TEST( writeRegisterBlockDeathTest, stopError )
+{
+    EXPECT_DEATH(
+        ( {
+            auto bus_multiplexer_aligner = MockFunction<Result<Void, Error_Code>()>{};
+            auto controller              = Mock_Controller{};
+
+            auto device = Device{ bus_multiplexer_aligner.AsStdFunction(),
+                                  controller,
+                                  random<Address>(),
+                                  random<Mock_Error>() };
+
+            EXPECT_CALL( bus_multiplexer_aligner, Call() ).WillOnce( Return( Result<Void, Error_Code>{} ) );
+            EXPECT_CALL( controller, start() ).WillOnce( Return( Result<Void, Error_Code>{} ) );
+            EXPECT_CALL( controller, address( _, _ ) ).WillOnce( Return( Result<Void, Error_Code>{} ) );
+            EXPECT_CALL( controller, write( A<std::uint8_t>() ) ).WillOnce( Return( Result<Void, Error_Code>{} ) );
+            EXPECT_CALL( controller, write( A<std::vector<std::uint8_t>>() ) )
+                .WillOnce( Return( Result<Void, Error_Code>{} ) );
+            EXPECT_CALL( controller, stop() ).WillOnce( Return( random<Mock_Error>() ) );
+
+            auto const data = random_container<std::vector<std::uint8_t>>();
+            static_cast<void>( device.write( random<std::uint8_t>(), &*data.begin(), &*data.end() ) );
+        } ),
+        "" );
 }
 
 /**

--- a/test/unit/picolibrary/i2c/main.cc
+++ b/test/unit/picolibrary/i2c/main.cc
@@ -109,22 +109,6 @@ TEST( ping, readError )
 }
 
 /**
- * \brief Verify picolibrary::I2C::ping() properly handles a stop condition transmission
- *        error.
- */
-TEST( ping, stopError )
-{
-    auto controller = Mock_Controller{};
-
-    EXPECT_CALL( controller, start() ).WillOnce( Return( Result<Void, Error_Code>{} ) );
-    EXPECT_CALL( controller, address( _, _ ) ).WillOnce( Return( Result<Void, Error_Code>{} ) );
-    EXPECT_CALL( controller, read( _ ) ).WillRepeatedly( Return( random<std::uint8_t>() ) );
-    EXPECT_CALL( controller, stop() ).WillOnce( Return( random<Mock_Error>() ) );
-
-    EXPECT_FALSE( ping( controller, random<Address>(), random<Operation>() ).is_error() );
-}
-
-/**
  * \brief Verify picolibrary::I2C::ping() works properly.
  */
 TEST( ping, worksProperly )
@@ -219,24 +203,6 @@ TEST( scan, readError )
 
     EXPECT_TRUE( result.is_error() );
     EXPECT_EQ( result.error(), error );
-}
-
-/**
- * \brief Verify picolibrary::I2C::scan() properly handles a stop condition transmission
- *        error.
- */
-TEST( scan, stopError )
-{
-    auto controller = Mock_Controller{};
-    auto functor    = MockFunction<Result<Void, Error_Code>( Address, Operation )>{};
-
-    EXPECT_CALL( controller, start() ).WillRepeatedly( Return( Result<Void, Error_Code>{} ) );
-    EXPECT_CALL( controller, address( _, _ ) ).WillRepeatedly( Return( Result<Void, Error_Code>{} ) );
-    EXPECT_CALL( controller, read( _ ) ).WillRepeatedly( Return( random<std::uint8_t>() ) );
-    EXPECT_CALL( controller, stop() ).WillRepeatedly( Return( random<Mock_Error>() ) );
-    EXPECT_CALL( functor, Call( _, _ ) ).WillRepeatedly( Return( Result<Void, Error_Code>{} ) );
-
-    EXPECT_FALSE( scan( controller, functor.AsStdFunction() ).is_error() );
 }
 
 /**

--- a/test/unit/picolibrary/i2c/main.cc
+++ b/test/unit/picolibrary/i2c/main.cc
@@ -109,6 +109,26 @@ TEST( ping, readError )
 }
 
 /**
+ * \brief Verify picolibrary::I2C::ping() properly handles a stop condition transmission
+ *        error.
+ */
+TEST( pingDeathTest, stopError )
+{
+    EXPECT_DEATH(
+        {
+            auto controller = Mock_Controller{};
+
+            EXPECT_CALL( controller, start() ).WillOnce( Return( Result<Void, Error_Code>{} ) );
+            EXPECT_CALL( controller, address( _, _ ) ).WillOnce( Return( Result<Void, Error_Code>{} ) );
+            EXPECT_CALL( controller, read( _ ) ).WillRepeatedly( Return( random<std::uint8_t>() ) );
+            EXPECT_CALL( controller, stop() ).WillOnce( Return( random<Mock_Error>() ) );
+
+            static_cast<void>( ping( controller, random<Address>(), random<Operation>() ) );
+        },
+        "" );
+}
+
+/**
  * \brief Verify picolibrary::I2C::ping() works properly.
  */
 TEST( ping, worksProperly )
@@ -203,6 +223,28 @@ TEST( scan, readError )
 
     EXPECT_TRUE( result.is_error() );
     EXPECT_EQ( result.error(), error );
+}
+
+/**
+ * \brief Verify picolibrary::I2C::scan() properly handles a stop condition transmission
+ *        error.
+ */
+TEST( scanDeathTest, stopError )
+{
+    EXPECT_DEATH(
+        ( {
+            auto controller = Mock_Controller{};
+            auto functor = MockFunction<Result<Void, Error_Code>( Address, Operation )>{};
+
+            EXPECT_CALL( controller, start() ).WillRepeatedly( Return( Result<Void, Error_Code>{} ) );
+            EXPECT_CALL( controller, address( _, _ ) ).WillRepeatedly( Return( Result<Void, Error_Code>{} ) );
+            EXPECT_CALL( controller, read( _ ) ).WillRepeatedly( Return( random<std::uint8_t>() ) );
+            EXPECT_CALL( controller, stop() ).WillRepeatedly( Return( random<Mock_Error>() ) );
+            EXPECT_CALL( functor, Call( _, _ ) ).WillRepeatedly( Return( Result<Void, Error_Code>{} ) );
+
+            static_cast<void>( scan( controller, functor.AsStdFunction() ) );
+        } ),
+        "" );
 }
 
 /**


### PR DESCRIPTION
Resolves #578 (Treat I2C bus control guard stop condition transmission
failure as a fatal error).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
