### PR TITLE
Add I2C bus control guard

### DIFF
--- a/include/picolibrary/i2c.h
+++ b/include/picolibrary/i2c.h
@@ -758,6 +758,49 @@ class Controller : public Basic_Controller {
     }
 };
 
+/**
+ * \brief RAII bus control guard.
+ *
+ * \tparam Controller The type of controller that is being used to interact with the bus.
+ */
+template<typename Controller>
+class Bus_Control_Guard {
+  public:
+    Bus_Control_Guard() = delete;
+
+    /**
+     * \brief Constructor.
+     *
+     * \param[in] controller The controller that is being used to interact with the bus.
+     */
+    Bus_Control_Guard( Controller & controller ) noexcept : m_controller{ controller }
+    {
+        m_controller.start();
+    }
+
+    Bus_Control_Guard( Bus_Control_Guard && ) = delete;
+
+    Bus_Control_Guard( Bus_Control_Guard const & ) = delete;
+
+    /**
+     * \brief Destructor.
+     */
+    ~Bus_Control_Guard() noexcept
+    {
+        m_controller.stop();
+    }
+
+    auto operator=( Bus_Control_Guard && ) = delete;
+
+    auto operator=( Bus_Control_Guard const & ) = delete;
+
+  private:
+    /**
+     * \brief The controller that is being used to interact with the bus.
+     */
+    Controller & m_controller;
+};
+
 } // namespace picolibrary::I2C
 
 #endif // PICOLIBRARY_I2C_H

--- a/test/unit/picolibrary/i2c/bus_control_guard/CMakeLists.txt
+++ b/test/unit/picolibrary/i2c/bus_control_guard/CMakeLists.txt
@@ -13,34 +13,22 @@
 # KIND, either express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-# File: test/unit/picolibrary/i2c/CMakeLists.txt
-# Description: picolibrary::I2C unit tests CMake rules.
-
-# build the picolibrary::I2C::Address_Numeric unit tests
-add_subdirectory( address_numeric )
-
-# build the picolibrary::I2C::Address_Transmitted unit tests
-add_subdirectory( address_transmitted )
+# File: test/unit/picolibrary/i2c/bus_control_guard/CMakeLists.txt
+# Description: picolibrary::I2C::Bus_Control_Guard unit tests CMake rules.
 
 # build the picolibrary::I2C::Bus_Control_Guard unit tests
-add_subdirectory( bus_control_guard )
-
-# build the picolibrary::I2C::Controller unit tests
-add_subdirectory( controller )
-
-# build the picolibrary::I2C unit tests
 if( ${PICOLIBRARY_ENABLE_UNIT_TESTING} )
     add_executable(
-        test-unit-picolibrary-i2c
+        test-unit-picolibrary-i2c-bus_control_guard
         main.cc
     )
     target_link_libraries(
-        test-unit-picolibrary-i2c
+        test-unit-picolibrary-i2c-bus_control_guard
         picolibrary
         picolibrary-testing-unit-fatal_error
     )
     add_test(
-        NAME    test-unit-picolibrary-i2c
-        COMMAND test-unit-picolibrary-i2c --gtest_color=yes
+        NAME    test-unit-picolibrary-i2c-bus_control_guard
+        COMMAND test-unit-picolibrary-i2c-bus_control_guard --gtest_color=yes
     )
 endif( ${PICOLIBRARY_ENABLE_UNIT_TESTING} )

--- a/test/unit/picolibrary/i2c/bus_control_guard/main.cc
+++ b/test/unit/picolibrary/i2c/bus_control_guard/main.cc
@@ -1,0 +1,62 @@
+/**
+ * picolibrary
+ *
+ * Copyright 2020-2022, Andrew Countryman <apcountryman@gmail.com> and the picolibrary
+ * contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/**
+ * \file
+ * \brief picolibrary::I2C::Bus_Control_Guard unit test program.
+ */
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "picolibrary/i2c.h"
+#include "picolibrary/testing/unit/i2c.h"
+
+namespace {
+
+using ::picolibrary::I2C::Bus_Control_Guard;
+using ::picolibrary::Testing::Unit::I2C::Mock_Controller;
+
+} // namespace
+
+/**
+ * \brief Verify picolibrary::I2C::Bus_Control_Guard works properly.
+ */
+TEST( busControlGuard, worksProperly )
+{
+    auto controller = Mock_Controller{};
+
+    EXPECT_CALL( controller, start() );
+
+    auto const guard = Bus_Control_Guard{ controller };
+
+    EXPECT_CALL( controller, stop() );
+}
+
+/**
+ * \brief Execute the picolibrary::I2C::Bus_Control_Guard unit tests.
+ *
+ * \param[in] argc The number of arguments to pass to testing::InitGoogleMock().
+ * \param[in] argc The array of arguments to pass to testing::InitGoogleMock().
+ *
+ * \return See Google Test's RUN_ALL_TESTS().
+ */
+int main( int argc, char * argv[] )
+{
+    ::testing::InitGoogleMock( &argc, argv );
+
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Resolves #1093 (Add I2C bus control guard).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
