### PR TITLE
Fix pseudo-random Microchip MCP23008 SDA slew rate control configuration generation

### DIFF
--- a/include/picolibrary/testing/unit/microchip/mcp23008.h
+++ b/include/picolibrary/testing/unit/microchip/mcp23008.h
@@ -56,9 +56,8 @@ inline auto random<Microchip::MCP23008::Sequential_Operation_Mode>()
 template<>
 inline auto random<Microchip::MCP23008::SDA_Slew_Rate_Control>()
 {
-    return static_cast<Microchip::MCP23008::SDA_Slew_Rate_Control>( random<std::uint8_t>(
-        static_cast<std::uint8_t>( Microchip::MCP23008::SDA_Slew_Rate_Control::ENABLED ),
-        static_cast<std::uint8_t>( Microchip::MCP23008::SDA_Slew_Rate_Control::DISABLED ) ) );
+    return random<bool>() ? Microchip::MCP23008::SDA_Slew_Rate_Control::DISABLED
+                          : Microchip::MCP23008::SDA_Slew_Rate_Control::ENABLED;
 }
 
 /**


### PR DESCRIPTION
Resolves #701 (Fix pseudo-random Microchip MCP23008 SDA slew rate
control configuration generation).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
