### PR TITLE
Fix pseudo-random WIZnet W5500 region generation

### DIFF
--- a/include/picolibrary/testing/unit/wiznet/w5500.h
+++ b/include/picolibrary/testing/unit/wiznet/w5500.h
@@ -56,9 +56,7 @@ inline auto random<WIZnet::W5500::Socket_ID>()
 template<>
 inline auto random<WIZnet::W5500::Region>()
 {
-    return static_cast<WIZnet::W5500::Region>( random<std::uint8_t>(
-        static_cast<std::uint8_t>( WIZnet::W5500::Region::REGISTERS ),
-        static_cast<std::uint8_t>( WIZnet::W5500::Region::RX_BUFFER ) ) );
+    return static_cast<WIZnet::W5500::Region>( random<std::uint8_t>( 0b01, 0b11 ) << 3 );
 }
 
 /**


### PR DESCRIPTION
Resolves #699 (Fix pseudo-random WIZnet W5500 region generation).

As previously implemented, a generated region could contain set bits
that were outside the REGION field.

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
