### PR TITLE
Fix pseudo-random Microchip MCP23008 interrupt mode generation

### DIFF
--- a/include/picolibrary/testing/unit/microchip/mcp23008.h
+++ b/include/picolibrary/testing/unit/microchip/mcp23008.h
@@ -68,9 +68,7 @@ inline auto random<Microchip::MCP23008::SDA_Slew_Rate_Control>()
 template<>
 inline auto random<Microchip::MCP23008::Interrupt_Mode>()
 {
-    return static_cast<Microchip::MCP23008::Interrupt_Mode>( random<std::uint8_t>(
-        static_cast<std::uint8_t>( Microchip::MCP23008::Interrupt_Mode::PUSH_PULL_ACTIVE_LOW ),
-        static_cast<std::uint8_t>( Microchip::MCP23008::Interrupt_Mode::OPEN_DRAIN ) ) );
+    return static_cast<Microchip::MCP23008::Interrupt_Mode>( random<std::uint8_t>( 0b00, 0b10 ) << 1 );
 }
 
 } // namespace picolibrary::Testing::Unit


### PR DESCRIPTION
Resolves #702 (Fix pseudo-random Microchip MCP23008 interrupt mode
generation).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
