### PR TITLE
Add WIZnet W5500 IP network stack socket interrupt enable/disable

### DIFF
--- a/include/picolibrary/wiznet/w5500/network_stack.h
+++ b/include/picolibrary/wiznet/w5500/network_stack.h
@@ -626,6 +626,28 @@ class Network_Stack {
     }
 
     /**
+     * \brief Enable socket interrupts.
+     *
+     * \return Nothing if enabling socket interrupts succeeded.
+     * \return An error code if enabling socket interrupts failed.
+     */
+    auto enable_socket_interrupts() noexcept
+    {
+        return m_driver->write_simr( 0xFF );
+    }
+
+    /**
+     * \brief Disable socket interrupts.
+     *
+     * \return Nothing if disabling socket interrupts succeeded.
+     * \return An error code if disabling socket interrupts failed.
+     */
+    auto disable_socket_interrupts() noexcept
+    {
+        return m_driver->write_simr( 0x00 );
+    }
+
+    /**
      * \brief Get a mask identifying the sockets for which interrupts are enabled (SIMR
      *        register value).
      *

--- a/test/unit/picolibrary/wiznet/w5500/network_stack/main.cc
+++ b/test/unit/picolibrary/wiznet/w5500/network_stack/main.cc
@@ -1604,6 +1604,76 @@ TEST( interruptContext, worksProperly )
 }
 
 /**
+ * \brief Verify picolibrary::WIZnet::W5500::Network_Stack::enable_socket_interrupts()
+ *        properly handles a SIMR register write error.
+ */
+TEST( enableSocketInterrupts, simrWriteError )
+{
+    auto driver = Mock_Driver{};
+
+    auto network_stack = Network_Stack{ driver };
+
+    auto const error = random<Mock_Error>();
+
+    EXPECT_CALL( driver, write_simr( _ ) ).WillOnce( Return( error ) );
+
+    auto const result = network_stack.enable_socket_interrupts();
+
+    EXPECT_TRUE( result.is_error() );
+    EXPECT_EQ( result.error(), error );
+}
+
+/**
+ * \brief Verify picolibrary::WIZnet::W5500::Network_Stack::enable_socket_interrupts()
+ *        works properly.
+ */
+TEST( enableSocketInterrupts, worksProperly )
+{
+    auto driver = Mock_Driver{};
+
+    auto network_stack = Network_Stack{ driver };
+
+    EXPECT_CALL( driver, write_simr( 0xFF ) ).WillOnce( Return( Result<Void, Error_Code>{} ) );
+
+    EXPECT_FALSE( network_stack.enable_socket_interrupts().is_error() );
+}
+
+/**
+ * \brief Verify picolibrary::WIZnet::W5500::Network_Stack::disable_socket_interrupts()
+ *        properly handles a SIMR register write error.
+ */
+TEST( disableSocketInterrupts, simrWriteError )
+{
+    auto driver = Mock_Driver{};
+
+    auto network_stack = Network_Stack{ driver };
+
+    auto const error = random<Mock_Error>();
+
+    EXPECT_CALL( driver, write_simr( _ ) ).WillOnce( Return( error ) );
+
+    auto const result = network_stack.disable_socket_interrupts();
+
+    EXPECT_TRUE( result.is_error() );
+    EXPECT_EQ( result.error(), error );
+}
+
+/**
+ * \brief Verify picolibrary::WIZnet::W5500::Network_Stack::disable_socket_interrupts()
+ *        works properly.
+ */
+TEST( disableSocketInterrupts, worksProperly )
+{
+    auto driver = Mock_Driver{};
+
+    auto network_stack = Network_Stack{ driver };
+
+    EXPECT_CALL( driver, write_simr( 0x00 ) ).WillOnce( Return( Result<Void, Error_Code>{} ) );
+
+    EXPECT_FALSE( network_stack.disable_socket_interrupts().is_error() );
+}
+
+/**
  * \brief Verify picolibrary::WIZnet::W5500::Network_Stack::enabled_socket_interrupts()
  *        properly handles a SIMR register read error.
  */


### PR DESCRIPTION
Resolves #732 (Add WIZnet W5500 IP network stack socket interrupt
enable/disable).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
