### PR TITLE
Add Microchip MCP23S08 facilities unit testing skeleton

### DIFF
--- a/test/unit/picolibrary/microchip/mcp23s08/CMakeLists.txt
+++ b/test/unit/picolibrary/microchip/mcp23s08/CMakeLists.txt
@@ -13,14 +13,5 @@
 # KIND, either express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-# File: test/unit/picolibrary/microchip/CMakeLists.txt
-# Description: picolibrary::Microchip unit tests CMake rules.
-
-# build the picolibrary::Asynchronous_Serial::MCP23008 unit tests
-add_subdirectory( mcp23008 )
-
-# build the picolibrary::Asynchronous_Serial::MCP23S08 unit tests
-add_subdirectory( mcp23s08 )
-
-# build the picolibrary::Asynchronous_Serial::MCP23X08 unit tests
-add_subdirectory( mcp23x08 )
+# File: test/unit/picolibrary/microchip/mcp23s08/CMakeLists.txt
+# Description: picolibrary::Microchip::MCP23S08 unit tests CMake rules.


### PR DESCRIPTION
Resolves #1182 (Add Microchip MCP23S08 facilities unit testing
skeleton).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
