### PR TITLE
Add WIZnet W5500 IP network stack TCP ephemeral port allocation information getters

### DIFF
--- a/include/picolibrary/wiznet/w5500/ip/network_stack.h
+++ b/include/picolibrary/wiznet/w5500/ip/network_stack.h
@@ -71,7 +71,9 @@ class Network_Stack {
     constexpr Network_Stack( Network_Stack && source ) noexcept :
         m_driver{ source.m_driver },
         m_nonresponsive_device_error{ source.m_nonresponsive_device_error },
-        m_tcp_ephemeral_port_allocation_enabled{ source.m_tcp_ephemeral_port_allocation_enabled }
+        m_tcp_ephemeral_port_allocation_enabled{ source.m_tcp_ephemeral_port_allocation_enabled },
+        m_tcp_ephemeral_port_min{ source.m_tcp_ephemeral_port_min },
+        m_tcp_ephemeral_port_max{ source.m_tcp_ephemeral_port_max }
     {
         source.m_driver = nullptr;
     }
@@ -96,6 +98,8 @@ class Network_Stack {
             m_driver                     = expression.m_driver;
             m_nonresponsive_device_error = expression.m_nonresponsive_device_error;
             m_tcp_ephemeral_port_allocation_enabled = expression.m_tcp_ephemeral_port_allocation_enabled;
+            m_tcp_ephemeral_port_min                = expression.m_tcp_ephemeral_port_min;
+            m_tcp_ephemeral_port_max                = expression.m_tcp_ephemeral_port_max;
 
             expression.m_driver = nullptr;
         } // if
@@ -734,8 +738,41 @@ class Network_Stack {
         } // if
 
         m_tcp_ephemeral_port_allocation_enabled = true;
+        m_tcp_ephemeral_port_min                = min;
+        m_tcp_ephemeral_port_max                = max;
 
         return {};
+    }
+
+    /**
+     * \brief Check if TCP ephemeral port allocation is enabled.
+     *
+     * \return true if TCP ephemeral port allocation is enabled.
+     * \return false if TCP ephemeral port allocation is not enabled.
+     */
+    auto tcp_ephemeral_port_allocation_enabled() const noexcept
+    {
+        return m_tcp_ephemeral_port_allocation_enabled;
+    }
+
+    /**
+     * \brief Get the lower bound of the TCP ephemeral port range.
+     *
+     * \return The lower bound of the TCP ephemeral port range.
+     */
+    auto tcp_ephemeral_port_min() const noexcept
+    {
+        return m_tcp_ephemeral_port_min;
+    }
+
+    /**
+     * \brief Get the upper bound of the TCP ephemeral port range.
+     *
+     * \return The upper bound of the TCP ephemeral port range.
+     */
+    auto tcp_ephemeral_port_max() const noexcept
+    {
+        return m_tcp_ephemeral_port_max;
     }
 
   private:
@@ -754,6 +791,16 @@ class Network_Stack {
      * \brief The TCP ephemeral port allocation enable state.
      */
     bool m_tcp_ephemeral_port_allocation_enabled{};
+
+    /**
+     * \brief The lower bound of the TCP ephemeral port range.
+     */
+    ::picolibrary::IP::TCP::Port m_tcp_ephemeral_port_min{};
+
+    /**
+     * \brief The upper bound of the TCP ephemeral port range.
+     */
+    ::picolibrary::IP::TCP::Port m_tcp_ephemeral_port_max{};
 };
 
 } // namespace picolibrary::WIZnet::W5500::IP

--- a/test/unit/picolibrary/wiznet/w5500/ip/network_stack/main.cc
+++ b/test/unit/picolibrary/wiznet/w5500/ip/network_stack/main.cc
@@ -94,6 +94,7 @@ TEST( constructor, worksProperly )
     auto const network_stack = Network_Stack{ driver, nonresponsive_device_error };
 
     EXPECT_EQ( network_stack.nonresponsive_device_error(), nonresponsive_device_error );
+    EXPECT_FALSE( network_stack.tcp_ephemeral_port_allocation_enabled() );
 }
 
 /**
@@ -1878,6 +1879,10 @@ TEST( enableTCPEphemeralPortAllocation, worksProperly )
     auto const max = random<TCP_Port>( min );
 
     EXPECT_FALSE( network_stack.enable_tcp_ephemeral_port_allocation( min, max ).is_error() );
+
+    EXPECT_TRUE( network_stack.tcp_ephemeral_port_allocation_enabled() );
+    EXPECT_EQ( network_stack.tcp_ephemeral_port_min(), min );
+    EXPECT_EQ( network_stack.tcp_ephemeral_port_max(), max );
 }
 
 /**


### PR DESCRIPTION
Resolves #787 (Add WIZnet W5500 IP network stack TCP ephemeral port
allocation information getters).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
