### PR TITLE
Fix missing I2C device write precondition documentation

### DIFF
--- a/include/picolibrary/i2c.h
+++ b/include/picolibrary/i2c.h
@@ -1251,6 +1251,8 @@ class Device {
     /**
      * \brief Write to a register.
      *
+     * \pre the device is responsive
+     *
      * \param[in] register_address The address of the register to write to.
      * \param[in] data The data to write to the register.
      */
@@ -1267,6 +1269,8 @@ class Device {
 
     /**
      * \brief Write to a block of registers.
+     *
+     * \pre the device is responsive
      *
      * \param[in] register_address The address of the block of registers to write to.
      * \param[in] begin, The beginning of the data to write to the block of registers.


### PR DESCRIPTION
Resolves #1177 (Fix missing I2C device write precondition
documentation).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
