### PR TITLE
Add output stream flushing to GPIO input pin state interactive test helper

### DIFF
--- a/include/picolibrary/testing/interactive/gpio.h
+++ b/include/picolibrary/testing/interactive/gpio.h
@@ -53,8 +53,15 @@ void state( Output_Stream & stream, Input_Pin pin, Delayer delay ) noexcept
     for ( ;; ) {
         delay();
 
-        auto const result = stream.put( pin.is_high() ? "high\n" : "low\n" );
-        expect( not result.is_error(), result.error() );
+        {
+            auto const result = stream.put( pin.is_high() ? "high\n" : "low\n" );
+            expect( not result.is_error(), result.error() );
+        }
+
+        {
+            auto const result = stream.flush();
+            expect( not result.is_error(), result.error() );
+        }
     } // for
 }
 


### PR DESCRIPTION
Resolves #1070 (Add output stream flushing to GPIO input pin state
interactive test helper).

Flushing the output stream prevents output delays.

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
