### PR TITLE
Fix missing GPIO active low output pin adapter template parameter documentation

### DIFF
--- a/include/picolibrary/gpio.h
+++ b/include/picolibrary/gpio.h
@@ -391,6 +391,8 @@ class Active_Low_Input_Pin : public Input_Pin {
  *            state. All output pin implementations should use this assumption. If the
  *            high pin/signal state is not the active pin/signal state, this class can be
  *            used to invert an output pin implementation's behavior.
+ *
+ * \tparam Output_Pin The type of output pin being adapted.
  */
 template<typename Output_Pin>
 class Active_Low_Output_Pin : public Output_Pin {


### PR DESCRIPTION
Resolves #1010 (Fix missing GPIO active low output pin adapter template
parameter documentation).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
