### PR TITLE
Allow precondition and postcondition checks to be performed in potentially constexpr contexts

### DIFF
--- a/include/picolibrary/postcondition.h
+++ b/include/picolibrary/postcondition.h
@@ -36,7 +36,7 @@ namespace picolibrary {
  * \param[in] error The fatal error that occurs if the guarantee is not met.
  */
 template<typename Error>
-void ensure( bool guarantee, Error error ) noexcept
+constexpr void ensure( bool guarantee, Error error ) noexcept
 {
     if ( not guarantee ) {
         trap_fatal_error( error );

--- a/include/picolibrary/precondition.h
+++ b/include/picolibrary/precondition.h
@@ -36,7 +36,7 @@ namespace picolibrary {
  * \param[in] error The fatal error that occurs if the expectation is not met.
  */
 template<typename Error>
-void expect( bool expectation, Error error ) noexcept
+constexpr void expect( bool expectation, Error error ) noexcept
 {
     if ( not expectation ) {
         trap_fatal_error( error );


### PR DESCRIPTION
Resolves #942 (Allow precondition and postcondition checks to be
performed in potentially constexpr contexts).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
