### PR TITLE
Fix pseudo-random WIZnet W5500 socket ID generation

### DIFF
--- a/include/picolibrary/testing/unit/wiznet/w5500.h
+++ b/include/picolibrary/testing/unit/wiznet/w5500.h
@@ -45,9 +45,7 @@ namespace picolibrary::Testing::Unit {
 template<>
 inline auto random<WIZnet::W5500::Socket_ID>()
 {
-    return static_cast<WIZnet::W5500::Socket_ID>( random<std::uint8_t>(
-        static_cast<std::uint8_t>( WIZnet::W5500::Socket_ID::_0 ),
-        static_cast<std::uint8_t>( WIZnet::W5500::Socket_ID::_7 ) ) );
+    return static_cast<WIZnet::W5500::Socket_ID>( random<std::uint8_t>( 0, 7 ) << 5 );
 }
 
 /**


### PR DESCRIPTION
Resolves #698 (Fix pseudo-random WIZnet W5500 socket ID generation).

As previously implemented, a generated socket ID could contain set bits
outside the SOCKET field.

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
