### PR TITLE
Add pseudo-random WIZnet W5500 no delayed ACK configuration generation

### DIFF
--- a/include/picolibrary/testing/unit/wiznet/w5500.h
+++ b/include/picolibrary/testing/unit/wiznet/w5500.h
@@ -183,6 +183,18 @@ inline auto random<WIZnet::W5500::Buffer_Size>()
         WIZnet::W5500::Buffer_Size::_0_KIB, WIZnet::W5500::Buffer_Size::_16_KIB );
 }
 
+/**
+ * \brief Generate a pseudo-random WIZnet W5500 no delayed ACK configuration.
+ *
+ * \return A pseudo-randomly generated WIZnet W5500 no delayed ACK configuration.
+ */
+template<>
+inline auto random<WIZnet::W5500::No_Delayed_ACK>()
+{
+    return random<bool>() ? WIZnet::W5500::No_Delayed_ACK::DISABLED
+                          : WIZnet::W5500::No_Delayed_ACK::ENABLED;
+}
+
 } // namespace picolibrary::Testing::Unit
 
 /**


### PR DESCRIPTION
Resolves #748 (Add pseudo-random WIZnet W5500 no delayed ACK
configuration generation).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
