### PR TITLE
Revise WIZnet W5500 IP network stack supported sockets terminology

### DIFF
--- a/include/picolibrary/testing/unit/wiznet/w5500/ip/network_stack.h
+++ b/include/picolibrary/testing/unit/wiznet/w5500/ip/network_stack.h
@@ -78,7 +78,7 @@ class Mock_Network_Stack {
     MOCK_METHOD( (Result<std::uint8_t, Error_Code>), retry_count, (), ( const ) );
 
     MOCK_METHOD( (Result<Void, Error_Code>), configure_socket_buffers, ( ::picolibrary::WIZnet::W5500::Buffer_Size ) );
-    MOCK_METHOD( std::uint_fast8_t, available_sockets, (), ( const ) );
+    MOCK_METHOD( std::uint_fast8_t, sockets, (), ( const ) );
     MOCK_METHOD( (Result<::picolibrary::WIZnet::W5500::Buffer_Size, Error_Code>), socket_buffer_size, (), ( const ) );
 
     MOCK_METHOD( (Result<Void, Error_Code>), configure_mac_address, (MAC_Address const &));

--- a/include/picolibrary/wiznet/w5500/ip/tcp.h
+++ b/include/picolibrary/wiznet/w5500/ip/tcp.h
@@ -471,9 +471,9 @@ class Client {
 
         SN_PORT::Type used_ports[ SOCKETS ];
 
-        auto const available_sockets = m_network_stack->available_sockets();
+        auto const sockets = m_network_stack->sockets();
 
-        for ( auto socket = std::uint_fast8_t{}; socket < available_sockets; ++socket ) {
+        for ( auto socket = std::uint_fast8_t{}; socket < sockets; ++socket ) {
             auto const socket_id = static_cast<Socket_ID>( socket << Control_Byte::Bit::SOCKET );
 
             Protocol protocol;
@@ -499,8 +499,8 @@ class Client {
             used_ports[ socket ] = protocol == Protocol::TCP ? port : 0;
         } // for
 
-        auto const is_available = [ &used_ports, available_sockets ]( SN_PORT::Type port ) noexcept -> bool {
-            for ( auto socket = std::uint_fast8_t{}; socket < available_sockets; ++socket ) {
+        auto const is_available = [ &used_ports, sockets ]( SN_PORT::Type port ) noexcept -> bool {
+            for ( auto socket = std::uint_fast8_t{}; socket < sockets; ++socket ) {
                 if ( used_ports[ socket ] == port ) {
                     return false;
                 } // if

--- a/test/unit/picolibrary/wiznet/w5500/ip/network_stack/main.cc
+++ b/test/unit/picolibrary/wiznet/w5500/ip/network_stack/main.cc
@@ -94,7 +94,7 @@ TEST( constructor, worksProperly )
     auto const network_stack = Network_Stack{ driver, nonresponsive_device_error };
 
     EXPECT_EQ( network_stack.nonresponsive_device_error(), nonresponsive_device_error );
-    EXPECT_EQ( network_stack.available_sockets(), 8 );
+    EXPECT_EQ( network_stack.sockets(), 8 );
     EXPECT_FALSE( network_stack.tcp_ephemeral_port_allocation_enabled() );
 }
 
@@ -810,9 +810,9 @@ TEST( configureSocketBuffers, invalidBufferSize )
 /**
  * \brief Verify picolibrary::WIZnet::W5500::IP::Network_Stack::configure_socket_buffers()
  *        properly handles an SN_RXBUF_SIZE register write error when configuring the
- *        socket buffer size of an available socket.
+ *        socket buffer size of a used socket.
  */
-TEST( configureSocketBuffers, writeSNRXBUFSIZEErrorAvailableSocket )
+TEST( configureSocketBuffers, writeSNRXBUFSIZEErrorUsedSocket )
 {
     auto driver = Mock_Driver{};
 
@@ -833,9 +833,9 @@ TEST( configureSocketBuffers, writeSNRXBUFSIZEErrorAvailableSocket )
 /**
  * \brief Verify picolibrary::WIZnet::W5500::IP::Network_Stack::configure_socket_buffers()
  *        properly handles an SN_TXBUF_SIZE register write error when configuring the
- *        socket buffer size of an available socket.
+ *        socket buffer size of a used socket.
  */
-TEST( configureSocketBuffers, writeSNTXBUFSIZEErrorAvailableSocket )
+TEST( configureSocketBuffers, writeSNTXBUFSIZEErrorUsedSocket )
 {
     auto driver = Mock_Driver{};
 
@@ -923,7 +923,7 @@ TEST( configureSocketBuffers, worksProperly )
 {
     struct {
         Buffer_Size       buffer_size;
-        std::uint_fast8_t available_sockets;
+        std::uint_fast8_t sockets;
     } const configurations[]{
         { Buffer_Size::_2_KIB, 8 },
         { Buffer_Size::_4_KIB, 4 },
@@ -953,7 +953,7 @@ TEST( configureSocketBuffers, worksProperly )
             // clang-format on
         };
 
-        for ( auto socket = std::uint_fast8_t{}; socket < configuration.available_sockets; ++socket ) {
+        for ( auto socket = std::uint_fast8_t{}; socket < configuration.sockets; ++socket ) {
             EXPECT_CALL(
                 driver,
                 write_sn_rxbuf_size(
@@ -966,7 +966,7 @@ TEST( configureSocketBuffers, worksProperly )
                 .WillOnce( Return( Result<Void, Error_Code>{} ) );
         } // for
 
-        for ( auto socket = configuration.available_sockets; socket < 8; ++socket ) {
+        for ( auto socket = configuration.sockets; socket < 8; ++socket ) {
             EXPECT_CALL(
                 driver, write_sn_rxbuf_size( socket_id[ socket ], static_cast<std::uint8_t>( Buffer_Size::_0_KIB ) ) )
                 .WillOnce( Return( Result<Void, Error_Code>{} ) );
@@ -977,7 +977,7 @@ TEST( configureSocketBuffers, worksProperly )
 
         EXPECT_FALSE( network_stack.configure_socket_buffers( configuration.buffer_size ).is_error() );
 
-        EXPECT_EQ( network_stack.available_sockets(), configuration.available_sockets );
+        EXPECT_EQ( network_stack.sockets(), configuration.sockets );
     } // for
 }
 

--- a/test/unit/picolibrary/wiznet/w5500/ip/tcp/client/main.cc
+++ b/test/unit/picolibrary/wiznet/w5500/ip/tcp/client/main.cc
@@ -1104,7 +1104,7 @@ TEST( bind, snmrReadError )
 
     auto const error = random<Mock_Error>();
 
-    EXPECT_CALL( network_stack, available_sockets() ).WillOnce( Return( random<std::uint_fast8_t>( 1, 8 ) ) );
+    EXPECT_CALL( network_stack, sockets() ).WillOnce( Return( random<std::uint_fast8_t>( 1, 8 ) ) );
     EXPECT_CALL( driver, read_sn_mr( _ ) ).WillOnce( Return( error ) );
 
     auto const result = client.bind( random<Port>( 1 ) );
@@ -1130,7 +1130,7 @@ TEST( bind, snportReadError )
 
     auto const error = random<Mock_Error>();
 
-    EXPECT_CALL( network_stack, available_sockets() ).WillOnce( Return( random<std::uint_fast8_t>( 1, 8 ) ) );
+    EXPECT_CALL( network_stack, sockets() ).WillOnce( Return( random<std::uint_fast8_t>( 1, 8 ) ) );
     EXPECT_CALL( driver, read_sn_mr( _ ) ).WillRepeatedly( Return( random<std::uint8_t>() ) );
     EXPECT_CALL( driver, read_sn_port( _ ) ).WillOnce( Return( error ) );
 
@@ -1158,7 +1158,7 @@ TEST( bind, ephemeralPortsExhausted )
     auto const ephemeral_port = random<Port>( 1 );
 
     EXPECT_CALL( network_stack, tcp_ephemeral_port_allocation_enabled() ).WillOnce( Return( true ) );
-    EXPECT_CALL( network_stack, available_sockets() ).WillOnce( Return( random<std::uint_fast8_t>( 1, 8 ) ) );
+    EXPECT_CALL( network_stack, sockets() ).WillOnce( Return( random<std::uint_fast8_t>( 1, 8 ) ) );
     EXPECT_CALL( driver, read_sn_mr( _ ) )
         .WillRepeatedly( Return( static_cast<std::uint8_t>(
             ( random<std::uint8_t>() & 0b1'1'1'1'0000 ) | 0b0001 ) ) );
@@ -1189,7 +1189,7 @@ TEST( bind, endpointInUse )
 
     auto const port = random<Port>( 1 );
 
-    EXPECT_CALL( network_stack, available_sockets() ).WillOnce( Return( random<std::uint_fast8_t>( 1, 8 ) ) );
+    EXPECT_CALL( network_stack, sockets() ).WillOnce( Return( random<std::uint_fast8_t>( 1, 8 ) ) );
     EXPECT_CALL( driver, read_sn_mr( _ ) )
         .WillRepeatedly( Return( static_cast<std::uint8_t>(
             ( random<std::uint8_t>() & 0b1'1'1'1'0000 ) | 0b0001 ) ) );
@@ -1218,7 +1218,7 @@ TEST( bind, snportWriteError )
 
     auto const error = random<Mock_Error>();
 
-    EXPECT_CALL( network_stack, available_sockets() ).WillOnce( Return( random<std::uint_fast8_t>( 1, 8 ) ) );
+    EXPECT_CALL( network_stack, sockets() ).WillOnce( Return( random<std::uint_fast8_t>( 1, 8 ) ) );
     EXPECT_CALL( driver, read_sn_mr( _ ) ).WillRepeatedly( Return( random<std::uint8_t>() ) );
     EXPECT_CALL( driver, read_sn_port( _ ) ).WillRepeatedly( Return( std::uint16_t{ 0 } ) );
     EXPECT_CALL( driver, write_sn_port( _, _ ) ).WillOnce( Return( error ) );
@@ -1246,7 +1246,7 @@ TEST( bind, sncrWriteError )
 
     auto const error = random<Mock_Error>();
 
-    EXPECT_CALL( network_stack, available_sockets() ).WillOnce( Return( random<std::uint_fast8_t>( 1, 8 ) ) );
+    EXPECT_CALL( network_stack, sockets() ).WillOnce( Return( random<std::uint_fast8_t>( 1, 8 ) ) );
     EXPECT_CALL( driver, read_sn_mr( _ ) ).WillRepeatedly( Return( random<std::uint8_t>() ) );
     EXPECT_CALL( driver, read_sn_port( _ ) ).WillRepeatedly( Return( std::uint16_t{ 0 } ) );
     EXPECT_CALL( driver, write_sn_port( _, _ ) ).WillOnce( Return( Result<Void, Error_Code>{} ) );
@@ -1275,7 +1275,7 @@ TEST( bind, sncrReadError )
 
     auto const error = random<Mock_Error>();
 
-    EXPECT_CALL( network_stack, available_sockets() ).WillOnce( Return( random<std::uint_fast8_t>( 1, 8 ) ) );
+    EXPECT_CALL( network_stack, sockets() ).WillOnce( Return( random<std::uint_fast8_t>( 1, 8 ) ) );
     EXPECT_CALL( driver, read_sn_mr( _ ) ).WillRepeatedly( Return( random<std::uint8_t>() ) );
     EXPECT_CALL( driver, read_sn_port( _ ) ).WillRepeatedly( Return( std::uint16_t{ 0 } ) );
     EXPECT_CALL( driver, write_sn_port( _, _ ) ).WillOnce( Return( Result<Void, Error_Code>{} ) );
@@ -1305,7 +1305,7 @@ TEST( bind, snsrReadError )
 
     auto const error = random<Mock_Error>();
 
-    EXPECT_CALL( network_stack, available_sockets() ).WillOnce( Return( random<std::uint_fast8_t>( 1, 8 ) ) );
+    EXPECT_CALL( network_stack, sockets() ).WillOnce( Return( random<std::uint_fast8_t>( 1, 8 ) ) );
     EXPECT_CALL( driver, read_sn_mr( _ ) ).WillRepeatedly( Return( random<std::uint8_t>() ) );
     EXPECT_CALL( driver, read_sn_port( _ ) ).WillRepeatedly( Return( std::uint16_t{ 0 } ) );
     EXPECT_CALL( driver, write_sn_port( _, _ ) ).WillOnce( Return( Result<Void, Error_Code>{} ) );
@@ -1348,7 +1348,7 @@ TEST( bind, invalidSNSRValue )
 
         auto const error = random<Mock_Error>();
 
-        EXPECT_CALL( network_stack, available_sockets() ).WillOnce( Return( random<std::uint_fast8_t>( 1, 8 ) ) );
+        EXPECT_CALL( network_stack, sockets() ).WillOnce( Return( random<std::uint_fast8_t>( 1, 8 ) ) );
         EXPECT_CALL( driver, read_sn_mr( _ ) ).WillRepeatedly( Return( random<std::uint8_t>() ) );
         EXPECT_CALL( driver, read_sn_port( _ ) ).WillRepeatedly( Return( uint16_t{ 0 } ) );
         EXPECT_CALL( driver, write_sn_port( _, _ ) ).WillOnce( Return( Result<Void, Error_Code>{} ) );
@@ -1391,14 +1391,14 @@ TEST( bind, worksProperly )
 
         auto client = Client{ driver, socket_id, network_stack };
 
-        auto const available_sockets  = random<std::uint_fast8_t>( 1, 8 );
+        auto const sockets            = random<std::uint_fast8_t>( 1, 8 );
         auto const ephemeral_port_min = random<Port>( 1 );
         auto const ephemeral_port_max = random<Port>( ephemeral_port_min );
         auto const reserved_ephemeral_port = random<Port>( ephemeral_port_min, ephemeral_port_max );
 
         EXPECT_CALL( network_stack, tcp_ephemeral_port_allocation_enabled() ).WillOnce( Return( true ) );
-        EXPECT_CALL( network_stack, available_sockets() ).WillOnce( Return( available_sockets ) );
-        for ( auto socket = std::uint_fast8_t{}; socket < available_sockets; ++socket ) {
+        EXPECT_CALL( network_stack, sockets() ).WillOnce( Return( sockets ) );
+        for ( auto socket = std::uint_fast8_t{}; socket < sockets; ++socket ) {
             auto const sn_mr   = random<std::uint8_t>();
             auto const sn_port = generate_sn_port( sn_mr, reserved_ephemeral_port );
 
@@ -1438,14 +1438,14 @@ TEST( bind, worksProperly )
 
         auto client = Client{ driver, socket_id, network_stack };
 
-        auto const available_sockets  = random<std::uint_fast8_t>( 1, 8 );
+        auto const sockets            = random<std::uint_fast8_t>( 1, 8 );
         auto const ephemeral_port_min = random<Port>( 1 );
         auto const ephemeral_port_max = random<Port>( ephemeral_port_min );
         auto const reserved_ephemeral_port = random<Port>( ephemeral_port_min, ephemeral_port_max );
 
         EXPECT_CALL( network_stack, tcp_ephemeral_port_allocation_enabled() ).WillOnce( Return( true ) );
-        EXPECT_CALL( network_stack, available_sockets() ).WillOnce( Return( available_sockets ) );
-        for ( auto socket = std::uint_fast8_t{}; socket < available_sockets; ++socket ) {
+        EXPECT_CALL( network_stack, sockets() ).WillOnce( Return( sockets ) );
+        for ( auto socket = std::uint_fast8_t{}; socket < sockets; ++socket ) {
             auto const sn_mr   = random<std::uint8_t>();
             auto const sn_port = generate_sn_port( sn_mr, reserved_ephemeral_port );
 
@@ -1485,11 +1485,11 @@ TEST( bind, worksProperly )
 
         auto client = Client{ driver, socket_id, network_stack };
 
-        auto const port              = random<Port>( 1 );
-        auto const available_sockets = random<std::uint_fast8_t>( 1, 8 );
+        auto const port    = random<Port>( 1 );
+        auto const sockets = random<std::uint_fast8_t>( 1, 8 );
 
-        EXPECT_CALL( network_stack, available_sockets() ).WillOnce( Return( available_sockets ) );
-        for ( auto socket = std::uint_fast8_t{}; socket < available_sockets; ++socket ) {
+        EXPECT_CALL( network_stack, sockets() ).WillOnce( Return( sockets ) );
+        for ( auto socket = std::uint_fast8_t{}; socket < sockets; ++socket ) {
             auto const sn_mr   = random<std::uint8_t>();
             auto const sn_port = generate_sn_port( sn_mr, port );
 
@@ -1522,15 +1522,15 @@ TEST( bind, worksProperly )
         auto client = Client{ driver, socket_id, network_stack };
 
         auto const address            = random<Address>( 1 );
-        auto const available_sockets  = random<std::uint_fast8_t>( 1, 8 );
+        auto const sockets            = random<std::uint_fast8_t>( 1, 8 );
         auto const ephemeral_port_min = random<Port>( 1 );
         auto const ephemeral_port_max = random<Port>( ephemeral_port_min );
         auto const reserved_ephemeral_port = random<Port>( ephemeral_port_min, ephemeral_port_max );
 
         EXPECT_CALL( driver, read_sipr() ).WillOnce( Return( address.as_byte_array() ) );
         EXPECT_CALL( network_stack, tcp_ephemeral_port_allocation_enabled() ).WillOnce( Return( true ) );
-        EXPECT_CALL( network_stack, available_sockets() ).WillOnce( Return( available_sockets ) );
-        for ( auto socket = std::uint_fast8_t{}; socket < available_sockets; ++socket ) {
+        EXPECT_CALL( network_stack, sockets() ).WillOnce( Return( sockets ) );
+        for ( auto socket = std::uint_fast8_t{}; socket < sockets; ++socket ) {
             auto const sn_mr   = random<std::uint8_t>();
             auto const sn_port = generate_sn_port( sn_mr, reserved_ephemeral_port );
 
@@ -1570,13 +1570,13 @@ TEST( bind, worksProperly )
 
         auto client = Client{ driver, socket_id, network_stack };
 
-        auto const address           = random<Address>( 1 );
-        auto const port              = random<Port>( 1 );
-        auto const available_sockets = random<std::uint_fast8_t>( 1, 8 );
+        auto const address = random<Address>( 1 );
+        auto const port    = random<Port>( 1 );
+        auto const sockets = random<std::uint_fast8_t>( 1, 8 );
 
         EXPECT_CALL( driver, read_sipr() ).WillOnce( Return( address.as_byte_array() ) );
-        EXPECT_CALL( network_stack, available_sockets() ).WillOnce( Return( available_sockets ) );
-        for ( auto socket = std::uint_fast8_t{}; socket < available_sockets; ++socket ) {
+        EXPECT_CALL( network_stack, sockets() ).WillOnce( Return( sockets ) );
+        for ( auto socket = std::uint_fast8_t{}; socket < sockets; ++socket ) {
             auto const sn_mr   = random<std::uint8_t>();
             auto const sn_port = generate_sn_port( sn_mr, port );
 


### PR DESCRIPTION
Resolves #870 (Revise WIZnet W5500 IP network stack supported sockets
terminology).

Change "available sockets" to "supported sockets" to differentiate
between the number of sockets the network stack has been configured to
support and sockets being available for allocation.

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
