### PR TITLE
Remove unnecessary HSM function explicit return types

### DIFF
--- a/include/picolibrary/state_machine.h
+++ b/include/picolibrary/state_machine.h
@@ -711,7 +711,7 @@ class HSM {
      *
      * \return Event ignored event handling result.
      */
-    static constexpr auto top( HSM & hsm, Event const & event ) noexcept -> Event_Handling_Result
+    static constexpr auto top( HSM & hsm, Event const & event ) noexcept
     {
         return hsm.event_ignored( event );
     }
@@ -723,7 +723,7 @@ class HSM {
      *
      * \return Event handled event handling result.
      */
-    constexpr auto event_handled( Event const & event ) const noexcept -> Event_Handling_Result
+    constexpr auto event_handled( Event const & event ) const noexcept
     {
         static_cast<void>( event );
 


### PR DESCRIPTION
Resolves #605 (Remove unnecessary HSM function explicit return types).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
