### PR TITLE
Add IPv4 address multicast address checker

### DIFF
--- a/include/picolibrary/ipv4.h
+++ b/include/picolibrary/ipv4.h
@@ -194,6 +194,17 @@ class Address {
     }
 
     /**
+     * \brief Check if the address is a multicast address (224.0.0.0-239.255.255.255).
+     *
+     * \return true if the address is a multicast address.
+     * \return false if the address is not a multicast address.
+     */
+    constexpr auto is_multicast() const noexcept
+    {
+        return as_byte_array()[ 0 ] >= 224 and as_byte_array()[ 0 ] <= 239;
+    }
+
+    /**
      * \brief Get the address in its byte array representation.
      *
      * \return The address in its byte array representation.

--- a/test/unit/picolibrary/ipv4/address/main.cc
+++ b/test/unit/picolibrary/ipv4/address/main.cc
@@ -115,6 +115,7 @@ TEST( any, worksProperly )
 
     EXPECT_TRUE( address.is_any() );
     EXPECT_FALSE( address.is_loopback() );
+    EXPECT_FALSE( address.is_multicast() );
     EXPECT_EQ( address.as_byte_array(), ANY_AS_BYTE_ARRAY );
     EXPECT_EQ( address.as_unsigned_integer(), ANY_AS_UNSIGNED_INTEGER );
 }
@@ -128,6 +129,7 @@ TEST( loopback, worksProperly )
 
     EXPECT_FALSE( address.is_any() );
     EXPECT_TRUE( address.is_loopback() );
+    EXPECT_FALSE( address.is_multicast() );
     EXPECT_EQ( address.as_byte_array(), LOOPBACK_AS_BYTE_ARRAY );
     EXPECT_EQ( address.as_unsigned_integer(), LOOPBACK_AS_UNSIGNED_INTEGER );
 }
@@ -141,6 +143,7 @@ TEST( broadcast, worksProperly )
 
     EXPECT_FALSE( address.is_any() );
     EXPECT_FALSE( address.is_loopback() );
+    EXPECT_FALSE( address.is_multicast() );
     EXPECT_EQ( address.as_byte_array(), BROADCAST_AS_BYTE_ARRAY );
     EXPECT_EQ( address.as_unsigned_integer(), BROADCAST_AS_UNSIGNED_INTEGER );
 }
@@ -154,6 +157,7 @@ TEST( constructorDefault, worksProperly )
 
     EXPECT_TRUE( address.is_any() );
     EXPECT_FALSE( address.is_loopback() );
+    EXPECT_FALSE( address.is_multicast() );
     EXPECT_EQ( address.as_byte_array(), ANY_AS_BYTE_ARRAY );
     EXPECT_EQ( address.as_unsigned_integer(), ANY_AS_UNSIGNED_INTEGER );
 }
@@ -171,6 +175,7 @@ TEST( constructorByteArray, worksProperly )
 
     EXPECT_EQ( address.is_any(), byte_array == ANY_AS_BYTE_ARRAY );
     EXPECT_EQ( address.is_loopback(), byte_array == LOOPBACK_AS_BYTE_ARRAY );
+    EXPECT_EQ( address.is_multicast(), byte_array[ 0 ] >= 224 and byte_array[ 0 ] <= 239 );
     EXPECT_EQ( address.as_byte_array(), byte_array );
     EXPECT_EQ( address.as_unsigned_integer(), unsigned_integer );
 }
@@ -188,6 +193,7 @@ TEST( constructorUnsignedInteger, worksProperly )
 
     EXPECT_EQ( address.is_any(), byte_array == ANY_AS_BYTE_ARRAY );
     EXPECT_EQ( address.is_loopback(), byte_array == LOOPBACK_AS_BYTE_ARRAY );
+    EXPECT_EQ( address.is_multicast(), byte_array[ 0 ] >= 224 and byte_array[ 0 ] <= 239 );
     EXPECT_EQ( address.as_byte_array(), byte_array );
     EXPECT_EQ( address.as_unsigned_integer(), unsigned_integer );
 }


### PR DESCRIPTION
Resolves #663 (Add IPv4 address multicast address checker).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
