### PR TITLE
Fix mock WIZnet W5500 IP network stack IPv4 namespace ambiguity

### DIFF
--- a/include/picolibrary/testing/unit/wiznet/w5500/ip/network_stack.h
+++ b/include/picolibrary/testing/unit/wiznet/w5500/ip/network_stack.h
@@ -87,14 +87,14 @@ class Mock_Network_Stack {
     MOCK_METHOD( (Result<Void, Error_Code>), configure_mac_address, (MAC_Address const &));
     MOCK_METHOD( (Result<MAC_Address, Error_Code>), mac_address, (), ( const ) );
 
-    MOCK_METHOD( (Result<Void, Error_Code>), configure_ip_address, (IPv4::Address const &));
-    MOCK_METHOD( (Result<IPv4::Address, Error_Code>), ip_address, (), ( const ) );
+    MOCK_METHOD( (Result<Void, Error_Code>), configure_ip_address, (::picolibrary::IPv4::Address const &));
+    MOCK_METHOD( (Result<::picolibrary::IPv4::Address, Error_Code>), ip_address, (), ( const ) );
 
-    MOCK_METHOD( (Result<Void, Error_Code>), configure_gateway_ip_address, (IPv4::Address const &));
-    MOCK_METHOD( (Result<IPv4::Address, Error_Code>), gateway_ip_address, (), ( const ) );
+    MOCK_METHOD( (Result<Void, Error_Code>), configure_gateway_ip_address, (::picolibrary::IPv4::Address const &));
+    MOCK_METHOD( (Result<::picolibrary::IPv4::Address, Error_Code>), gateway_ip_address, (), ( const ) );
 
-    MOCK_METHOD( (Result<Void, Error_Code>), configure_subnet_mask, (IPv4::Address const &));
-    MOCK_METHOD( (Result<IPv4::Address, Error_Code>), subnet_mask, (), ( const ) );
+    MOCK_METHOD( (Result<Void, Error_Code>), configure_subnet_mask, (::picolibrary::IPv4::Address const &));
+    MOCK_METHOD( (Result<::picolibrary::IPv4::Address, Error_Code>), subnet_mask, (), ( const ) );
 
     MOCK_METHOD( (Result<Void, Error_Code>), configure_interrupt_assert_wait_time, ( std::uint16_t ) );
     MOCK_METHOD( (Result<std::uint16_t, Error_Code>), interrupt_assert_wait_time, (), ( const ) );


### PR DESCRIPTION
Resolves #794 (Fix mock WIZnet W5500 IP network stack IPv4 namespace
ambiguity).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
