### PR TITLE
Fix mock WIZnet W5500 IP network stack specific socket allocation function return type

### DIFF
--- a/include/picolibrary/testing/unit/wiznet/w5500/ip/network_stack.h
+++ b/include/picolibrary/testing/unit/wiznet/w5500/ip/network_stack.h
@@ -113,10 +113,7 @@ class Mock_Network_Stack {
     MOCK_METHOD( (Result<Void, Error_Code>), service, () );
 
     MOCK_METHOD( (Result<::picolibrary::WIZnet::W5500::Socket_ID, Error_Code>), allocate_socket, () );
-    MOCK_METHOD(
-        (Result<::picolibrary::WIZnet::W5500::Socket_ID, Error_Code>),
-        allocate_socket,
-        ( ::picolibrary::WIZnet::W5500::Socket_ID ) );
+    MOCK_METHOD( (Result<Void, Error_Code>), allocate_socket, ( ::picolibrary::WIZnet::W5500::Socket_ID ) );
     MOCK_METHOD( void, deallocate_socket, ( ::picolibrary::WIZnet::W5500::Socket_ID ) );
 
     MOCK_METHOD(


### PR DESCRIPTION
Resolves #820 (Fix mock WIZnet W5500 IP network stack specific socket
allocation function return type).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
