### PR TITLE
Add pseudo-random WIZnet W5500 link status generation

### DIFF
--- a/include/picolibrary/testing/unit/wiznet/w5500.h
+++ b/include/picolibrary/testing/unit/wiznet/w5500.h
@@ -70,6 +70,17 @@ inline auto random<WIZnet::W5500::PHY_Mode>()
     return static_cast<WIZnet::W5500::PHY_Mode>( random<std::uint8_t>( 0b0000, 0b1111 ) << 3 );
 }
 
+/**
+ * \brief Generate a pseudo-random WIZnet W5500 link status.
+ *
+ * \return A pseudo-randomly generated WIZnet W5500 link status.
+ */
+template<>
+inline auto random<WIZnet::W5500::Link_Status>()
+{
+    return random<bool>() ? WIZnet::W5500::Link_Status::DOWN : WIZnet::W5500::Link_Status::UP;
+}
+
 } // namespace picolibrary::Testing::Unit
 
 /**


### PR DESCRIPTION
Resolves #694 (Add pseudo-random WIZnet W5500 link status generation).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
