### PR TITLE
Add range constrained pseudo-random WIZnet W5500 socket buffer size generation

### DIFF
--- a/include/picolibrary/testing/unit/wiznet/w5500.h
+++ b/include/picolibrary/testing/unit/wiznet/w5500.h
@@ -25,6 +25,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <cstdlib>
 #include <vector>
 
 #include "gmock/gmock.h"
@@ -127,14 +128,59 @@ inline auto random<WIZnet::W5500::Link_Speed>()
 }
 
 /**
+ * \brief Generate a pseudo-random WIZnet W5500 socket buffer size within the specified
+ *        range.
+ *
+ * \param[in] min The lower bound of the allowable range.
+ * \param[in] max The upper bound of the allowable range.
+ *
+ * \return A pseudo-random WIZnet W5500 socket buffer size in the range [min,max].
+ */
+template<>
+inline auto random<WIZnet::W5500::Buffer_Size>( WIZnet::W5500::Buffer_Size min, WIZnet::W5500::Buffer_Size max )
+{
+    auto const shift = []( WIZnet::W5500::Buffer_Size buffer_size ) -> std::uint8_t {
+        switch ( buffer_size ) {
+            case WIZnet::W5500::Buffer_Size::_0_KIB: return 0;
+            case WIZnet::W5500::Buffer_Size::_1_KIB: return 1;
+            case WIZnet::W5500::Buffer_Size::_2_KIB: return 2;
+            case WIZnet::W5500::Buffer_Size::_4_KIB: return 3;
+            case WIZnet::W5500::Buffer_Size::_8_KIB: return 4;
+            case WIZnet::W5500::Buffer_Size::_16_KIB: return 5;
+            default: std::abort();
+        } // switch
+    };
+
+    return static_cast<WIZnet::W5500::Buffer_Size>(
+        ( 1 << random<std::uint8_t>( shift( min ), shift( max ) ) ) >> 1 );
+}
+
+/**
+ * \brief Generate a pseudo-random WIZnet W5500 socket buffer size greater than or equal
+ *        to a minimum socket buffer size.
+ *
+ * \param[in] min The lower bound of the allowable range.
+ *
+ * \return A pseudo-random WIZnet W5500 socket buffer size in the range
+ *         [min,picolibrary::WIZnet::W5500::Buffer_Size::_16_KIB].
+ */
+template<>
+inline auto random<WIZnet::W5500::Buffer_Size>( WIZnet::W5500::Buffer_Size min )
+{
+    return random<WIZnet::W5500::Buffer_Size>( min, WIZnet::W5500::Buffer_Size::_16_KIB );
+}
+
+/**
  * \brief Generate a pseudo-random WIZnet W5500 socket buffer size.
  *
- * \brief A pseudo-randomly generated WIZnet W5500 socket buffer size.
+ * \return A pseudo-random WIZnet W5500 socket buffer size in the range
+ *         [picolibrary::WIZnet::W5500::Buffer_Size::_0_KIB,picolibrary::WIZnet::W5500::Buffer_Size::_16_KIB].
  */
 template<>
 inline auto random<WIZnet::W5500::Buffer_Size>()
 {
-    return static_cast<WIZnet::W5500::Buffer_Size>( ( 1 << random<std::uint8_t>( 0, 5 ) ) >> 1 );
+    return random<WIZnet::W5500::Buffer_Size>(
+        WIZnet::W5500::Buffer_Size::_0_KIB, WIZnet::W5500::Buffer_Size::_16_KIB );
 }
 
 } // namespace picolibrary::Testing::Unit


### PR DESCRIPTION
Resolves #716 (Add range constrained pseudo-random WIZnet W5500 socket
buffer size generation).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
