### PR TITLE
Treat asynchronous serial transmitter hello world interactive test helper errors as fatal errors

### DIFF
--- a/include/picolibrary/testing/interactive/asynchronous_serial.h
+++ b/include/picolibrary/testing/interactive/asynchronous_serial.h
@@ -23,6 +23,8 @@
 #ifndef PICOLIBRARY_TESTING_INTERACTIVE_ASYNCHRONOUS_SERIAL_H
 #define PICOLIBRARY_TESTING_INTERACTIVE_ASYNCHRONOUS_SERIAL_H
 
+#include "picolibrary/fatal_error.h"
+
 /**
  * \brief Asynchronous serial interactive testing facilities.
  */
@@ -38,15 +40,18 @@ namespace picolibrary::Testing::Interactive::Asynchronous_Serial {
 template<typename Transmitter>
 void hello_world( Transmitter transmitter ) noexcept
 {
-    if ( transmitter.initialize().is_error() ) {
-        return;
-    } // if
-
+    {
+        auto const result = transmitter.initialize();
+        if ( result.is_error() ) {
+            trap_fatal_error( result.error() );
+        } // if
+    }
     auto const * string = "Hello, world!\n";
 
     while ( auto const character = *string++ ) {
-        if ( transmitter.transmit( character ).is_error() ) {
-            return;
+        auto const result = transmitter.transmit( character );
+        if ( result.is_error() ) {
+            trap_fatal_error( result.error() );
         } // if
     }     // while
 }


### PR DESCRIPTION
Resolves #589 (Treat asynchronous serial transmitter hello world
interactive test helper errors as fatal errors).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
