### PR TITLE
Fix pseudo-random Microchip MCP23008 sequential operation mode configuration generation

### DIFF
--- a/include/picolibrary/testing/unit/microchip/mcp23008.h
+++ b/include/picolibrary/testing/unit/microchip/mcp23008.h
@@ -43,9 +43,8 @@ namespace picolibrary::Testing::Unit {
 template<>
 inline auto random<Microchip::MCP23008::Sequential_Operation_Mode>()
 {
-    return static_cast<Microchip::MCP23008::Sequential_Operation_Mode>( random<std::uint8_t>(
-        static_cast<std::uint8_t>( Microchip::MCP23008::Sequential_Operation_Mode::ENABLED ),
-        static_cast<std::uint8_t>( Microchip::MCP23008::Sequential_Operation_Mode::DISABLED ) ) );
+    return random<bool>() ? Microchip::MCP23008::Sequential_Operation_Mode::DISABLED
+                          : Microchip::MCP23008::Sequential_Operation_Mode::ENABLED;
 }
 
 /**


### PR DESCRIPTION
Resolves #700 (Fix pseudo-random Microchip MCP23008 sequential operation
mode configuration generation).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
