### PR TITLE
Fix WIZnet W5500 IP network stack specific socket allocation function documentation

### DIFF
--- a/include/picolibrary/wiznet/w5500/ip/network_stack.h
+++ b/include/picolibrary/wiznet/w5500/ip/network_stack.h
@@ -907,7 +907,7 @@ class Network_Stack {
      *
      * \param[in] socket_id The socket ID of the socket to allocate.
      *
-     * \return socket_id if the socket was successfully allocated.
+     * \return Nothing if the socket was successfully allocated.
      * \return picolibrary::Generic_Error::LOGIC_ERROR if the socket is not available.
      */
     auto allocate_socket( Socket_ID socket_id ) noexcept -> Result<Void, Error_Code>


### PR DESCRIPTION
Resolves #869 (Fix WIZnet W5500 IP network stack specific socket
allocation function documentation).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
