### PR TITLE
Fix missing Microchip MCP23S08 mock communication controller constructor

### DIFF
--- a/include/picolibrary/testing/unit/microchip/mcp23s08.h
+++ b/include/picolibrary/testing/unit/microchip/mcp23s08.h
@@ -150,6 +150,14 @@ class Mock_Communication_Controller : public SPI::Mock_Device {
   public:
     Mock_Communication_Controller() = default;
 
+    Mock_Communication_Controller(
+        SPI::Mock_Controller &,
+        SPI::Mock_Controller::Configuration const &,
+        SPI::Mock_Device_Selector::Handle,
+        ::picolibrary::Microchip::MCP23S08::Address_Transmitted )
+    {
+    }
+
     Mock_Communication_Controller( Mock_Communication_Controller && ) = delete;
 
     Mock_Communication_Controller( Mock_Communication_Controller const & ) = delete;


### PR DESCRIPTION
Resolves #1202 (Fix missing Microchip MCP23S08 mock communication
controller constructor).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
