### PR TITLE
Fix Microchip MCP23S08 communication controller destructor documentation

### DIFF
--- a/include/picolibrary/microchip/mcp23s08.h
+++ b/include/picolibrary/microchip/mcp23s08.h
@@ -554,7 +554,7 @@ class Communication_Controller : public Device {
     constexpr Communication_Controller( Communication_Controller && source ) noexcept = default;
 
     /**
-     * \brief Destructor..
+     * \brief Destructor.
      */
     ~Communication_Controller() noexcept = default;
 


### PR DESCRIPTION
Resolves #1206 (Fix Microchip MCP23S08 communication controller
destructor documentation).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
