### PR TITLE
Add Microchip MCP23008/MCP23S08 internally pulled-up input pin

### DIFF
--- a/include/picolibrary/microchip/mcp23x08.h
+++ b/include/picolibrary/microchip/mcp23x08.h
@@ -24,8 +24,10 @@
 #define PICOLIBRARY_MICROCHIP_MCP23X08_H
 
 #include <cstdint>
+#include <utility>
 
 #include "picolibrary/bit_manipulation.h"
+#include "picolibrary/gpio.h"
 
 /**
  * \brief Microchip MCP23008/MCP23S08 facilities.
@@ -1125,6 +1127,166 @@ class Pin {
      * \brief The mask identifying the pin.
      */
     std::uint8_t m_mask{};
+};
+
+/**
+ * \brief Internally pulled-up input pin.
+ *
+ * \tparam Caching_Driver The type of caching driver used to interact with a
+ *         MCP23008/MCP23S08.
+ */
+template<typename Caching_Driver>
+class Internally_Pulled_Up_Input_Pin {
+  public:
+    /**
+     * \brief Constructor.
+     */
+    constexpr Internally_Pulled_Up_Input_Pin() noexcept = default;
+
+    /**
+     * \brief Constructor.
+     *
+     * \param[in] caching_driver The caching driver used to interact with the
+     *            MCP23008/MCP23S08 the pin is a member of.
+     * \param[in] mask The mask identifying the pin.
+     */
+    constexpr Internally_Pulled_Up_Input_Pin( Caching_Driver & caching_driver, std::uint8_t mask ) noexcept :
+        m_pin{ caching_driver, mask }
+    {
+    }
+
+    /**
+     * \brief Constructor.
+     *
+     * \param[in] source The source of the move.
+     */
+    constexpr Internally_Pulled_Up_Input_Pin( Internally_Pulled_Up_Input_Pin && source ) noexcept = default;
+
+    Internally_Pulled_Up_Input_Pin( Internally_Pulled_Up_Input_Pin const & ) = delete;
+
+    /**
+     * \brief Destructor.
+     */
+    ~Internally_Pulled_Up_Input_Pin() noexcept
+    {
+        disable();
+    }
+
+    /**
+     * \brief Assignment operator.
+     *
+     * \param[in] expression The expression to be assigned.
+     *
+     * \return The assigned to object.
+     */
+    constexpr auto & operator=( Internally_Pulled_Up_Input_Pin && expression ) noexcept
+    {
+        if ( &expression != this ) {
+            disable();
+
+            m_pin = std::move( expression.m_pin );
+        } // if
+
+        return *this;
+    }
+
+    auto operator=( Internally_Pulled_Up_Input_Pin const & ) = delete;
+
+    /**
+     * \brief Initialize the pin's hardware.
+     *
+     * \param[in] initial_pull_up_state The initial state of the pin's internal pull-up
+     *            resistor.
+     */
+    void initialize( ::picolibrary::GPIO::Initial_Pull_Up_State initial_pull_up_state = ::picolibrary::GPIO::Initial_Pull_Up_State::DISABLED ) noexcept
+    {
+        m_pin.configure_pin_as_internally_pulled_up_input();
+
+        switch ( initial_pull_up_state ) {
+            case ::picolibrary::GPIO::Initial_Pull_Up_State::DISABLED:
+                m_pin.disable_pull_up();
+                break;
+            case ::picolibrary::GPIO::Initial_Pull_Up_State::ENABLED:
+                m_pin.enable_pull_up();
+                break;
+        } // switch
+    }
+
+    /**
+     * \brief Check if the pin's internal pull-up resistor is disabled.
+     *
+     * \return true if the pin's internal pull-up resistor is disabled.
+     * \return false if the pin's internal pull-up resistor is not disabled.
+     */
+    auto pull_up_is_disabled() const noexcept
+    {
+        return m_pin.pull_up_is_disabled();
+    }
+
+    /**
+     * \brief Check if the pin's internal pull-up resistor is enabled.
+     *
+     * \return true if the pin's internal pull-up resistor is enabled.
+     * \return false if the pin's internal pull-up resistor is not enabled.
+     */
+    auto pull_up_is_enabled() const noexcept
+    {
+        return m_pin.pull_up_is_enabled();
+    }
+
+    /**
+     * \brief Disable the pin's internal pull-up resistor.
+     */
+    void disable_pull_up() noexcept
+    {
+        m_pin.disable_pull_up();
+    }
+
+    /**
+     * \brief Enable the pin's internal pull-up resistor.
+     */
+    void enable_pull_up() noexcept
+    {
+        m_pin.enable_pull_up();
+    }
+
+    /**
+     * \brief Check if the pin is in the low state.
+     *
+     * \return true if the pin is in the low state.
+     * \return false if the pin is not in the low state.
+     */
+    auto is_low() const noexcept
+    {
+        return m_pin.is_low();
+    }
+
+    /**
+     * \brief Check if the pin is in the high state.
+     *
+     * \return true if the pin is in the high state.
+     * \return false if the pin is not in the high state.
+     */
+    auto is_high() const noexcept
+    {
+        return m_pin.is_high();
+    }
+
+  private:
+    /**
+     * \brief The pin.
+     */
+    Pin<Caching_Driver> m_pin{};
+
+    /**
+     * \brief Disable the pin.
+     */
+    constexpr void disable() noexcept
+    {
+        if ( m_pin ) {
+            m_pin.disable_pull_up();
+        } // if
+    }
 };
 
 } // namespace picolibrary::Microchip::MCP23X08

