### PR TITLE
Fix missing mock WIZnet W5500 IP network stack TCP client socket construction

### DIFF
--- a/include/picolibrary/testing/unit/wiznet/w5500/ip/network_stack.h
+++ b/include/picolibrary/testing/unit/wiznet/w5500/ip/network_stack.h
@@ -31,6 +31,7 @@
 #include "picolibrary/ipv4.h"
 #include "picolibrary/mac_address.h"
 #include "picolibrary/result.h"
+#include "picolibrary/testing/unit/wiznet/w5500/ip/tcp.h"
 #include "picolibrary/void.h"
 #include "picolibrary/wiznet/w5500.h"
 
@@ -41,6 +42,12 @@ namespace picolibrary::Testing::Unit::WIZnet::W5500::IP {
  */
 class Mock_Network_Stack {
   public:
+    /**
+     * \brief The type of TCP client socket that is used to interact with the network
+     *        stack.
+     */
+    using TCP_Client = TCP::Mock_Client::Handle;
+
     /**
      * \brief Constructor.
      */
@@ -123,6 +130,9 @@ class Mock_Network_Stack {
     MOCK_METHOD( bool, tcp_ephemeral_port_allocation_enabled, (), ( const ) );
     MOCK_METHOD( ::picolibrary::IP::TCP::Port, tcp_ephemeral_port_min, (), ( const ) );
     MOCK_METHOD( ::picolibrary::IP::TCP::Port, tcp_ephemeral_port_max, (), ( const ) );
+
+    MOCK_METHOD( (Result<TCP_Client, Error_Code>), make_tcp_client, () );
+    MOCK_METHOD( (Result<TCP_Client, Error_Code>), make_tcp_client, ( ::picolibrary::WIZnet::W5500::Socket_ID ) );
 };
 
 } // namespace picolibrary::Testing::Unit::WIZnet::W5500::IP


### PR DESCRIPTION
Resolves #821 (Fix missing mock WIZnet W5500 IP network stack TCP client
socket construction).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
