### PR TITLE
Remove IP protocol

### DIFF
--- a/include/picolibrary/ip.h
+++ b/include/picolibrary/ip.h
@@ -384,13 +384,6 @@ constexpr auto operator>=( Address const & lhs, Address const & rhs ) noexcept
     return not( lhs < rhs );
 }
 
-/**
- * \brief Protocol.
- */
-enum class Protocol : std::uint8_t {
-    TCP = 6, ///< TCP.
-};
-
 } // namespace picolibrary::IP
 
 namespace picolibrary {


### PR DESCRIPTION
Resolves #677 (Remove IP protocol).

The IP protcol enum class is no longer needed for the application for
which it was originally intended to be used.

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