--- a/test/unit/picolibrary/microchip/mcp23x08/CMakeLists.txt
+++ b/test/unit/picolibrary/microchip/mcp23x08/CMakeLists.txt
@@ -19,5 +19,8 @@
 # build the picolibrary::Microchip::MCP23X08::Caching_Driver unit tests
 add_subdirectory( caching_driver )
 
+# build the picolibrary::Microchip::MCP23X08::Internally_Pulled_Up_Input_Pin unit tests
+add_subdirectory( internally_pulled_up_input_pin )
+
 # build the picolibrary::Microchip::MCP23X08::Pin unit tests
 add_subdirectory( pin )

--- a/test/unit/picolibrary/microchip/mcp23x08/internally_pulled_up_input_pin/CMakeLists.txt
+++ b/test/unit/picolibrary/microchip/mcp23x08/internally_pulled_up_input_pin/CMakeLists.txt
@@ -1,0 +1,35 @@
+# picolibrary
+#
+# Copyright 2020-2022, Andrew Countryman <apcountryman@gmail.com> and the picolibrary
+# contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+# file except in compliance with the License. You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+# File: test/unit/picolibrary/microchip/mcp23x08/internally_pulled_up_input_pin/CMakeLists.txt
+# Description: picolibrary::Microchip::MCP23X08::Internally_Pulled_Up_Input_Pin unit tests
+#       CMake rules.
+
+# build the picolibrary::Microchip::MCP23X08::Internally_Pulled_Up_Input_Pin unit tests
+if( ${PICOLIBRARY_ENABLE_UNIT_TESTING} )
+    add_executable(
+        test-unit-picolibrary-microchip-mcp23x08-internally_pulled_up_input_pin
+        main.cc
+    )
+    target_link_libraries(
+        test-unit-picolibrary-microchip-mcp23x08-internally_pulled_up_input_pin
+        picolibrary
+        picolibrary-testing-unit-fatal_error
+    )
+    add_test(
+        NAME    test-unit-picolibrary-microchip-mcp23x08-internally_pulled_up_input_pin
+        COMMAND test-unit-picolibrary-microchip-mcp23x08-internally_pulled_up_input_pin --gtest_color=yes
+    )
+endif( ${PICOLIBRARY_ENABLE_UNIT_TESTING} )

