### PR TITLE
Fix I2C address inequality operator unit test name spelling

### DIFF
--- a/test/unit/picolibrary/i2c/address/main.cc
+++ b/test/unit/picolibrary/i2c/address/main.cc
@@ -169,7 +169,7 @@ TEST( equalityOperator, worksProperly )
  * \brief Verify picolibrary::I2C::operator!=( picolibrary::I2C::Address,
  *        picolibrary::I2C::Address ) works properly.
  */
-TEST( inqualityOperator, worksProperly )
+TEST( inequalityOperator, worksProperly )
 {
     {
         auto const lhs = random_numeric_address();


### PR DESCRIPTION
Resolves #628 (Fix I2C address inequality operator unit test name
spelling).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
