### PR TITLE
Fix fixed capacity vector reverse iterator construction implicit conversion errors

### DIFF
--- a/include/picolibrary/fixed_capacity_vector.h
+++ b/include/picolibrary/fixed_capacity_vector.h
@@ -540,7 +540,7 @@ class Fixed_Capacity_Vector {
      */
     auto rbegin() noexcept -> Reverse_Iterator
     {
-        return { end() };
+        return Reverse_Iterator{ end() };
     }
 
     /**
@@ -550,7 +550,7 @@ class Fixed_Capacity_Vector {
      */
     auto rbegin() const noexcept -> Const_Reverse_Iterator
     {
-        return { end() };
+        return Const_Reverse_Iterator{ end() };
     }
 
     /**
@@ -560,7 +560,7 @@ class Fixed_Capacity_Vector {
      */
     auto crbegin() const noexcept -> Const_Reverse_Iterator
     {
-        return { cend() };
+        return Const_Reverse_Iterator{ cend() };
     }
 
     /**
@@ -575,7 +575,7 @@ class Fixed_Capacity_Vector {
      */
     auto rend() noexcept -> Reverse_Iterator
     {
-        return { begin() };
+        return Reverse_Iterator{ begin() };
     }
 
     /**
@@ -590,7 +590,7 @@ class Fixed_Capacity_Vector {
      */
     auto rend() const noexcept -> Const_Reverse_Iterator
     {
-        return { begin() };
+        return Const_Reverse_Iterator{ begin() };
     }
 
     /**
@@ -605,7 +605,7 @@ class Fixed_Capacity_Vector {
      */
     auto crend() const noexcept -> Const_Reverse_Iterator
     {
-        return { cbegin() };
+        return Const_Reverse_Iterator{ cbegin() };
     }
 
     /**


### PR DESCRIPTION
Resolves #1040 (Fix fixed capacity vector reverse iterator construction
implicit conversion errors).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
