### PR TITLE
Fix WIZnet W5500 network stack move constructor and move assignment operator

### DIFF
--- a/include/picolibrary/wiznet/w5500/network_stack.h
+++ b/include/picolibrary/wiznet/w5500/network_stack.h
@@ -70,7 +70,8 @@ class Network_Stack {
      */
     constexpr Network_Stack( Network_Stack && source ) noexcept :
         m_driver{ source.m_driver },
-        m_nonresponsive_device_error{ source.m_nonresponsive_device_error }
+        m_nonresponsive_device_error{ source.m_nonresponsive_device_error },
+        m_tcp_ephemeral_port_allocation_enabled{ source.m_tcp_ephemeral_port_allocation_enabled }
     {
         source.m_driver = nullptr;
     }
@@ -92,6 +93,7 @@ class Network_Stack {
         if ( &expression != this ) {
             m_driver                     = expression.m_driver;
             m_nonresponsive_device_error = expression.m_nonresponsive_device_error;
+            m_tcp_ephemeral_port_allocation_enabled = expression.m_tcp_ephemeral_port_allocation_enabled;
 
             expression.m_driver = nullptr;
         } // if


### PR DESCRIPTION
Resolves #750 (Fix WIZnet W5500 network stack move constructor and move
assignment operator).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
