### PR TITLE
Fix I2C controller bus scan interactive test helper controller initialization

### DIFF
--- a/include/picolibrary/testing/interactive/i2c.h
+++ b/include/picolibrary/testing/interactive/i2c.h
@@ -48,7 +48,7 @@ void scan( Output_Stream & stream, Controller controller ) noexcept
 {
     // #lizard forgives the length
 
-    controller.initializer();
+    controller.initialize();
 
     auto devices_found = false;
 


### PR DESCRIPTION
Resolves #1118 (Fix I2C controller bus scan interactive test helper
controller initialization).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
