### PR TITLE
Add pseudo-random WIZnet W5500 ping blocking configuration generation

### DIFF
--- a/include/picolibrary/testing/unit/wiznet/w5500.h
+++ b/include/picolibrary/testing/unit/wiznet/w5500.h
@@ -60,6 +60,18 @@ inline auto random<WIZnet::W5500::Region>()
 }
 
 /**
+ * \brief Generate a pseudo-random WIZnet W5500 ping blocking configuration.
+ *
+ * \return A pseudo-randomly generated WIZnet W5500 ping blocking configuration.
+ */
+template<>
+inline auto random<WIZnet::W5500::Ping_Blocking>()
+{
+    return random<bool>() ? WIZnet::W5500::Ping_Blocking::DISABLED
+                          : WIZnet::W5500::Ping_Blocking::ENABLED;
+}
+
+/**
  * \brief Generate a pseudo-random WIZnet W5500 PHY mode.
  *
  * \return A pseudo-randomly generated WIZnet W5500 PHY mode.


### PR DESCRIPTION
Resolves #710 (Add pseudo-random WIZnet W5500 ping blocking
configuration generation).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
