### PR TITLE
Fix WIZnet W5500 established socket status spelling

### DIFF
--- a/include/picolibrary/wiznet/w5500.h
+++ b/include/picolibrary/wiznet/w5500.h
@@ -1775,7 +1775,7 @@ enum class Socket_Status : std::uint8_t {
     CLOSED        = 0x00, ///< Closed.
     OPENED_TCP    = 0x13, ///< Opened (TCP).
     LISTEN        = 0x14, ///< Waiting for connection request from remote endpoint.
-    ESTABLISED    = 0x17, ///< Established.
+    ESTABLISHED   = 0x17, ///< Established.
     CLOSE_WAIT    = 0x1C, ///< Waiting for connection termination request from local user.
     OPENED_UDP    = 0x22, ///< Opened (UDP).
     OPENED_MACRAW = 0x42, ///< Opened (MACRAW).


### PR DESCRIPTION
Resolves #735 (Fix WIZnet W5500 established socket status spelling).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
