### PR TITLE
Revise WIZnet W5500 IP network stack specific socket allocation function return type

### DIFF
--- a/include/picolibrary/wiznet/w5500/ip/network_stack.h
+++ b/include/picolibrary/wiznet/w5500/ip/network_stack.h
@@ -911,7 +911,7 @@ class Network_Stack {
      * \return picolibrary::Generic_Error::LOGIC_ERROR if the socket is not available for
      *         allocation.
      */
-    auto allocate_socket( Socket_ID socket_id ) noexcept -> Result<Socket_ID, Error_Code>
+    auto allocate_socket( Socket_ID socket_id ) noexcept -> Result<Void, Error_Code>
     {
         auto const socket = static_cast<std::uint_fast8_t>(
             static_cast<std::uint_fast8_t>( socket_id ) >> Control_Byte::Bit::SOCKET );
@@ -922,7 +922,7 @@ class Network_Stack {
 
         m_socket_state[ socket ] = Socket_State::ALLOCATED;
 
-        return socket_id;
+        return {};
     }
 
     /**


### PR DESCRIPTION
Resolves #815 (Revise WIZnet W5500 IP network stack specific socket
allocation function return type).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
