### PR TITLE
Fix WIZnet W5500 IP network stack nonresponsive device error getter documentation

### DIFF
--- a/include/picolibrary/wiznet/w5500/network_stack.h
+++ b/include/picolibrary/wiznet/w5500/network_stack.h
@@ -108,6 +108,9 @@ class Network_Stack {
     /**
      * \brief Get the error code that is returned when an operation fails due to the W5500
      *        being nonresponsive.
+     *
+     * \return The error code that is returned when an operation fails due to the W5500
+     *         being nonresponsive.
      */
     constexpr auto const & nonresponsive_device_error() const noexcept
     {


### PR DESCRIPTION
Resolves #760 (Fix WIZnet W5500 IP network stack nonresponsive device
error getter documentation).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
