### PR TITLE
Add pseudo-random WIZnet W5500 socket buffer size generation

### DIFF
--- a/include/picolibrary/testing/unit/wiznet/w5500.h
+++ b/include/picolibrary/testing/unit/wiznet/w5500.h
@@ -126,6 +126,17 @@ inline auto random<WIZnet::W5500::Link_Speed>()
     return random<bool>() ? WIZnet::W5500::Link_Speed::_10_MBPS : WIZnet::W5500::Link_Speed::_100_MBPS;
 }
 
+/**
+ * \brief Generate a pseudo-random WIZnet W5500 socket buffer size.
+ *
+ * \brief A pseudo-randomly generated WIZnet W5500 socket buffer size.
+ */
+template<>
+inline auto random<WIZnet::W5500::Buffer_Size>()
+{
+    return static_cast<WIZnet::W5500::Buffer_Size>( ( 1 << random<std::uint8_t>( 0, 5 ) ) >> 1 );
+}
+
 } // namespace picolibrary::Testing::Unit
 
 /**


### PR DESCRIPTION
Resolves #712 (Add pseudo-random WIZnet W5500 socket buffer size
generation).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
