### PR TITLE
Explicitly delete WIZnet W5500 IP network stack copy constructor and copy assignment operator

### DIFF
--- a/include/picolibrary/wiznet/w5500/network_stack.h
+++ b/include/picolibrary/wiznet/w5500/network_stack.h
@@ -76,6 +76,8 @@ class Network_Stack {
         source.m_driver = nullptr;
     }
 
+    Network_Stack( Network_Stack const & ) = delete;
+
     /**
      * \brief Destructor.
      */
@@ -100,6 +102,8 @@ class Network_Stack {
 
         return *this;
     }
+
+    auto operator=( Network_Stack const & ) = delete;
 
     /**
      * \brief Get the error code that is returned when an operation fails due to the W5500


### PR DESCRIPTION
Resolves #741 (Explicitly delete WIZnet W5500 IP network stack copy
constructor and copy assignment operator).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
