### PR TITLE
Fix WIZnet W5500 send TCP keepalive packet command spelling

### DIFF
--- a/include/picolibrary/wiznet/w5500.h
+++ b/include/picolibrary/wiznet/w5500.h
@@ -1764,7 +1764,7 @@ enum class Command : std::uint8_t {
     CLOSE                        = 0x10, ///< Close.
     SEND                         = 0x20, ///< Send.
     SEND_UDP_DATAGRAM_MANUAL_MAC = 0x21, ///< Send a UDP datagram using a manually configured destination MAC address instead of one obtained by ARP.
-    SEND_TCP_KEEP_ALIVE_PACKET   = 0x22, ///< Send a TCP keep-alive packet.
+    SEND_TCP_KEEPALIVE_PACKET    = 0x22, ///< Send a TCP keepalive packet.
     RECEIVE                      = 0x40, ///< Receive.
 };
 


### PR DESCRIPTION
Resolves #742 (Fix WIZnet W5500 send TCP keepalive packet command
spelling).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
