### PR TITLE
Replace IP endpoint unit test port literal with default constructed port

### DIFF
--- a/test/unit/picolibrary/ip/endpoint/main.cc
+++ b/test/unit/picolibrary/ip/endpoint/main.cc
@@ -82,7 +82,7 @@ TEST( constructorDefault, worksProperly )
     auto const endpoint = Endpoint{};
 
     EXPECT_EQ( endpoint.address(), Address{} );
-    EXPECT_EQ( endpoint.port(), 0 );
+    EXPECT_EQ( endpoint.port(), Port{} );
 }
 
 /**


### PR DESCRIPTION
Resolves #681 (Replace IP endpoint unit test port literal with default
constructed port).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
