### PR TITLE
Fix WIZnet W5500 IP network stack socket buffers configuration socket ID calculations

### DIFF
--- a/include/picolibrary/wiznet/w5500/ip/network_stack.h
+++ b/include/picolibrary/wiznet/w5500/ip/network_stack.h
@@ -372,7 +372,7 @@ class Network_Stack {
     {
         // #lizard forgives the length
 
-        auto available_sockets = std::uint8_t{};
+        auto available_sockets = std::uint_fast8_t{};
 
         switch ( buffer_size ) {
             case Buffer_Size::_2_KIB: available_sockets = 16 / 2; break;
@@ -382,10 +382,12 @@ class Network_Stack {
             default: return Generic_Error::INVALID_ARGUMENT;
         } // switch
 
-        for ( auto socket = std::uint8_t{}; socket < available_sockets; ++socket ) {
+        for ( auto socket = std::uint_fast8_t{}; socket < available_sockets; ++socket ) {
+            auto const socket_id = static_cast<Socket_ID>( socket << Control_Byte::Bit::SOCKET );
+
             {
                 auto result = m_driver->write_sn_rxbuf_size(
-                    static_cast<Socket_ID>( socket ), static_cast<std::uint8_t>( buffer_size ) );
+                    socket_id, static_cast<std::uint8_t>( buffer_size ) );
                 if ( result.is_error() ) {
                     return result.error();
                 } // if
@@ -393,7 +395,7 @@ class Network_Stack {
 
             {
                 auto result = m_driver->write_sn_txbuf_size(
-                    static_cast<Socket_ID>( socket ), static_cast<std::uint8_t>( buffer_size ) );
+                    socket_id, static_cast<std::uint8_t>( buffer_size ) );
                 if ( result.is_error() ) {
                     return result.error();
                 } // if
@@ -401,10 +403,11 @@ class Network_Stack {
         } // for
 
         for ( auto socket = available_sockets; socket < SOCKETS; ++socket ) {
+            auto const socket_id = static_cast<Socket_ID>( socket << Control_Byte::Bit::SOCKET );
+
             {
                 auto result = m_driver->write_sn_rxbuf_size(
-                    static_cast<Socket_ID>( socket ),
-                    static_cast<std::uint8_t>( Buffer_Size::_0_KIB ) );
+                    socket_id, static_cast<std::uint8_t>( Buffer_Size::_0_KIB ) );
                 if ( result.is_error() ) {
                     return result.error();
                 } // if
@@ -412,8 +415,7 @@ class Network_Stack {
 
             {
                 auto result = m_driver->write_sn_txbuf_size(
-                    static_cast<Socket_ID>( socket ),
-                    static_cast<std::uint8_t>( Buffer_Size::_0_KIB ) );
+                    socket_id, static_cast<std::uint8_t>( Buffer_Size::_0_KIB ) );
                 if ( result.is_error() ) {
                     return result.error();
                 } // if

--- a/test/unit/picolibrary/wiznet/w5500/ip/network_stack/main.cc
+++ b/test/unit/picolibrary/wiznet/w5500/ip/network_stack/main.cc
@@ -921,8 +921,8 @@ TEST( configureSocketBuffers, writeSNTXBUFSIZEErrorUnusedSocket )
 TEST( configureSocketBuffers, worksProperly )
 {
     struct {
-        Buffer_Size  buffer_size;
-        std::uint8_t available_sockets;
+        Buffer_Size       buffer_size;
+        std::uint_fast8_t available_sockets;
     } const configurations[]{
         { Buffer_Size::_2_KIB, 8 },
         { Buffer_Size::_4_KIB, 4 },
@@ -937,31 +937,40 @@ TEST( configureSocketBuffers, worksProperly )
 
         auto network_stack = Network_Stack{ driver, random<Mock_Error>() };
 
-        for ( auto socket = std::uint8_t{}; socket < configuration.available_sockets; ++socket ) {
+        Socket_ID const socket_id[]{
+            // clang-format off
+
+            Socket_ID::_0,
+            Socket_ID::_1,
+            Socket_ID::_2,
+            Socket_ID::_3,
+            Socket_ID::_4,
+            Socket_ID::_5,
+            Socket_ID::_6,
+            Socket_ID::_7,
+
+            // clang-format on
+        };
+
+        for ( auto socket = std::uint_fast8_t{}; socket < configuration.available_sockets; ++socket ) {
             EXPECT_CALL(
                 driver,
                 write_sn_rxbuf_size(
-                    static_cast<Socket_ID>( socket ),
-                    static_cast<std::uint8_t>( configuration.buffer_size ) ) )
+                    socket_id[ socket ], static_cast<std::uint8_t>( configuration.buffer_size ) ) )
                 .WillOnce( Return( Result<Void, Error_Code>{} ) );
             EXPECT_CALL(
                 driver,
                 write_sn_txbuf_size(
-                    static_cast<Socket_ID>( socket ),
-                    static_cast<std::uint8_t>( configuration.buffer_size ) ) )
+                    socket_id[ socket ], static_cast<std::uint8_t>( configuration.buffer_size ) ) )
                 .WillOnce( Return( Result<Void, Error_Code>{} ) );
         } // for
 
         for ( auto socket = configuration.available_sockets; socket < 8; ++socket ) {
             EXPECT_CALL(
-                driver,
-                write_sn_rxbuf_size(
-                    static_cast<Socket_ID>( socket ), static_cast<std::uint8_t>( Buffer_Size::_0_KIB ) ) )
+                driver, write_sn_rxbuf_size( socket_id[ socket ], static_cast<std::uint8_t>( Buffer_Size::_0_KIB ) ) )
                 .WillOnce( Return( Result<Void, Error_Code>{} ) );
             EXPECT_CALL(
-                driver,
-                write_sn_txbuf_size(
-                    static_cast<Socket_ID>( socket ), static_cast<std::uint8_t>( Buffer_Size::_0_KIB ) ) )
+                driver, write_sn_txbuf_size( socket_id[ socket ], static_cast<std::uint8_t>( Buffer_Size::_0_KIB ) ) )
                 .WillOnce( Return( Result<Void, Error_Code>{} ) );
         } // for
 


### PR DESCRIPTION
Resolves #789 (Fix WIZnet W5500 IP network stack socket buffers
configuration socket ID calculations).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