--- a/test/unit/picolibrary/microchip/mcp23x08/internally_pulled_up_input_pin/main.cc
+++ b/test/unit/picolibrary/microchip/mcp23x08/internally_pulled_up_input_pin/main.cc
@@ -1,0 +1,445 @@
+/**
+ * picolibrary
+ *
+ * Copyright 2020-2022, Andrew Countryman <apcountryman@gmail.com> and the picolibrary
+ * contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/**
+ * \file
+ * \brief picolibrary::Microchip::MCP23X08::Internally_Pulled_Up_Input_Pin unit test
+ *        program.
+ */
+
+#include <cstdint>
+#include <utility>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "picolibrary/gpio.h"
+#include "picolibrary/microchip/mcp23x08.h"
+#include "picolibrary/testing/unit/microchip/mcp23x08.h"
+#include "picolibrary/testing/unit/random.h"
+
+namespace {
+
+using ::picolibrary::GPIO::Initial_Pull_Up_State;
+using ::picolibrary::Microchip::MCP23X08::Internally_Pulled_Up_Input_Pin;
+using ::picolibrary::Testing::Unit::random;
+using ::picolibrary::Testing::Unit::Microchip::MCP23X08::Mock_Caching_Driver;
+using ::testing::_;
+using ::testing::InSequence;
+using ::testing::Return;
+
+} // namespace
+
+/**
+ * \brief Verify
+ *        picolibrary::Microchip::MCP23X08::Internally_Pulled_Up_Input_Pin::Internally_Pulled_Up_Input_Pin()
+ *        works properly.
+ */
+TEST( constructorDefault, worksProperly )
+{
+    Internally_Pulled_Up_Input_Pin<Mock_Caching_Driver>{};
+}
+
+/**
+ * \brief Verify
+ *        picolibrary::Microchip::MCP23X08::Internally_Pulled_Up_Input_Pin::Internally_Pulled_Up_Input_Pin(
+ *        Caching_Driver &, std::uint8_t ) works properly.
+ */
+TEST( constructorCachingDriverMask, worksProperly )
+{
+    auto const in_sequence = InSequence{};
+
+    auto       mcp23x08 = Mock_Caching_Driver{};
+    auto const mask     = random<std::uint8_t>();
+
+    auto const pin = Internally_Pulled_Up_Input_Pin{ mcp23x08, mask };
+
+    auto const gppu = random<std::uint8_t>();
+
+    EXPECT_CALL( mcp23x08, gppu() ).WillOnce( Return( gppu ) );
+    EXPECT_CALL( mcp23x08, write_gppu( gppu & ~mask ) );
+}
+
+/**
+ * \brief Verify
+ *        picolibrary::Microchip::MCP23X08::Internally_Pulled_Up_Input_Pin::Internally_Pulled_Up_Input_Pin(
+ *        picolibrary::Microchip::MCP23X08::Internally_Pulled_Up_Input_Pin && ) works
+ *        properly.
+ */
+TEST( constructorMove, worksProperly )
+{
+    {
+        Internally_Pulled_Up_Input_Pin<Mock_Caching_Driver>{
+            Internally_Pulled_Up_Input_Pin<Mock_Caching_Driver>{}
+        };
+    }
+
+    {
+        auto const in_sequence = InSequence{};
+
+        auto       mcp23x08 = Mock_Caching_Driver{};
+        auto const mask     = random<std::uint8_t>();
+
+        auto source = Internally_Pulled_Up_Input_Pin{ mcp23x08, mask };
+
+        EXPECT_CALL( mcp23x08, gppu() ).Times( 0 );
+        EXPECT_CALL( mcp23x08, write_gppu( _ ) ).Times( 0 );
+
+        auto const pin = Internally_Pulled_Up_Input_Pin{ std::move( source ) };
+
+        auto const gppu = random<std::uint8_t>();
+
+        EXPECT_CALL( mcp23x08, gppu() ).WillOnce( Return( gppu ) );
+        EXPECT_CALL( mcp23x08, write_gppu( gppu & ~mask ) );
+    }
+}
+
+/**
+ * \brief Verify
+ *        picolibrary::Microchip::MCP23X08::Internally_Pulled_Up_Input_Pin::operator=(
+ *        picolibrary::Microchip::MCP23X08::Internally_Pulled_Up_Input_Pin && ) works
+ *        properly.
+ */
+TEST( assignmentOperatorMove, worksProperly )
+{
+    {
+        auto expression = Internally_Pulled_Up_Input_Pin<Mock_Caching_Driver>{};
+        auto object     = Internally_Pulled_Up_Input_Pin<Mock_Caching_Driver>{};
+
+        object = std::move( expression );
+    }
+
+    {
+        auto const in_sequence = InSequence{};
+
+        auto       mcp23x08 = Mock_Caching_Driver{};
+        auto const mask     = random<std::uint8_t>();
+
+        auto expression = Internally_Pulled_Up_Input_Pin{ mcp23x08, mask };
+        auto object     = Internally_Pulled_Up_Input_Pin<Mock_Caching_Driver>{};
+
+        EXPECT_CALL( mcp23x08, gppu() ).Times( 0 );
+        EXPECT_CALL( mcp23x08, write_gppu( _ ) ).Times( 0 );
+
+        object = std::move( expression );
+
+        auto const gppu = random<std::uint8_t>();
+
+        EXPECT_CALL( mcp23x08, gppu() ).WillOnce( Return( gppu ) );
+        EXPECT_CALL( mcp23x08, write_gppu( gppu & ~mask ) );
+    }
+
+    {
+        auto const in_sequence = InSequence{};
+
+        auto       mcp23x08 = Mock_Caching_Driver{};
+        auto const mask     = random<std::uint8_t>();
+
+        auto expression = Internally_Pulled_Up_Input_Pin<Mock_Caching_Driver>{};
+        auto object     = Internally_Pulled_Up_Input_Pin{ mcp23x08, mask };
+
+        auto const gppu = random<std::uint8_t>();
+
+        EXPECT_CALL( mcp23x08, gppu() ).WillOnce( Return( gppu ) );
+        EXPECT_CALL( mcp23x08, write_gppu( gppu & ~mask ) );
+
+        object = std::move( expression );
+
+        EXPECT_CALL( mcp23x08, gppu() ).Times( 0 );
+        EXPECT_CALL( mcp23x08, write_gppu( _ ) ).Times( 0 );
+    }
+
+    {
+        auto const in_sequence = InSequence{};
+
+        auto       expression_mcp23x08 = Mock_Caching_Driver{};
+        auto const expression_mask     = random<std::uint8_t>();
+        auto       object_mcp23x08     = Mock_Caching_Driver{};
+        auto const object_mask         = random<std::uint8_t>();
+
+        auto expression = Internally_Pulled_Up_Input_Pin{ expression_mcp23x08, expression_mask };
+        auto object = Internally_Pulled_Up_Input_Pin{ object_mcp23x08, object_mask };
+
+        auto const object_gppu = random<std::uint8_t>();
+
+        EXPECT_CALL( expression_mcp23x08, gppu() ).Times( 0 );
+        EXPECT_CALL( expression_mcp23x08, write_gppu( _ ) ).Times( 0 );
+        EXPECT_CALL( object_mcp23x08, gppu() ).WillOnce( Return( object_gppu ) );
+        EXPECT_CALL( object_mcp23x08, write_gppu( object_gppu & ~object_mask ) );
+
+        object = std::move( expression );
+
+        auto const expression_gppu = random<std::uint8_t>();
+
+        EXPECT_CALL( expression_mcp23x08, gppu() ).WillOnce( Return( expression_gppu ) );
+        EXPECT_CALL( expression_mcp23x08, write_gppu( expression_gppu & ~expression_mask ) );
+        EXPECT_CALL( object_mcp23x08, gppu() ).Times( 0 );
+        EXPECT_CALL( object_mcp23x08, write_gppu( _ ) ).Times( 0 );
+    }
+
+    {
+        auto pin = Internally_Pulled_Up_Input_Pin<Mock_Caching_Driver>{};
+
+        pin = std::move( pin );
+    }
+
+    {
+        auto const in_sequence = InSequence{};
+
+        auto       mcp23x08 = Mock_Caching_Driver{};
+        auto const mask     = random<std::uint8_t>();
+
+        auto pin = Internally_Pulled_Up_Input_Pin{ mcp23x08, mask };
+
+        EXPECT_CALL( mcp23x08, gppu() ).Times( 0 );
+        EXPECT_CALL( mcp23x08, write_gppu( _ ) ).Times( 0 );
+
+        pin = std::move( pin );
+
+        auto const gppu = random<std::uint8_t>();
+
+        EXPECT_CALL( mcp23x08, gppu() ).WillOnce( Return( gppu ) );
+        EXPECT_CALL( mcp23x08, write_gppu( gppu & ~mask ) );
+    }
+}
+
+/**
+ * \brief Verify
+ *        picolibrary::Microchip::MCP23X08::Internally_Pulled_Up_Input_Pin::initialize()
+ *        works properly.
+ */
+TEST( initialize, worksProperly )
+{
+    {
+        auto const in_sequence = InSequence{};
+
+        auto       mcp23x08 = Mock_Caching_Driver{};
+        auto const mask     = random<std::uint8_t>();
+
+        auto pin = Internally_Pulled_Up_Input_Pin{ mcp23x08, mask };
+
+        auto const iodir = random<std::uint8_t>();
+        auto const gppu  = random<std::uint8_t>();
+
+        EXPECT_CALL( mcp23x08, iodir() ).WillOnce( Return( iodir ) );
+        EXPECT_CALL( mcp23x08, write_iodir( iodir | mask ) );
+        EXPECT_CALL( mcp23x08, gppu() ).WillOnce( Return( gppu ) );
+        EXPECT_CALL( mcp23x08, write_gppu( gppu & ~mask ) );
+
+        pin.initialize();
+
+        EXPECT_CALL( mcp23x08, gppu() ).WillOnce( Return( random<std::uint8_t>() ) );
+        EXPECT_CALL( mcp23x08, write_gppu( _ ) );
+    }
+
+    {
+        auto const in_sequence = InSequence{};
+
+        auto       mcp23x08 = Mock_Caching_Driver{};
+        auto const mask     = random<std::uint8_t>();
+
+        auto pin = Internally_Pulled_Up_Input_Pin{ mcp23x08, mask };
+
+        auto const iodir = random<std::uint8_t>();
+        auto const gppu  = random<std::uint8_t>();
+
+        EXPECT_CALL( mcp23x08, iodir() ).WillOnce( Return( iodir ) );
+        EXPECT_CALL( mcp23x08, write_iodir( iodir | mask ) );
+        EXPECT_CALL( mcp23x08, gppu() ).WillOnce( Return( gppu ) );
+        EXPECT_CALL( mcp23x08, write_gppu( gppu & ~mask ) );
+
+        pin.initialize( Initial_Pull_Up_State::DISABLED );
+
+        EXPECT_CALL( mcp23x08, gppu() ).WillOnce( Return( random<std::uint8_t>() ) );
+        EXPECT_CALL( mcp23x08, write_gppu( _ ) );
+    }
+
+    {
+        auto const in_sequence = InSequence{};
+
+        auto       mcp23x08 = Mock_Caching_Driver{};
+        auto const mask     = random<std::uint8_t>();
+
+        auto pin = Internally_Pulled_Up_Input_Pin{ mcp23x08, mask };
+
+        auto const iodir = random<std::uint8_t>();
+        auto const gppu  = random<std::uint8_t>();
+
+        EXPECT_CALL( mcp23x08, iodir() ).WillOnce( Return( iodir ) );
+        EXPECT_CALL( mcp23x08, write_iodir( iodir | mask ) );
+        EXPECT_CALL( mcp23x08, gppu() ).WillOnce( Return( gppu ) );
+        EXPECT_CALL( mcp23x08, write_gppu( gppu | mask ) );
+
+        pin.initialize( Initial_Pull_Up_State::ENABLED );
+
+        EXPECT_CALL( mcp23x08, gppu() ).WillOnce( Return( random<std::uint8_t>() ) );
+        EXPECT_CALL( mcp23x08, write_gppu( _ ) );
+    }
+}
+
+/**
+ * \brief Verify
+ *        picolibrary::Microchip::MCP23X08::Internally_Pulled_Up_Input_Pin::pull_up_is_disabled()
+ *        works properly.
+ */
+TEST( pullUpIsDisabled, worksProperly )
+{
+    auto       mcp23x08 = Mock_Caching_Driver{};
+    auto const mask     = random<std::uint8_t>();
+
+    auto const pin = Internally_Pulled_Up_Input_Pin{ mcp23x08, mask };
+
+    auto const gppu = random<std::uint8_t>();
+
+    EXPECT_CALL( mcp23x08, gppu() ).WillOnce( Return( gppu ) );
+
+    EXPECT_EQ( pin.pull_up_is_disabled(), not( gppu & mask ) );
+
+    EXPECT_CALL( mcp23x08, gppu() ).WillOnce( Return( random<std::uint8_t>() ) );
+    EXPECT_CALL( mcp23x08, write_gppu( _ ) );
+}
+
+/**
+ * \brief Verify
+ *        picolibrary::Microchip::MCP23X08::Internally_Pulled_Up_Input_Pin::pull_up_is_enabled()
+ *        works properly.
+ */
+TEST( pullUpIsEnabled, worksProperly )
+{
+    auto       mcp23x08 = Mock_Caching_Driver{};
+    auto const mask     = random<std::uint8_t>();
+
+    auto const pin = Internally_Pulled_Up_Input_Pin{ mcp23x08, mask };
+
+    auto const gppu = random<std::uint8_t>();
+
+    EXPECT_CALL( mcp23x08, gppu() ).WillOnce( Return( gppu ) );
+
+    EXPECT_EQ( pin.pull_up_is_enabled(), static_cast<bool>( gppu & mask ) );
+
+    EXPECT_CALL( mcp23x08, gppu() ).WillOnce( Return( random<std::uint8_t>() ) );
+    EXPECT_CALL( mcp23x08, write_gppu( _ ) );
+}
+
+/**
+ * \brief Verify
+ *        picolibrary::Microchip::MCP23X08::Internally_Pulled_Up_Input_Pin::disable_pull_up()
+ *        works properly.
+ */
+TEST( disablePullUp, worksProperly )
+{
+    auto const in_sequence = InSequence{};
+
+    auto       mcp23x08 = Mock_Caching_Driver{};
+    auto const mask     = random<std::uint8_t>();
+
+    auto pin = Internally_Pulled_Up_Input_Pin{ mcp23x08, mask };
+
+    auto const gppu = random<std::uint8_t>();
+
+    EXPECT_CALL( mcp23x08, gppu() ).WillOnce( Return( gppu ) );
+    EXPECT_CALL( mcp23x08, write_gppu( gppu & ~mask ) );
+
+    pin.disable_pull_up();
+
+    EXPECT_CALL( mcp23x08, gppu() ).WillOnce( Return( random<std::uint8_t>() ) );
+    EXPECT_CALL( mcp23x08, write_gppu( _ ) );
+}
+
+/**
+ * \brief Verify
+ *        picolibrary::Microchip::MCP23X08::Internally_Pulled_Up_Input_Pin::enable_pull_up()
+ *        works properly.
+ */
+TEST( enablePullUp, worksProperly )
+{
+    auto const in_sequence = InSequence{};
+
+    auto       mcp23x08 = Mock_Caching_Driver{};
+    auto const mask     = random<std::uint8_t>();
+
+    auto pin = Internally_Pulled_Up_Input_Pin{ mcp23x08, mask };
+
+    auto const gppu = random<std::uint8_t>();
+
+    EXPECT_CALL( mcp23x08, gppu() ).WillOnce( Return( gppu ) );
+    EXPECT_CALL( mcp23x08, write_gppu( gppu | mask ) );
+
+    pin.enable_pull_up();
+
+    EXPECT_CALL( mcp23x08, gppu() ).WillOnce( Return( random<std::uint8_t>() ) );
+    EXPECT_CALL( mcp23x08, write_gppu( _ ) );
+}
+
+/**
+ * \brief Verify
+ *        picolibrary::Microchip::MCP23X08::Internally_Pulled_Up_Input_Pin::is_low() works
+ *        properly.
+ */
+TEST( isLow, worksProperly )
+{
+    auto       mcp23x08 = Mock_Caching_Driver{};
+    auto const mask     = random<std::uint8_t>();
+
+    auto const pin = Internally_Pulled_Up_Input_Pin{ mcp23x08, mask };
+
+    auto const gpio = random<std::uint8_t>();
+
+    EXPECT_CALL( mcp23x08, read_gpio() ).WillOnce( Return( gpio ) );
+
+    EXPECT_EQ( pin.is_low(), not( gpio & mask ) );
+
+    EXPECT_CALL( mcp23x08, gppu() ).WillOnce( Return( random<std::uint8_t>() ) );
+    EXPECT_CALL( mcp23x08, write_gppu( _ ) );
+}
+
+/**
+ * \brief Verify
+ *        picolibrary::Microchip::MCP23X08::Internally_Pulled_Up_Input_Pin::is_high()
+ *        works properly.
+ */
+TEST( isHigh, worksProperly )
+{
+    auto       mcp23x08 = Mock_Caching_Driver{};
+    auto const mask     = random<std::uint8_t>();
+
+    auto const pin = Internally_Pulled_Up_Input_Pin{ mcp23x08, mask };
+
+    auto const gpio = random<std::uint8_t>();
+
+    EXPECT_CALL( mcp23x08, read_gpio() ).WillOnce( Return( gpio ) );
+
+    EXPECT_EQ( pin.is_high(), static_cast<bool>( gpio & mask ) );
+
+    EXPECT_CALL( mcp23x08, gppu() ).WillOnce( Return( random<std::uint8_t>() ) );
+    EXPECT_CALL( mcp23x08, write_gppu( _ ) );
+}
+
+/**
+ * \brief Execute the picolibrary::Microchip::MCP23X08::Internally_Pulled_Up_Input_Pin
+ *        unit tests.
+ *
+ * \param[in] argc The number of arguments to pass to testing::InitGoogleMock().
+ * \param[in] argc The array of arguments to pass to testing::InitGoogleMock().
+ *
+ * \return See Google Test's RUN_ALL_TESTS().
+ */
+int main( int argc, char * argv[] )
+{
+    ::testing::InitGoogleMock( &argc, argv );
+
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Resolves #1215 (Add Microchip MCP23008/MCP23S08 internally pulled-up
input pin).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
