### PR TITLE
Add pseudo-random WIZnet W5500 link mode generation

### DIFF
--- a/include/picolibrary/testing/unit/wiznet/w5500.h
+++ b/include/picolibrary/testing/unit/wiznet/w5500.h
@@ -81,6 +81,17 @@ inline auto random<WIZnet::W5500::Link_Status>()
     return random<bool>() ? WIZnet::W5500::Link_Status::DOWN : WIZnet::W5500::Link_Status::UP;
 }
 
+/**
+ * \brief Generate a pseudo-random WIZnet W5500 link mode.
+ *
+ * \return A pseudo-randomly generated WIZnet W5500 link mode.
+ */
+template<>
+inline auto random<WIZnet::W5500::Link_Mode>()
+{
+    return random<bool>() ? WIZnet::W5500::Link_Mode::HALF_DUPLEX : WIZnet::W5500::Link_Mode::FULL_DUPLEX;
+}
+
 } // namespace picolibrary::Testing::Unit
 
 /**


### PR DESCRIPTION
Resolves #695 (Add pseudo-random WIZnet W5500 link mode generation).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
