### PR TITLE
Fix missing header in binary integer output format specifier unit test program

### DIFF
--- a/test/unit/picolibrary/format/binary/main.cc
+++ b/test/unit/picolibrary/format/binary/main.cc
@@ -22,6 +22,7 @@
 
 #include <bitset>
 #include <cstddef>
+#include <cstdint>
 #include <cstring>
 #include <limits>
 #include <sstream>


### PR DESCRIPTION
Resolves #977 (Fix missing header in binary integer output format
specifier unit test program).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
