### PR TITLE
Fix I2C bus multiplexer aligner call operator constness

### DIFF
--- a/include/picolibrary/i2c.h
+++ b/include/picolibrary/i2c.h
@@ -1038,7 +1038,7 @@ class Bus_Multiplexer_Aligner {
      * \brief Align the bus's nonexistent multiplexers to enable communication with a
      *        specific device.
      */
-    constexpr void operator()() noexcept
+    constexpr void operator()() const noexcept
     {
     }
 };


### PR DESCRIPTION
Resolves #1116 (Fix I2C bus multiplexer aligner call operator
constness).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
