### PR TITLE
Add GPIO output pin based SPI device selector

### DIFF
--- a/include/picolibrary/spi.h
+++ b/include/picolibrary/spi.h
@@ -335,6 +335,33 @@ class Device_Selector_Concept {
     void deselect() noexcept;
 };
 
+/**
+ * \brief GPIO output pin based device selector.
+ *
+ * \tparam GPIO_Output_Pin The type of GPIO output pin used to select a device.
+ */
+template<typename GPIO_Output_Pin>
+class GPIO_Output_Pin_Device_Selector : public GPIO_Output_Pin {
+  public:
+    using GPIO_Output_Pin::GPIO_Output_Pin;
+
+    /**
+     * \brief Select the device.
+     */
+    void select() noexcept
+    {
+        GPIO_Output_Pin::transition_to_high();
+    }
+
+    /**
+     * \brief Deselect the device.
+     */
+    void deselect() noexcept
+    {
+        GPIO_Output_Pin::transition_to_low();
+    }
+};
+
 } // namespace picolibrary::SPI
 
 #endif // PICOLIBRARY_SPI_H

--- a/test/unit/picolibrary/spi/gpio_output_pin_device_selector/CMakeLists.txt
+++ b/test/unit/picolibrary/spi/gpio_output_pin_device_selector/CMakeLists.txt
@@ -13,11 +13,22 @@
 # KIND, either express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-# File: test/unit/picolibrary/spi/CMakeLists.txt
-# Description: picolibrary::SPI unit tests CMake rules.
-
-# build the picolibrary::SPI::Controller unit tests
-add_subdirectory( controller )
+# File: test/unit/picolibrary/spi/gpio_output_pin_device_selector/CMakeLists.txt
+# Description: picolibrary::SPI::GPIO_Output_Pin_Device_Selector unit tests CMake rules.
 
 # build the picolibrary::SPI::GPIO_Output_Pin_Device_Selector unit tests
-add_subdirectory( gpio_output_pin_device_selector )
+if( ${PICOLIBRARY_ENABLE_UNIT_TESTING} )
+    add_executable(
+        test-unit-picolibrary-spi-gpio_output_pin_device_selector
+        main.cc
+    )
+    target_link_libraries(
+        test-unit-picolibrary-spi-gpio_output_pin_device_selector
+        picolibrary
+        picolibrary-testing-unit-fatal_error
+    )
+    add_test(
+        NAME    test-unit-picolibrary-spi-gpio_output_pin_device_selector
+        COMMAND test-unit-picolibrary-spi-gpio_output_pin_device_selector --gtest_color=yes
+    )
+endif( ${PICOLIBRARY_ENABLE_UNIT_TESTING} )

--- a/test/unit/picolibrary/spi/gpio_output_pin_device_selector/main.cc
+++ b/test/unit/picolibrary/spi/gpio_output_pin_device_selector/main.cc
@@ -1,0 +1,74 @@
+/**
+ * picolibrary
+ *
+ * Copyright 2020-2022, Andrew Countryman <apcountryman@gmail.com> and the picolibrary
+ * contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/**
+ * \file
+ * \brief picolibrary::SPI::GPIO_Output_Pin_Device_Selector unit test program.
+ */
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "picolibrary/spi.h"
+#include "picolibrary/testing/unit/gpio.h"
+
+namespace {
+
+using Device_Selector =
+    ::picolibrary::SPI::GPIO_Output_Pin_Device_Selector<::picolibrary::Testing::Unit::GPIO::Mock_Output_Pin>;
+
+} // namespace
+
+/**
+ * \brief Verify picolibrary::SPI::GPIO_Output_Pin_Device_Selector::select() works
+ *        properly.
+ */
+TEST( select, worksProperly )
+{
+    auto device_selector = Device_Selector{};
+
+    EXPECT_CALL( device_selector, transition_to_high() );
+
+    device_selector.select();
+}
+
+/**
+ * \brief Verify picolibrary::SPI::GPIO_Output_Pin_Device_Selector::deselect() works
+ *        properly.
+ */
+TEST( deselect, worksProperly )
+{
+    auto device_deselector = Device_Selector{};
+
+    EXPECT_CALL( device_deselector, transition_to_low() );
+
+    device_deselector.deselect();
+}
+
+/**
+ * \brief Execute the picolibrary::SPI::GPIO_Output_Pin_Device_Selector unit tests.
+ *
+ * \param[in] argc The number of arguments to pass to testing::InitGoogleMock().
+ * \param[in] argc The array of arguments to pass to testing::InitGoogleMock().
+ *
+ * \return See Google Test's RUN_ALL_TESTS().
+ */
+int main( int argc, char * argv[] )
+{
+    ::testing::InitGoogleMock( &argc, argv );
+
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Resolves #1128 (Add GPIO output pin based SPI device selector).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
