### PR TITLE
Add WIZnet W5500 TCP over IP unit testing skeleton

### DIFF
--- a/test/unit/picolibrary/wiznet/w5500/ip/tcp/CMakeLists.txt
+++ b/test/unit/picolibrary/wiznet/w5500/ip/tcp/CMakeLists.txt
@@ -13,11 +13,5 @@
 # KIND, either express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-# File: test/unit/picolibrary/wiznet/w5500/ip/CMakeLists.txt
-# Description: picolibrary::WIZnet::W5500::IP unit tests CMake rules.
-
-# build the picolibrary::WIZnet::W5500::IP::Network_Stack unit tests
-add_subdirectory( network_stack )
-
-# build the picolibrary::WIZnet::W5500::IP::TCP unit tests
-add_subdirectory( tcp )
+# File: test/unit/picolibrary/wiznet/w5500/ip/tcp/CMakeLists.txt
+# Description: picolibrary::WIZnet::W5500::IP::TCP unit tests CMake rules.


### PR DESCRIPTION
Resolves #773 (Add WIZnet W5500 TCP over IP unit testing skeleton).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
