### PR TITLE
Explicitly delete Microchip MCP23008/MCP23S08 pin copy assignment operator

### DIFF
--- a/include/picolibrary/microchip/mcp23x08.h
+++ b/include/picolibrary/microchip/mcp23x08.h
@@ -963,6 +963,8 @@ class Pin {
         return *this;
     }
 
+    auto operator=( Pin const & ) = delete;
+
     /**
      * \brief Check if the pin is associated with a caching driver.
      *


### PR DESCRIPTION
Resolves #1219 (Explicitly delete Microchip MCP23008/MCP23S08 pin copy
assignment operator).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
