### PR TITLE
Add WIZnet W5500 IP network stack TCP ephemeral port allocation control

### DIFF
--- a/include/picolibrary/wiznet/w5500/network_stack.h
+++ b/include/picolibrary/wiznet/w5500/network_stack.h
@@ -26,6 +26,7 @@
 #include <cstdint>
 
 #include "picolibrary/error.h"
+#include "picolibrary/ip/tcp.h"
 #include "picolibrary/ipv4.h"
 #include "picolibrary/mac_address.h"
 #include "picolibrary/result.h"
@@ -656,6 +657,33 @@ class Network_Stack {
     auto service() noexcept -> Result<Void, Error_Code>
     {
         return {};
+    }
+
+    /**
+     * \brief Enable TCP ephemeral port allocation.
+     *
+     * \param[in] min The lower bound of the ephemeral port range.
+     * \param[in] max The upper bound of the ephemeral port range.
+     *
+     * \return Nothing if enabling TCP ephemeral port allocation succeeded.
+     * \return picolibrary::Generic_Error::INVALID_ARGUMENT if min is not less than or
+     *         equal to max.
+     */
+    auto enable_tcp_ephemeral_port_allocation( IP::TCP::Port min = 49152, IP::TCP::Port max = 65535 ) noexcept
+        -> Result<Void, Error_Code>
+    {
+        if ( not( min <= max ) ) {
+            return Generic_Error::INVALID_ARGUMENT;
+        } // if
+
+        return {};
+    }
+
+    /**
+     * \brief Disable TCP ephemeral port allocation.
+     */
+    void disable_tcp_ephemeral_port_allocation() noexcept
+    {
     }
 
   private:

--- a/include/picolibrary/wiznet/w5500/network_stack.h
+++ b/include/picolibrary/wiznet/w5500/network_stack.h
@@ -671,7 +671,7 @@ class Network_Stack {
      * \return picolibrary::Generic_Error::INVALID_ARGUMENT if min is not less than or
      *         equal to max.
      */
-    auto enable_tcp_ephemeral_port_allocation( IP::TCP::Port min = 49152, IP::TCP::Port max = 65535 ) noexcept
+    auto enable_tcp_ephemeral_port_allocation( IP::TCP::Port min, IP::TCP::Port max ) noexcept
         -> Result<Void, Error_Code>
     {
         if ( m_tcp_ephemeral_port_allocation_enabled ) {

--- a/include/picolibrary/wiznet/w5500/network_stack.h
+++ b/include/picolibrary/wiznet/w5500/network_stack.h
@@ -666,24 +666,25 @@ class Network_Stack {
      * \param[in] max The upper bound of the ephemeral port range.
      *
      * \return Nothing if enabling TCP ephemeral port allocation succeeded.
+     * \return picolibrary::Generic_Error::LOGIC_ERROR if TCP ephemeral port allocation
+     *         has already been enabled.
      * \return picolibrary::Generic_Error::INVALID_ARGUMENT if min is not less than or
      *         equal to max.
      */
     auto enable_tcp_ephemeral_port_allocation( IP::TCP::Port min = 49152, IP::TCP::Port max = 65535 ) noexcept
         -> Result<Void, Error_Code>
     {
+        if ( m_tcp_ephemeral_port_allocation_enabled ) {
+            return Generic_Error::LOGIC_ERROR;
+        } // if
+
         if ( not( min <= max ) ) {
             return Generic_Error::INVALID_ARGUMENT;
         } // if
 
-        return {};
-    }
+        m_tcp_ephemeral_port_allocation_enabled = true;
 
-    /**
-     * \brief Disable TCP ephemeral port allocation.
-     */
-    void disable_tcp_ephemeral_port_allocation() noexcept
-    {
+        return {};
     }
 
   private:
@@ -691,6 +692,11 @@ class Network_Stack {
      * \brief The driver for the W5500 the network stack utilizes.
      */
     Driver * m_driver{};
+
+    /**
+     * \brief The TCP ephemeral port allocation enable state.
+     */
+    bool m_tcp_ephemeral_port_allocation_enabled{};
 };
 
 } // namespace picolibrary::WIZnet::W5500

--- a/include/picolibrary/wiznet/w5500/network_stack.h
+++ b/include/picolibrary/wiznet/w5500/network_stack.h
@@ -668,8 +668,7 @@ class Network_Stack {
      * \return Nothing if enabling TCP ephemeral port allocation succeeded.
      * \return picolibrary::Generic_Error::LOGIC_ERROR if TCP ephemeral port allocation
      *         has already been enabled.
-     * \return picolibrary::Generic_Error::INVALID_ARGUMENT if min is not less than or
-     *         equal to max.
+     * \return picolibrary::Generic_Error::INVALID_ARGUMENT if min is greater than max.
      */
     auto enable_tcp_ephemeral_port_allocation( IP::TCP::Port min, IP::TCP::Port max ) noexcept
         -> Result<Void, Error_Code>

--- a/include/picolibrary/wiznet/w5500/network_stack.h
+++ b/include/picolibrary/wiznet/w5500/network_stack.h
@@ -669,6 +669,8 @@ class Network_Stack {
      * \return picolibrary::Generic_Error::LOGIC_ERROR if TCP ephemeral port allocation
      *         has already been enabled.
      * \return picolibrary::Generic_Error::INVALID_ARGUMENT if min is greater than max.
+     * \return picolibrary::Generic_Error::INVALID_ARGUMENT if min is the port number that
+     *         is used to represent any port number (0).
      */
     auto enable_tcp_ephemeral_port_allocation( IP::TCP::Port min, IP::TCP::Port max ) noexcept
         -> Result<Void, Error_Code>
@@ -678,6 +680,10 @@ class Network_Stack {
         } // if
 
         if ( not( min <= max ) ) {
+            return Generic_Error::INVALID_ARGUMENT;
+        } // if
+
+        if ( min.is_any() ) {
             return Generic_Error::INVALID_ARGUMENT;
         } // if
 

--- a/include/picolibrary/wiznet/w5500/network_stack.h
+++ b/include/picolibrary/wiznet/w5500/network_stack.h
@@ -666,8 +666,8 @@ class Network_Stack {
      * \param[in] max The upper bound of the ephemeral port range.
      *
      * \return Nothing if enabling TCP ephemeral port allocation succeeded.
-     * \return picolibrary::Generic_Error::LOGIC_ERROR if TCP ephemeral port allocation
-     *         has already been enabled.
+     * \return picolibrary::Generic_Error::LOGIC_ERROR if TCP ephemeral port allocation is
+     *         already enabled.
      * \return picolibrary::Generic_Error::INVALID_ARGUMENT if min is greater than max.
      * \return picolibrary::Generic_Error::INVALID_ARGUMENT if min is the port number that
      *         is used to represent any port number (0).

--- a/test/unit/picolibrary/wiznet/w5500/network_stack/main.cc
+++ b/test/unit/picolibrary/wiznet/w5500/network_stack/main.cc
@@ -1703,9 +1703,12 @@ TEST( enableTCPEphemeralPortAllocation, alreadyEnabled )
 
     auto network_stack = Network_Stack{ driver };
 
-    EXPECT_FALSE( network_stack.enable_tcp_ephemeral_port_allocation().is_error() );
+    auto const min = random<std::uint16_t>();
+    auto const max = random<std::uint16_t>( min );
 
-    auto result = network_stack.enable_tcp_ephemeral_port_allocation();
+    EXPECT_FALSE( network_stack.enable_tcp_ephemeral_port_allocation( min, max ).is_error() );
+
+    auto result = network_stack.enable_tcp_ephemeral_port_allocation( min, max );
 
     EXPECT_TRUE( result.is_error() );
     EXPECT_EQ( result.error(), Generic_Error::LOGIC_ERROR );
@@ -1738,24 +1741,14 @@ TEST( enableTCPEphemeralPortAllocation, invalidPortRange )
  */
 TEST( enableTCPEphemeralPortAllocation, worksProperly )
 {
-    {
-        auto driver = Mock_Driver{};
+    auto driver = Mock_Driver{};
 
-        auto network_stack = Network_Stack{ driver };
+    auto network_stack = Network_Stack{ driver };
 
-        EXPECT_FALSE( network_stack.enable_tcp_ephemeral_port_allocation().is_error() );
-    }
+    auto const min = random<std::uint16_t>();
+    auto const max = random<std::uint16_t>( min );
 
-    {
-        auto driver = Mock_Driver{};
-
-        auto network_stack = Network_Stack{ driver };
-
-        auto const min = random<std::uint16_t>();
-        auto const max = random<std::uint16_t>( min );
-
-        EXPECT_FALSE( network_stack.enable_tcp_ephemeral_port_allocation( min, max ).is_error() );
-    }
+    EXPECT_FALSE( network_stack.enable_tcp_ephemeral_port_allocation( min, max ).is_error() );
 }
 
 /**

--- a/test/unit/picolibrary/wiznet/w5500/network_stack/main.cc
+++ b/test/unit/picolibrary/wiznet/w5500/network_stack/main.cc
@@ -28,10 +28,12 @@
 #include "gtest/gtest.h"
 #include "picolibrary/error.h"
 #include "picolibrary/fixed_size_array.h"
+#include "picolibrary/ip/tcp.h"
 #include "picolibrary/ipv4.h"
 #include "picolibrary/mac_address.h"
 #include "picolibrary/result.h"
 #include "picolibrary/testing/unit/error.h"
+#include "picolibrary/testing/unit/ip.h"
 #include "picolibrary/testing/unit/ipv4.h"
 #include "picolibrary/testing/unit/mac_address.h"
 #include "picolibrary/testing/unit/random.h"
@@ -65,6 +67,7 @@ using ::testing::InSequence;
 using ::testing::Return;
 
 using IPv4_Address = ::picolibrary::IPv4::Address;
+using TCP_Port     = ::picolibrary::IP::TCP::Port;
 
 template<typename T, std::size_t N>
 auto random_fixed_size_array()
@@ -1703,8 +1706,8 @@ TEST( enableTCPEphemeralPortAllocation, alreadyEnabled )
 
     auto network_stack = Network_Stack{ driver };
 
-    auto const min = random<std::uint16_t>();
-    auto const max = random<std::uint16_t>( min );
+    auto const min = random<TCP_Port>( 1 );
+    auto const max = random<TCP_Port>( min );
 
     EXPECT_FALSE( network_stack.enable_tcp_ephemeral_port_allocation( min, max ).is_error() );
 
@@ -1725,10 +1728,28 @@ TEST( enableTCPEphemeralPortAllocation, invalidPortRange )
 
     auto network_stack = Network_Stack{ driver };
 
-    auto const min = random<std::uint16_t>( 1 );
-    auto const max = random<std::uint16_t>( 0, min - 1 );
+    auto const min = random<TCP_Port>( 1 );
+    auto const max = random<TCP_Port>( 0, min.as_unsigned_integer() - 1 );
 
     auto const result = network_stack.enable_tcp_ephemeral_port_allocation( min, max );
+
+    EXPECT_TRUE( result.is_error() );
+    EXPECT_EQ( result.error(), Generic_Error::INVALID_ARGUMENT );
+}
+
+/**
+ * \brief Verify
+ *        picolibrary::WIZnet::W5500::Network_Stack::enable_tcp_ephemeral_port_allocation()
+ *        properly handles an invalid port range bound.
+ */
+TEST( enableTCPEphemeralPortAllocation, invalidPortRangeBound )
+{
+    auto driver = Mock_Driver{};
+
+    auto network_stack = Network_Stack{ driver };
+
+    auto const result = network_stack.enable_tcp_ephemeral_port_allocation(
+        0, random<TCP_Port>( 0 ) );
 
     EXPECT_TRUE( result.is_error() );
     EXPECT_EQ( result.error(), Generic_Error::INVALID_ARGUMENT );
@@ -1745,8 +1766,8 @@ TEST( enableTCPEphemeralPortAllocation, worksProperly )
 
     auto network_stack = Network_Stack{ driver };
 
-    auto const min = random<std::uint16_t>();
-    auto const max = random<std::uint16_t>( min );
+    auto const min = random<TCP_Port>( 1 );
+    auto const max = random<TCP_Port>( min );
 
     EXPECT_FALSE( network_stack.enable_tcp_ephemeral_port_allocation( min, max ).is_error() );
 }

--- a/test/unit/picolibrary/wiznet/w5500/network_stack/main.cc
+++ b/test/unit/picolibrary/wiznet/w5500/network_stack/main.cc
@@ -1693,6 +1693,79 @@ TEST( service, worksProperly )
 }
 
 /**
+ * \brief Verify
+ *        picolibrary::WIZnet::W5500::Network_Stack::enable_tcp_ephemeral_port_allocation()
+ *        properly handles an invalid port range.
+ */
+TEST( enableTCPEphemeralPortAllocation, invalidPortRange )
+{
+    auto driver = Mock_Driver{};
+
+    auto network_stack = Network_Stack{ driver };
+
+    auto const min = random<std::uint16_t>( 1 );
+    auto const max = random<std::uint16_t>( 0, min - 1 );
+
+    auto const result = network_stack.enable_tcp_ephemeral_port_allocation( min, max );
+
+    EXPECT_TRUE( result.is_error() );
+    EXPECT_EQ( result.error(), Generic_Error::INVALID_ARGUMENT );
+}
+
+/**
+ * \brief Verify
+ *        picolibrary::WIZnet::W5500::Network_Stack::enable_tcp_ephemeral_port_allocation()
+ *        works properly.
+ */
+TEST( enableTCPEphemeralPortAllocation, worksProperly )
+{
+    {
+        auto driver = Mock_Driver{};
+
+        auto network_stack = Network_Stack{ driver };
+
+        EXPECT_FALSE( network_stack.enable_tcp_ephemeral_port_allocation().is_error() );
+    }
+
+    {
+        auto driver = Mock_Driver{};
+
+        auto network_stack = Network_Stack{ driver };
+
+        auto const min = random<std::uint16_t>();
+        auto const max = random<std::uint16_t>( min );
+
+        EXPECT_FALSE( network_stack.enable_tcp_ephemeral_port_allocation( min, max ).is_error() );
+    }
+}
+
+/**
+ * \brief Verify
+ *        picolibrary::WIZnet::W5500::Network_Stack::disable_tcp_ephemeral_port_allocation()
+ *        works properly.
+ */
+TEST( disableTCPEphemeralPortAllocation, worksProperly )
+{
+    {
+        auto driver = Mock_Driver{};
+
+        auto network_stack = Network_Stack{ driver };
+
+        network_stack.disable_tcp_ephemeral_port_allocation();
+    }
+
+    {
+        auto driver = Mock_Driver{};
+
+        auto network_stack = Network_Stack{ driver };
+
+        EXPECT_FALSE( network_stack.enable_tcp_ephemeral_port_allocation().is_error() );
+
+        network_stack.disable_tcp_ephemeral_port_allocation();
+    }
+}
+
+/**
  * \brief Execute the picolibrary::WIZnet::W5500::Network_Stack unit tests.
  *
  * \param[in] argc The number of arguments to pass to testing::InitGoogleMock().

--- a/test/unit/picolibrary/wiznet/w5500/network_stack/main.cc
+++ b/test/unit/picolibrary/wiznet/w5500/network_stack/main.cc
@@ -1695,6 +1695,25 @@ TEST( service, worksProperly )
 /**
  * \brief Verify
  *        picolibrary::WIZnet::W5500::Network_Stack::enable_tcp_ephemeral_port_allocation()
+ *        properly handles TCP ephemeral port allocation already having been enabled.
+ */
+TEST( enableTCPEphemeralPortAllocation, alreadyEnabled )
+{
+    auto driver = Mock_Driver{};
+
+    auto network_stack = Network_Stack{ driver };
+
+    EXPECT_FALSE( network_stack.enable_tcp_ephemeral_port_allocation().is_error() );
+
+    auto result = network_stack.enable_tcp_ephemeral_port_allocation();
+
+    EXPECT_TRUE( result.is_error() );
+    EXPECT_EQ( result.error(), Generic_Error::LOGIC_ERROR );
+}
+
+/**
+ * \brief Verify
+ *        picolibrary::WIZnet::W5500::Network_Stack::enable_tcp_ephemeral_port_allocation()
  *        properly handles an invalid port range.
  */
 TEST( enableTCPEphemeralPortAllocation, invalidPortRange )
@@ -1736,32 +1755,6 @@ TEST( enableTCPEphemeralPortAllocation, worksProperly )
         auto const max = random<std::uint16_t>( min );
 
         EXPECT_FALSE( network_stack.enable_tcp_ephemeral_port_allocation( min, max ).is_error() );
-    }
-}
-
-/**
- * \brief Verify
- *        picolibrary::WIZnet::W5500::Network_Stack::disable_tcp_ephemeral_port_allocation()
- *        works properly.
- */
-TEST( disableTCPEphemeralPortAllocation, worksProperly )
-{
-    {
-        auto driver = Mock_Driver{};
-
-        auto network_stack = Network_Stack{ driver };
-
-        network_stack.disable_tcp_ephemeral_port_allocation();
-    }
-
-    {
-        auto driver = Mock_Driver{};
-
-        auto network_stack = Network_Stack{ driver };
-
-        EXPECT_FALSE( network_stack.enable_tcp_ephemeral_port_allocation().is_error() );
-
-        network_stack.disable_tcp_ephemeral_port_allocation();
     }
 }
 


### PR DESCRIPTION
Resolves #722 (Add WIZnet W5500 IP network stack TCP ephemeral port
allocation control).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
