### PR TITLE
Add Microchip MCP3008 driver nonresponsive device error getter

### DIFF
--- a/include/picolibrary/microchip/mcp3008.h
+++ b/include/picolibrary/microchip/mcp3008.h
@@ -224,16 +224,16 @@ class Driver : public Device {
      *            configuration that meets the MCP3008's communication requirements.
      * \param[in] device_selector The SPI device selector used to select and deselect the
      *            MCP3008.
-     * \param[in] nonresponsive The error code to return when getting a sample fails due
-     *            to the MCP3008 being nonresponsive.
+     * \param[in] nonresponsive_device_error The error code to return when getting a
+     *            sample fails due to the MCP3008 being nonresponsive.
      */
     constexpr Driver(
         Controller &                       controller,
         typename Controller::Configuration configuration,
         Device_Selector                    device_selector,
-        Error_Code                         nonresponsive ) noexcept :
+        Error_Code                         nonresponsive_device_error ) noexcept :
         Device{ controller, configuration, std::move( device_selector ) },
-        m_nonresponsive{ nonresponsive }
+        m_nonresponsive_device_error{ nonresponsive_device_error }
     {
     }
 
@@ -265,12 +265,27 @@ class Driver : public Device {
     using Device::initialize;
 
     /**
+     * \brief Get the error code that is returned when getting a sample fails due to the
+     *        MCP3008 being nonresponsive.
+     *
+     * \return The error code that is returned when getting a sample fails due to the
+     *         MCP3008 being nonresponsive.
+     */
+    constexpr auto const & nonresponsive_device_error() const noexcept
+    {
+        return m_nonresponsive_device_error;
+    }
+
+    /**
      * \brief Get a sample.
      *
      * \param[in] input The input to get the sample from.
      *
      * \return A sample if getting the sample succeeded.
-     * \return An error code if getting the sample failed.
+     * \return picolibrary::Microchip::MCP3008::Driver<Controller_Type,
+     *         Device_Selector_Type>::nonresponsive_device_error() if getting the sample
+     *         failed due to the MCP3008 being nonresponsive.
+     * \return An error code if getting the sample failed for any other reason.
      */
     auto sample( Input input ) noexcept -> Result<Sample, Error_Code>
     {
@@ -309,7 +324,7 @@ class Driver : public Device {
         }
 
         if ( data[ 1 ] & 0b100 ) {
-            return m_nonresponsive;
+            return m_nonresponsive_device_error;
         } // if
 
         return Sample{ ( static_cast<Sample::Value>( data[ 1 ] & 0b11 )
@@ -322,7 +337,7 @@ class Driver : public Device {
      * \brief The error code to return when getting a sample fails due to the MCP3008
      *        being nonresponsive.
      */
-    Error_Code m_nonresponsive{};
+    Error_Code m_nonresponsive_device_error{};
 };
 
 /**

--- a/test/unit/picolibrary/microchip/mcp3008/driver/main.cc
+++ b/test/unit/picolibrary/microchip/mcp3008/driver/main.cc
@@ -59,6 +59,22 @@ using Driver =
 } // namespace
 
 /**
+ * \brief Verify picolibrary::Microchip::MCP3008::Driver::Driver( Controller,
+ *        Controller::Configuration, Device_Selector, picolibrary::Error_Code ) works
+ *        properly.
+ */
+TEST( constructor, worksProperly )
+{
+    auto controller = Mock_Controller{};
+
+    auto const nonresponsive_device_error = random<Mock_Error>();
+
+    auto const mcp3008 = Driver{ controller, {}, {}, nonresponsive_device_error };
+
+    EXPECT_EQ( mcp3008.nonresponsive_device_error(), nonresponsive_device_error );
+}
+
+/**
  * \brief Verify picolibrary::Microchip::MCP3008::Driver::sample() properly handles a
  *        configuration error.
  */
@@ -132,15 +148,15 @@ TEST( sample, dataExchangeError )
 
 /**
  * \brief Verify picolibrary::Microchip::MCP3008::Driver::sample() properly handles a
- *        nonresponsive device.
+ *        nonresponsive device error.
  */
-TEST( sample, nonresponsiveDevice )
+TEST( sample, nonresponsiveDeviceError )
 {
     auto controller = Mock_Controller{};
 
-    auto const nonresponsive = random<Mock_Error>();
+    auto const nonresponsive_device_error = random<Mock_Error>();
 
-    auto mcp3008 = Driver{ controller, {}, {}, nonresponsive };
+    auto mcp3008 = Driver{ controller, {}, {}, nonresponsive_device_error };
 
     auto device_selector        = Mock_Device_Selector{};
     auto device_selector_handle = device_selector.handle();
@@ -164,7 +180,7 @@ TEST( sample, nonresponsiveDevice )
     auto const result = mcp3008.sample( {} );
 
     EXPECT_TRUE( result.is_error() );
-    EXPECT_EQ( result.error(), nonresponsive );
+    EXPECT_EQ( result.error(), nonresponsive_device_error );
 }
 
 /**

--- a/test/unit/picolibrary/microchip/mcp3008/driver/main.cc
+++ b/test/unit/picolibrary/microchip/mcp3008/driver/main.cc
@@ -59,7 +59,7 @@ using Driver =
 } // namespace
 
 /**
- * \brief Verify picolibrary::Microchip::MCP3008::Driver::Driver( Controller,
+ * \brief Verify picolibrary::Microchip::MCP3008::Driver::Driver( Controller &,
  *        Controller::Configuration, Device_Selector, picolibrary::Error_Code ) works
  *        properly.
  */


### PR DESCRIPTION
Resolves #737 (Add Microchip MCP3008 driver nonresponsive device error
getter).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
