### PR TITLE
Add pseudo-random WIZnet W5500 PHY mode generation

### DIFF
--- a/include/picolibrary/testing/unit/wiznet/w5500.h
+++ b/include/picolibrary/testing/unit/wiznet/w5500.h
@@ -63,6 +63,17 @@ inline auto random<WIZnet::W5500::Region>()
         static_cast<std::uint8_t>( WIZnet::W5500::Region::RX_BUFFER ) ) );
 }
 
+/**
+ * \brief Generate a pseudo-random WIZnet W5500 PHY mode.
+ *
+ * \return A pseudo-randomly generated WIZnet W5500 PHY mode.
+ */
+template<>
+inline auto random<WIZnet::W5500::PHY_Mode>()
+{
+    return static_cast<WIZnet::W5500::PHY_Mode>( random<std::uint8_t>( 0b0000, 0b1111 ) << 3 );
+}
+
 } // namespace picolibrary::Testing::Unit
 
 /**


### PR DESCRIPTION
Resolves #693 (Add pseudo-random WIZnet W5500 PHY mode generation).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
