### PR TITLE
Return mock WIZnet W5500 IP network stack nonresponsive device error by value

### DIFF
--- a/include/picolibrary/testing/unit/wiznet/w5500/ip/network_stack.h
+++ b/include/picolibrary/testing/unit/wiznet/w5500/ip/network_stack.h
@@ -59,7 +59,7 @@ class Mock_Network_Stack {
 
     auto operator=( Mock_Network_Stack const & ) = delete;
 
-    MOCK_METHOD( Error_Code const &, nonresponsive_device_error, (), ( const ) );
+    MOCK_METHOD( Error_Code, nonresponsive_device_error, (), ( const ) );
 
     MOCK_METHOD( (Result<Void, Error_Code>), ping_w5500, (), ( const ) );
 


### PR DESCRIPTION
Resolves #796 (Return mock WIZnet W5500 IP network stack nonresponsive
device error by value).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
