### PR TITLE
Fix defaulting of concept class special member functions

### DIFF
--- a/include/picolibrary/asynchronous_serial.h
+++ b/include/picolibrary/asynchronous_serial.h
@@ -45,21 +45,21 @@ class Basic_Transmitter_Concept {
     /**
      * \brief Constructor.
      */
-    Basic_Transmitter_Concept() noexcept = default;
+    Basic_Transmitter_Concept() noexcept;
 
     /**
      * \brief Constructor.
      *
      * \param[in] source The source of the move.
      */
-    Basic_Transmitter_Concept( Basic_Transmitter_Concept && source ) noexcept = default;
+    Basic_Transmitter_Concept( Basic_Transmitter_Concept && source ) noexcept;
 
     Basic_Transmitter_Concept( Basic_Transmitter_Concept const & ) = delete;
 
     /**
      * \brief Destructor.
      */
-    ~Basic_Transmitter_Concept() noexcept = default;
+    ~Basic_Transmitter_Concept() noexcept;
 
     /**
      * \brief Assignment operator.
@@ -68,8 +68,7 @@ class Basic_Transmitter_Concept {
      *
      * \return The assigned to object.
      */
-    auto operator=( Basic_Transmitter_Concept && expression ) noexcept
-        -> Basic_Transmitter_Concept & = default;
+    auto operator=( Basic_Transmitter_Concept && expression ) noexcept -> Basic_Transmitter_Concept &;
 
     auto operator=( Basic_Transmitter_Concept const & ) = delete;
 
@@ -99,21 +98,21 @@ class Transmitter_Concept {
     /**
      * \brief Constructor.
      */
-    Transmitter_Concept() noexcept = default;
+    Transmitter_Concept() noexcept;
 
     /**
      * \brief Constructor.
      *
      * \param[in] source The source of the move.
      */
-    Transmitter_Concept( Transmitter_Concept && source ) noexcept = default;
+    Transmitter_Concept( Transmitter_Concept && source ) noexcept;
 
     Transmitter_Concept( Transmitter_Concept const & ) = delete;
 
     /**
      * \brief Destructor.
      */
-    ~Transmitter_Concept() noexcept = default;
+    ~Transmitter_Concept() noexcept;
 
     /**
      * \brief Assignment operator.
@@ -122,7 +121,7 @@ class Transmitter_Concept {
      *
      * \return The assigned to object.
      */
-    auto operator=( Transmitter_Concept && expression ) noexcept -> Transmitter_Concept & = default;
+    auto operator=( Transmitter_Concept && expression ) noexcept -> Transmitter_Concept &;
 
     auto operator=( Transmitter_Concept const & ) = delete;
 

--- a/include/picolibrary/gpio.h
+++ b/include/picolibrary/gpio.h
@@ -60,21 +60,21 @@ class Input_Pin_Concept {
     /**
      * \brief Constructor.
      */
-    Input_Pin_Concept() noexcept = default;
+    Input_Pin_Concept() noexcept;
 
     /**
      * \brief Constructor.
      *
      * \param[in] source The source of the move.
      */
-    Input_Pin_Concept( Input_Pin_Concept && source ) noexcept = default;
+    Input_Pin_Concept( Input_Pin_Concept && source ) noexcept;
 
     Input_Pin_Concept( Input_Pin_Concept const & ) = delete;
 
     /**
      * \brief Destructor.
      */
-    ~Input_Pin_Concept() noexcept = default;
+    ~Input_Pin_Concept() noexcept;
 
     /**
      * \brief Assignment operator.
@@ -83,7 +83,7 @@ class Input_Pin_Concept {
      *
      * \return The assigned to object.
      */
-    auto operator=( Input_Pin_Concept && expression ) noexcept -> Input_Pin_Concept & = default;
+    auto operator=( Input_Pin_Concept && expression ) noexcept -> Input_Pin_Concept &;
 
     auto operator=( Input_Pin_Concept const & ) = delete;
 
@@ -123,21 +123,21 @@ class Internally_Pulled_Up_Input_Pin_Concept {
     /**
      * \brief Constructor.
      */
-    Internally_Pulled_Up_Input_Pin_Concept() noexcept = default;
+    Internally_Pulled_Up_Input_Pin_Concept() noexcept;
 
     /**
      * \brief Constructor.
      *
      * \param[in] source The source of the move.
      */
-    Internally_Pulled_Up_Input_Pin_Concept( Internally_Pulled_Up_Input_Pin_Concept && source ) noexcept = default;
+    Internally_Pulled_Up_Input_Pin_Concept( Internally_Pulled_Up_Input_Pin_Concept && source ) noexcept;
 
     Internally_Pulled_Up_Input_Pin_Concept( Internally_Pulled_Up_Input_Pin_Concept const & ) = delete;
 
     /**
      * \brief Destructor.
      */
-    ~Internally_Pulled_Up_Input_Pin_Concept() noexcept = default;
+    ~Internally_Pulled_Up_Input_Pin_Concept() noexcept;
 
     /**
      * \brief Assignment operator.
@@ -147,7 +147,7 @@ class Internally_Pulled_Up_Input_Pin_Concept {
      * \return The assigned to object.
      */
     auto operator=( Internally_Pulled_Up_Input_Pin_Concept && expression ) noexcept
-        -> Internally_Pulled_Up_Input_Pin_Concept & = default;
+        -> Internally_Pulled_Up_Input_Pin_Concept &;
 
     auto operator=( Internally_Pulled_Up_Input_Pin_Concept const & ) = delete;
 
@@ -216,21 +216,21 @@ class Output_Pin_Concept {
     /**
      * \brief Constructor.
      */
-    Output_Pin_Concept() noexcept = default;
+    Output_Pin_Concept() noexcept;
 
     /**
      * \brief Constructor.
      *
      * \param[in] source The source of the move.
      */
-    Output_Pin_Concept( Output_Pin_Concept && source ) noexcept = default;
+    Output_Pin_Concept( Output_Pin_Concept && source ) noexcept;
 
     Output_Pin_Concept( Output_Pin_Concept const & ) = delete;
 
     /**
      * \brief Destructor.
      */
-    ~Output_Pin_Concept() noexcept = default;
+    ~Output_Pin_Concept() noexcept;
 
     /**
      * \brief Assignment operator.
@@ -239,7 +239,7 @@ class Output_Pin_Concept {
      *
      * \return The assigned to object.
      */
-    auto operator=( Output_Pin_Concept && expression ) noexcept -> Output_Pin_Concept & = default;
+    auto operator=( Output_Pin_Concept && expression ) noexcept -> Output_Pin_Concept &;
 
     auto operator=( Output_Pin_Concept const & ) = delete;
 
@@ -280,21 +280,21 @@ class IO_Pin_Concept {
     /**
      * \brief Constructor.
      */
-    IO_Pin_Concept() noexcept = default;
+    IO_Pin_Concept() noexcept;
 
     /**
      * \brief Constructor.
      *
      * \param[in] source The source of the move.
      */
-    IO_Pin_Concept( IO_Pin_Concept && source ) noexcept = default;
+    IO_Pin_Concept( IO_Pin_Concept && source ) noexcept;
 
     IO_Pin_Concept( IO_Pin_Concept const & ) = delete;
 
     /**
      * \brief Destructor.
      */
-    ~IO_Pin_Concept() noexcept = default;
+    ~IO_Pin_Concept() noexcept;
 
     /**
      * \brief Assignment operator.
@@ -303,7 +303,7 @@ class IO_Pin_Concept {
      *
      * \return The assigned to object.
      */
-    auto operator=( IO_Pin_Concept && expression ) noexcept -> IO_Pin_Concept & = default;
+    auto operator=( IO_Pin_Concept && expression ) noexcept -> IO_Pin_Concept &;
 
     auto operator=( IO_Pin_Concept const & ) = delete;
 


### PR DESCRIPTION
Resolves #1063 (Fix defaulting of concept class special member
functions).

Concept class special member functions should not have implementations
since the classes should never be instantiated.

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
