### PR TITLE
Fix I2C device ping read NACK handling

### DIFF
--- a/include/picolibrary/i2c.h
+++ b/include/picolibrary/i2c.h
@@ -820,7 +820,7 @@ auto ping( Controller & controller, Address_Transmitted address, Operation opera
 
     auto const response = controller.address( address, operation );
 
-    if ( operation == Operation::READ ) {
+    if ( operation == Operation::READ and response == Response::ACK ) {
         controller.read( Response::NACK );
     } // if
 

--- a/test/unit/picolibrary/i2c/main.cc
+++ b/test/unit/picolibrary/i2c/main.cc
@@ -68,7 +68,9 @@ TEST( ping, worksProperly )
             EXPECT_CALL( controller, start() );
             EXPECT_CALL( controller, address( address, Operation::READ ) )
                 .WillOnce( Return( test_case.response ) );
-            EXPECT_CALL( controller, read( Response::NACK ) ).WillOnce( Return( random<std::uint8_t>() ) );
+            if ( test_case.response == Response::ACK ) {
+                EXPECT_CALL( controller, read( Response::NACK ) ).WillOnce( Return( random<std::uint8_t>() ) );
+            } // if
             EXPECT_CALL( controller, stop() );
 
             EXPECT_EQ( ping( controller, address, Operation::READ ), test_case.response );
@@ -129,7 +131,9 @@ TEST( ping, worksProperly )
             EXPECT_CALL( controller, start() );
             EXPECT_CALL( controller, address( address, Operation::READ ) )
                 .WillOnce( Return( test_case.response_read ) );
-            EXPECT_CALL( controller, read( Response::NACK ) ).WillOnce( Return( random<std::uint8_t>() ) );
+            if ( test_case.response_read == Response::ACK ) {
+                EXPECT_CALL( controller, read( Response::NACK ) ).WillOnce( Return( random<std::uint8_t>() ) );
+            } // if
             EXPECT_CALL( controller, stop() );
 
             EXPECT_CALL( controller, start() );


### PR DESCRIPTION
Resolves #1110 (Fix I2C device ping read NACK handling).

A read should only be performed if the device is responsive.

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
