### PR TITLE
Convert TCP over IP port number to class

### DIFF
--- a/include/picolibrary/ip/tcp.h
+++ b/include/picolibrary/ip/tcp.h
@@ -40,7 +40,197 @@ namespace picolibrary::IP::TCP {
 /**
  * \brief Port number.
  */
-using Port = std::uint16_t;
+class Port {
+  public:
+    /**
+     * \brief Port number unsigned integer representation.
+     */
+    using Unsigned_Integer = std::uint16_t;
+
+    /**
+     * \brief Get the port number that is used to represent any port number (0).
+     *
+     * \return The port number that is used to represent any port number.
+     */
+    static constexpr auto any() noexcept
+    {
+        return Port{};
+    }
+
+    /**
+     * \brief Constructor.
+     */
+    constexpr Port() noexcept = default;
+
+    /**
+     * \brief Constructor.
+     *
+     * \param[in] port The port number in its unsigned integer representation.
+     */
+    constexpr Port( Unsigned_Integer port ) noexcept : m_port{ port }
+    {
+    }
+
+    /**
+     * \brief Constructor.
+     *
+     * \param[in] source The source of the move.
+     */
+    constexpr Port( Port && source ) noexcept = default;
+
+    /**
+     * \brief Constructor.
+     *
+     * \param[in] original The original to copy.
+     */
+    constexpr Port( Port const & original ) noexcept = default;
+
+    /**
+     * \brief Destructor.
+     */
+    ~Port() noexcept = default;
+
+    /**
+     * \brief Assignment operator.
+     *
+     * \param[in] expression The expression to be assigned.
+     *
+     * \return The assigned to object.
+     */
+    constexpr auto operator=( Port && expression ) noexcept -> Port & = default;
+
+    /**
+     * \brief Assignment operator.
+     *
+     * \param[in] expression The expression to be assigned.
+     *
+     * \return The assigned to object.
+     */
+    constexpr auto operator=( Port const & expression ) noexcept -> Port & = default;
+
+    /**
+     * \brief Check if the port number represents any port number (0).
+     *
+     * \return true if the port number represents any port number.
+     * \return false if the port number does not represent any port number.
+     */
+    constexpr auto is_any() const noexcept
+    {
+        return not m_port;
+    }
+
+    /**
+     * \brief Get the port number in its unsigned integer representation.
+     *
+     * \return The port number in its unsigned integer representation.
+     */
+    constexpr auto as_unsigned_integer() const noexcept
+    {
+        return m_port;
+    }
+
+  private:
+    /**
+     * \brief The port number in its unsigned integer representation.
+     */
+    Unsigned_Integer m_port{};
+};
+
+/**
+ * \brief Equality operator.
+ *
+ * \relatedalso picolibrary::IP::TCP::Port
+ *
+ * \param[in] lhs The left hand side of the comparison.
+ * \param[in] rhs The right hand side of the comparison.
+ *
+ * \return true if lhs is equal to rhs.
+ * \return false if lhs is not equal to rhs.
+ */
+constexpr auto operator==( Port lhs, Port rhs ) noexcept
+{
+    return lhs.as_unsigned_integer() == rhs.as_unsigned_integer();
+}
+
+/**
+ * \brief Inequality operator.
+ *
+ * \relatedalso picolibrary::IP::TCP::Port
+ *
+ * \param[in] lhs The left hand side of the comparison.
+ * \param[in] rhs The right hand side of the comparison.
+ *
+ * \return true if lhs is not equal to rhs.
+ * \return false if lhs is equal to rhs.
+ */
+constexpr auto operator!=( Port lhs, Port rhs ) noexcept
+{
+    return not( lhs == rhs );
+}
+
+/**
+ * \brief Less than operator.
+ *
+ * \relatedalso picolibrary::IP::TCP::Port
+ *
+ * \param[in] lhs The left hand side of the comparison.
+ * \param[in] rhs The right hand side of the comparison.
+ *
+ * \return true if lhs is less than rhs.
+ * \return false if lhs is not less than rhs.
+ */
+constexpr auto operator<( Port lhs, Port rhs ) noexcept
+{
+    return lhs.as_unsigned_integer() < rhs.as_unsigned_integer();
+}
+
+/**
+ * \brief Greater than operator.
+ *
+ * \relatedalso picolibrary::IP::TCP::Port
+ *
+ * \param[in] lhs The left hand side of the comparison.
+ * \param[in] rhs The right hand side of the comparison.
+ *
+ * \return true if lhs is greater than rhs.
+ * \return false if lhs is not greater than rhs.
+ */
+constexpr auto operator>( Port lhs, Port rhs ) noexcept
+{
+    return rhs < lhs;
+}
+
+/**
+ * \brief Less than or equal to operator.
+ *
+ * \relatedalso picolibrary::IP::TCP::Port
+ *
+ * \param[in] lhs The left hand side of the comparison.
+ * \param[in] rhs The right hand side of the comparison.
+ *
+ * \return true if lhs is less than or equal to rhs.
+ * \return false if lhs is not less than or equal to rhs.
+ */
+constexpr auto operator<=( Port lhs, Port rhs ) noexcept
+{
+    return not( lhs > rhs );
+}
+
+/**
+ * \brief Greater than or equal to operator.
+ *
+ * \relatedalso picolibrary::IP::TCP::Port
+ *
+ * \param[in] lhs The left hand side of the comparison.
+ * \param[in] rhs The right hand side of the comparison.
+ *
+ * \return true if lhs is greater than or equal to rhs.
+ * \return false if lhs is not greater than or equal to rhs.
+ */
+constexpr auto operator>=( Port lhs, Port rhs ) noexcept
+{
+    return not( lhs < rhs );
+}
 
 /**
  * \brief Endpoint.
@@ -244,6 +434,61 @@ constexpr auto operator>=( Endpoint const & lhs, Endpoint const & rhs ) noexcept
 namespace picolibrary {
 
 /**
+ * \brief picolibrary::IP::TCP::Port output formatter.
+ *
+ * picolibrary::IP::TCP::Port only supports the default format specification ("{}").
+ */
+template<>
+class Output_Formatter<IP::TCP::Port> {
+  public:
+    /**
+     * \brief Constructor.
+     */
+    constexpr Output_Formatter() noexcept = default;
+
+    Output_Formatter( Output_Formatter && ) = delete;
+
+    Output_Formatter( Output_Formatter const & ) = delete;
+
+    /**
+     * \brief Destructor.
+     */
+    ~Output_Formatter() noexcept = default;
+
+    auto operator=( Output_Formatter && ) = delete;
+
+    auto operator=( Output_Formatter const & ) = delete;
+
+    /**
+     * \brief Parse the format specification for the picolibrary::IP::TCP::Port to be
+     *        formatted.
+     *
+     * \param[in] format The format specification for the picolibrary::IP::TCP::Port to be
+     *            formatted.
+     *
+     * \return format.
+     */
+    constexpr auto parse( char const * format ) noexcept -> Result<char const *, Void>
+    {
+        return format;
+    }
+
+    /**
+     * \brief Write the picolibrary::IP::TCP::Port to the stream.
+     *
+     * \param[in] stream The stream to write the picolibrary::IP::TCP::Port to.
+     * \param[in] endpoint The picolibrary::IP::TCP::Port to write to the stream.
+     *
+     * \return Nothing if the write succeeded.
+     * \return An error code if the write failed.
+     */
+    auto print( Output_Stream & stream, IP::TCP::Port port ) noexcept -> Result<Void, Error_Code>
+    {
+        return stream.print( "{}", Format::Decimal{ port.as_unsigned_integer() } );
+    }
+};
+
+/**
  * \brief picolibrary::IP::TCP::Endpoint output formatter.
  *
  * picolibrary::IP::TCP::Endpoint only supports the default format specification ("{}").
@@ -295,7 +540,7 @@ class Output_Formatter<IP::TCP::Endpoint> {
     auto print( Output_Stream & stream, IP::TCP::Endpoint const & endpoint ) noexcept
         -> Result<Void, Error_Code>
     {
-        return stream.print( "{}:{}", endpoint.address(), Format::Decimal{ endpoint.port() } );
+        return stream.print( "{}:{}", endpoint.address(), endpoint.port() );
     }
 };
 

--- a/include/picolibrary/testing/unit/ip/tcp.h
+++ b/include/picolibrary/testing/unit/ip/tcp.h
@@ -31,6 +31,17 @@
 namespace picolibrary::Testing::Unit {
 
 /**
+ * \brief Generate a pseudo-random TCP over IP port number.
+ *
+ * \return A pseudo-random TCP over IP port number.
+ */
+template<>
+inline auto random<::picolibrary::IP::TCP::Port>()
+{
+    return ::picolibrary::IP::TCP::Port{ random<::picolibrary::IP::TCP::Port::Unsigned_Integer>() };
+}
+
+/**
  * \brief Generate a pseudo-random TCP over IP endpoint.
  *
  * \brief A pseudo-random TCP over IP endpoint.

--- a/test/unit/picolibrary/ip/tcp/endpoint/main.cc
+++ b/test/unit/picolibrary/ip/tcp/endpoint/main.cc
@@ -32,6 +32,7 @@
 #include "picolibrary/ipv4.h"
 #include "picolibrary/testing/unit/error.h"
 #include "picolibrary/testing/unit/ip.h"
+#include "picolibrary/testing/unit/ip/tcp.h"
 #include "picolibrary/testing/unit/random.h"
 #include "picolibrary/testing/unit/stream.h"
 
@@ -55,7 +56,7 @@ auto unspecified_address_with_port( Port port )
 {
     auto stream = std::ostringstream{};
 
-    stream << "ANY:" << port;
+    stream << "ANY:" << port.as_unsigned_integer();
 
     return stream.str();
 }
@@ -67,7 +68,8 @@ auto dot_decimal_with_port( IPv4_Address const & address, Port port )
     stream << static_cast<std::uint_fast16_t>( address.as_byte_array()[ 0 ] ) << '.'
            << static_cast<std::uint_fast16_t>( address.as_byte_array()[ 1 ] ) << '.'
            << static_cast<std::uint_fast16_t>( address.as_byte_array()[ 2 ] ) << '.'
-           << static_cast<std::uint_fast16_t>( address.as_byte_array()[ 3 ] ) << ':' << port;
+           << static_cast<std::uint_fast16_t>( address.as_byte_array()[ 3 ] ) << ':'
+           << port.as_unsigned_integer();
 
     return stream.str();
 }

--- a/test/unit/picolibrary/ip/tcp/port/CMakeLists.txt
+++ b/test/unit/picolibrary/ip/tcp/port/CMakeLists.txt
@@ -13,11 +13,22 @@
 # KIND, either express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-# File: test/unit/picolibrary/ip/tcp/CMakeLists.txt
-# Description: picolibrary::IP::TCP unit tests CMake rules.
-
-# build the picolibrary::IP::TCP::Endpoint unit tests
-add_subdirectory( endpoint )
+# File: test/unit/picolibrary/ip/tcp/port/CMakeLists.txt
+# Description: picolibrary::IP::TCP::Port unit tests CMake rules.
 
 # build the picolibrary::IP::TCP::Port unit tests
-add_subdirectory( port )
+if( ${PICOLIBRARY_ENABLE_UNIT_TESTING} )
+    add_executable(
+        test-unit-picolibrary-ip-tcp-port
+        main.cc
+    )
+    target_link_libraries(
+        test-unit-picolibrary-ip-tcp-port
+        picolibrary
+        picolibrary-fatal_error
+    )
+    add_test(
+        NAME    test-unit-picolibrary-ip-tcp-port
+        COMMAND test-unit-picolibrary-ip-tcp-port --gtest_color=yes
+    )
+endif( ${PICOLIBRARY_ENABLE_UNIT_TESTING} )

--- a/test/unit/picolibrary/ip/tcp/port/main.cc
+++ b/test/unit/picolibrary/ip/tcp/port/main.cc
@@ -1,0 +1,298 @@
+/**
+ * picolibrary
+ *
+ * Copyright 2020-2021, Andrew Countryman <apcountryman@gmail.com> and the picolibrary
+ * contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/**
+ * \file
+ * \brief picolibrary::IP::TCP::Port unit test program.
+ */
+
+#include <sstream>
+#include <string>
+#include <utility>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "picolibrary/error.h"
+#include "picolibrary/ip/tcp.h"
+#include "picolibrary/testing/unit/error.h"
+#include "picolibrary/testing/unit/random.h"
+#include "picolibrary/testing/unit/stream.h"
+
+namespace {
+
+using ::picolibrary::Generic_Error;
+using ::picolibrary::IP::TCP::Port;
+using ::picolibrary::Testing::Unit::Mock_Error;
+using ::picolibrary::Testing::Unit::Mock_Output_Stream;
+using ::picolibrary::Testing::Unit::Output_String_Stream;
+using ::picolibrary::Testing::Unit::random;
+using ::picolibrary::Testing::Unit::random_container;
+using ::testing::A;
+using ::testing::Return;
+
+auto random_unique_unsigned_integers()
+{
+    auto const a = random<Port::Unsigned_Integer>();
+    auto const b = random<Port::Unsigned_Integer>();
+
+    return std::pair<Port::Unsigned_Integer, Port::Unsigned_Integer>{
+        a, b != a ? b : b ^ random<Port::Unsigned_Integer>( 1 )
+    };
+}
+
+auto decimal( Port::Unsigned_Integer unsigned_integer )
+{
+    auto stream = std::ostringstream{};
+
+    stream << unsigned_integer;
+
+    return stream.str();
+}
+
+} // namespace
+
+/**
+ * \brief Verify picolibrary::IP::TCP::Port::any() works properly.
+ */
+TEST( any, worksProperly )
+{
+    auto const port = Port::any();
+
+    EXPECT_TRUE( port.is_any() );
+    EXPECT_EQ( port.as_unsigned_integer(), 0 );
+}
+
+/**
+ * \brief Verify picolibrary::IP::TCP::Port::Port() works properly.
+ */
+TEST( constructorDefault, worksProperly )
+{
+    auto const port = Port{};
+
+    EXPECT_TRUE( port.is_any() );
+    EXPECT_EQ( port.as_unsigned_integer(), 0 );
+}
+
+/**
+ * \brief Verify picolibrary::IP::TCP::Port::Port(
+ *        picolibrary::IP::TCP::Port::Unsigned_Integer ) works properly.
+ */
+TEST( constructorUnsignedInteger, worksProperly )
+{
+    auto const unsigned_integer = random<Port::Unsigned_Integer>();
+
+    auto const port = Port{ unsigned_integer };
+
+    EXPECT_EQ( port.is_any(), unsigned_integer == 0 );
+    EXPECT_EQ( port.as_unsigned_integer(), unsigned_integer );
+}
+
+/**
+ * \brief Verify picolibrary::IP::TCP::operator==( picolibrary::IP::TCP::Port,
+ *        picolibrary::IP::TCP::Port ) works properly.
+ */
+TEST( equalityOperator, worksProperly )
+{
+    {
+        auto const lhs = random<Port::Unsigned_Integer>();
+        auto const rhs = lhs;
+
+        EXPECT_TRUE( Port{ lhs } == Port{ rhs } );
+    }
+
+    {
+        auto const [ lhs, rhs ] = random_unique_unsigned_integers();
+
+        EXPECT_FALSE( Port{ lhs } == Port{ rhs } );
+    }
+}
+
+/**
+ * \brief Verify picolibrary::IP::TCP::operator!=( picolibrary::IP::TCP::Port,
+ *        picolibrary::IP::TCP::Port ) works properly.
+ */
+TEST( inequalityOperator, worksProperly )
+{
+    {
+        auto const lhs = random<Port::Unsigned_Integer>();
+        auto const rhs = lhs;
+
+        EXPECT_FALSE( Port{ lhs } != Port{ rhs } );
+    }
+
+    {
+        auto const [ lhs, rhs ] = random_unique_unsigned_integers();
+
+        EXPECT_TRUE( Port{ lhs } != Port{ rhs } );
+    }
+}
+
+/**
+ * \brief Verify picolibrary::IP::TCP::operator<( picolibrary::IP::TCP::Port,
+ *        picolibrary::IP::TCP::Port ) works properly.
+ */
+TEST( lessThanOperator, worksProperly )
+{
+    {
+        auto const rhs = random<Port::Unsigned_Integer>( 1 );
+        auto const lhs = random<Port::Unsigned_Integer>( 0, rhs - 1 );
+
+        EXPECT_TRUE( Port{ lhs } < Port{ rhs } );
+    }
+
+    {
+        auto const rhs = random<Port::Unsigned_Integer>();
+        auto const lhs = random<Port::Unsigned_Integer>( rhs );
+
+        EXPECT_FALSE( Port{ lhs } < Port{ rhs } );
+    }
+}
+
+/**
+ * \brief Verify picolibrary::IP::TCP::operator>( picolibrary::IP::TCP::Port,
+ *        picolibrary::IP::TCP::Port ) works properly.
+ */
+TEST( greaterThanOperator, worksProperly )
+{
+    {
+        auto const lhs = random<Port::Unsigned_Integer>( 1 );
+        auto const rhs = random<Port::Unsigned_Integer>( 0, lhs - 1 );
+
+        EXPECT_TRUE( Port{ lhs } > Port{ rhs } );
+    }
+
+    {
+        auto const lhs = random<Port::Unsigned_Integer>();
+        auto const rhs = random<Port::Unsigned_Integer>( lhs );
+
+        EXPECT_FALSE( Port{ lhs } > Port{ rhs } );
+    }
+}
+
+/**
+ * \brief Verify picolibrary::IP::TCP::operator<=( picolibrary::IP::TCP::Port,
+ *        picolibrary::IP::TCP::Port ) works properly.
+ */
+TEST( lessThanOrEqualToOperator, worksProperly )
+{
+    {
+        auto const lhs = random<Port::Unsigned_Integer>();
+        auto const rhs = random<Port::Unsigned_Integer>( lhs );
+
+        EXPECT_TRUE( Port{ lhs } <= Port{ rhs } );
+    }
+
+    {
+        auto const lhs = random<Port::Unsigned_Integer>( 1 );
+        auto const rhs = random<Port::Unsigned_Integer>( 0, lhs - 1 );
+
+        EXPECT_FALSE( Port{ lhs } <= Port{ rhs } );
+    }
+}
+
+/**
+ * \brief Verify picolibrary::IP::TCP::operator>=( picolibrary::IP::TCP::Port,
+ *        picolibrary::IP::TCP::Port ) works properly.
+ */
+TEST( greaterThanOrEqualToOperator, worksProperly )
+{
+    {
+        auto const rhs = random<Port::Unsigned_Integer>();
+        auto const lhs = random<Port::Unsigned_Integer>( rhs );
+
+        EXPECT_TRUE( Port{ lhs } >= Port{ rhs } );
+    }
+
+    {
+        auto const rhs = random<Port::Unsigned_Integer>( 1 );
+        auto const lhs = random<Port::Unsigned_Integer>( 0, rhs - 1 );
+
+        EXPECT_FALSE( Port{ lhs } >= Port{ rhs } );
+    }
+}
+
+/**
+ * \brief Verify picolibrary::Output_Formatter<picolibrary::IP::TCP::Port> properly
+ *        handles an invalid format string.
+ */
+TEST( outputFormatter, invalidFormatString )
+{
+    auto stream = Output_String_Stream{};
+
+    auto const result = stream.print(
+        ( std::string{ '{' } + random_container<std::string>( random<std::uint_fast8_t>( 1 ) ) + '}' )
+            .c_str(),
+        Port{} );
+
+    EXPECT_TRUE( result.is_error() );
+    EXPECT_EQ( result.error(), Generic_Error::INVALID_FORMAT );
+
+    EXPECT_FALSE( stream.end_of_file_reached() );
+    EXPECT_TRUE( stream.io_error_present() );
+    EXPECT_FALSE( stream.fatal_error_present() );
+}
+
+/**
+ * \brief Verify picolibrary::Output_Formatter<picolibrary::IP::TCP::Port> properly
+ *        handles a print error.
+ */
+TEST( outputFormatter, printError )
+{
+    auto stream = Mock_Output_Stream{};
+
+    auto const error = random<Mock_Error>();
+
+    EXPECT_CALL( stream.buffer(), put( A<std::string>() ) ).WillOnce( Return( error ) );
+
+    auto const result = stream.print( "{}", Port{} );
+
+    EXPECT_TRUE( result.is_error() );
+    EXPECT_EQ( result.error(), error );
+
+    EXPECT_FALSE( stream.end_of_file_reached() );
+    EXPECT_FALSE( stream.io_error_present() );
+    EXPECT_TRUE( stream.fatal_error_present() );
+}
+
+/**
+ * \brief Verify picolibrary::Output_Formatter<picolibrary::IP::TCP::Port> works properly.
+ */
+TEST( outputFormatter, worksProperly )
+{
+    auto stream = Output_String_Stream{};
+
+    auto const port = Port{ random<Port::Unsigned_Integer>() };
+
+    EXPECT_FALSE( stream.print( "{}", port ).is_error() );
+
+    EXPECT_EQ( stream.string(), decimal( port.as_unsigned_integer() ) );
+}
+
+/**
+ * \brief Execute the picolibrary::IP::TCP::Port unit tests.
+ *
+ * \param[in] argc The number of arguments to pass to testing::InitGoogleMock().
+ * \param[in] argv The array  of arguments to pass to testing::InitGoogleMock().
+ *
+ * \return See Google Test's RUN_ALL_TESTS().
+ */
+int main( int argc, char * argv[] )
+{
+    ::testing::InitGoogleMock( &argc, argv );
+
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Resolves #651 (Convert TCP over IP port number to class).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
