### PR TITLE
Fix unit tests CMake rules subdirectory addition ordering

### DIFF
--- a/test/unit/picolibrary/CMakeLists.txt
+++ b/test/unit/picolibrary/CMakeLists.txt
@@ -31,9 +31,6 @@ add_subdirectory( error_code )
 # build the picolibrary::Event unit tests
 add_subdirectory( event )
 
-# build the picolibrary::GPIO unit tests
-add_subdirectory( gpio )
-
 # build the picolibrary::Format unit tests
 add_subdirectory( format )
 
@@ -42,6 +39,9 @@ add_subdirectory( generic_error )
 
 # build the picolibrary::Generic_Error_Category unit tests
 add_subdirectory( generic_error_category )
+
+# build the picolibrary::GPIO unit tests
+add_subdirectory( gpio )
 
 # build the picolibrary::I2C unit tests
 add_subdirectory( i2c )


### PR DESCRIPTION
Resolves #1079 (Fix unit tests CMake rules subdirectory addition
ordering).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
