### PR TITLE
Pass I2C bus control guard stop error code to fatal error trap

### DIFF
--- a/include/picolibrary/i2c.h
+++ b/include/picolibrary/i2c.h
@@ -791,7 +791,7 @@ class Bus_Control_Guard {
         if ( m_controller ) {
             auto result = m_controller->stop();
             if ( result.is_error() ) {
-                trap_fatal_error();
+                trap_fatal_error( result.error() );
             } // if
         }     // if
     }


### PR DESCRIPTION
Resolves #585 (Pass I2C bus control guard stop error code to fatal error
trap).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
