### PR TITLE
Add I2C controller bus scan interactive test helper

### DIFF
--- a/include/picolibrary/testing/interactive/i2c.h
+++ b/include/picolibrary/testing/interactive/i2c.h
@@ -46,6 +46,8 @@ namespace picolibrary::Testing::Interactive::I2C {
 template<typename Controller>
 void scan( Output_Stream & stream, Controller controller ) noexcept
 {
+    // #lizard forgives the length
+
     controller.initializer();
 
     auto devices_found = false;

--- a/include/picolibrary/testing/interactive/i2c.h
+++ b/include/picolibrary/testing/interactive/i2c.h
@@ -23,10 +23,57 @@
 #ifndef PICOLIBRARY_TESTING_INTERACTIVE_I2C_H
 #define PICOLIBRARY_TESTING_INTERACTIVE_I2C_H
 
+#include <cstdint>
+
+#include "picolibrary/format.h"
+#include "picolibrary/i2c.h"
+#include "picolibrary/precondition.h"
+#include "picolibrary/stream.h"
+
 /**
  * \brief Inter-Integrated Circuit (I2C) interactive testing facilities.
  */
 namespace picolibrary::Testing::Interactive::I2C {
+
+/**
+ * \brief Controller bus scan interactive test helper.
+ *
+ * \tparam Controller The type of controller used to communicate with devices on the bus.
+ *
+ * \param[in] stream The output stream to write the scan results to.
+ * \param[in] controller The controller used to communicate with devices on the bus.
+ */
+template<typename Controller>
+void scan( Output_Stream & stream, Controller controller ) noexcept
+{
+    controller.initializer();
+
+    auto devices_found = false;
+
+    ::picolibrary::I2C::scan(
+        controller,
+        [ &stream, &devices_found ](
+            ::picolibrary::I2C::Address_Numeric address, auto operation, auto response ) noexcept {
+            if ( response == ::picolibrary::I2C::Response::ACK ) {
+                devices_found = true;
+
+                auto const result = stream.print(
+                    "device found: {} ({})\n",
+                    Format::Hexadecimal{ static_cast<std::uint8_t>( address.as_unsigned_integer() ) },
+                    operation == ::picolibrary::I2C::Operation::READ ? 'R' : 'W' );
+                expect( not result.is_error(), result.error() );
+            } // if
+        } );
+
+    if ( not devices_found ) {
+        auto const result = stream.put( "no devices found\n" );
+        expect( not result.is_error(), result.error() );
+    } // if
+
+    auto const result = stream.flush();
+    expect( not result.is_error(), result.error() );
+}
+
 } // namespace picolibrary::Testing::Interactive::I2C
 
 #endif // PICOLIBRARY_TESTING_INTERACTIVE_I2C_H


### PR DESCRIPTION
Resolves #1096 (Add I2C controller bus scan interactive test helper).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
