### PR TITLE
Add pseudo-random WIZnet W5500 link speed generation

### DIFF
--- a/include/picolibrary/testing/unit/wiznet/w5500.h
+++ b/include/picolibrary/testing/unit/wiznet/w5500.h
@@ -92,6 +92,17 @@ inline auto random<WIZnet::W5500::Link_Mode>()
     return random<bool>() ? WIZnet::W5500::Link_Mode::HALF_DUPLEX : WIZnet::W5500::Link_Mode::FULL_DUPLEX;
 }
 
+/**
+ * \brief Generate a pseudo-random WIZnet W5500 link speed.
+ *
+ * \return A pseudo-randomly generated WIZnet W5500 link speed.
+ */
+template<>
+inline auto random<WIZnet::W5500::Link_Speed>()
+{
+    return random<bool>() ? WIZnet::W5500::Link_Speed::_10_MBPS : WIZnet::W5500::Link_Speed::_100_MBPS;
+}
+
 } // namespace picolibrary::Testing::Unit
 
 /**


### PR DESCRIPTION
Resolves #696 (Add pseudo-random WIZnet W5500 link speed generation).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
