### PR TITLE
Add Microchip MCP23S08 output pin toggle interactive test helper

### DIFF
--- a/include/picolibrary/testing/interactive/microchip/mcp23s08.h
+++ b/include/picolibrary/testing/interactive/microchip/mcp23s08.h
@@ -84,6 +84,47 @@ void state(
         std::move( delay ) );
 }
 
+/**
+ * \brief Output pin toggle interactive test helper.
+ *
+ * \tparam Output_Pin The type of output pin to toggle.
+ * \tparam Controller The type of controller used to communicate with the MCP23S08.
+ * \tparam Device_Selector The type of device selector used to select and deselect the
+ *         MCP23S08.
+ * \tparam Delayer A nullary functor called to introduce a delay each time the pin is
+ *         toggled.
+ *
+ * \param[in] controller The controller used to communicate with the MCP23S08.
+ * \param[in] configuration The controller clock and data exchange bit order configuration
+ *            that meets the MCP23S08's communication requirements.
+ * \param[in] device_selector The device selector used to select and deselect the
+ *            MCP23S08.
+ * \param[in] address The MCP23S08's address.
+ * \param[in] mask The mask identifying the pin.
+ * \param[in] delay The nullary functor to call to introduce a delay each time the pin is
+ *            toggled.
+ */
+template<template<typename> typename Output_Pin, typename Controller, typename Device_Selector, typename Delayer>
+void toggle(
+    Controller                                              controller,
+    typename Controller::Configuration                      configuration,
+    Device_Selector                                         device_selector,
+    ::picolibrary::Microchip::MCP23S08::Address_Transmitted address,
+    std::uint8_t                                            mask,
+    Delayer                                                 delay ) noexcept
+{
+    controller.initialize();
+
+    auto mcp23s08 = ::picolibrary::Microchip::MCP23X08::Caching_Driver<::picolibrary::Microchip::MCP23S08::Driver<Controller, Device_Selector>>{
+        controller, configuration, std::move( device_selector ), std::move( address )
+    };
+
+    mcp23s08.initialize();
+
+    ::picolibrary::Testing::Interactive::GPIO::toggle(
+        Output_Pin{ mcp23s08, mask }, std::move( delay ) );
+}
+
 } // namespace picolibrary::Testing::Interactive::Microchip::MCP23S08
 
 #endif // PICOLIBRARY_TESTING_INTERACTIVE_MICROCHIP_MCP23S08_H

--- a/include/picolibrary/testing/interactive/microchip/mcp23s08.h
+++ b/include/picolibrary/testing/interactive/microchip/mcp23s08.h
@@ -113,6 +113,8 @@ void toggle(
     std::uint8_t                                            mask,
     Delayer                                                 delay ) noexcept
 {
+    // #lizard forgives the parameter count
+
     controller.initialize();
 
     auto mcp23s08 = ::picolibrary::Microchip::MCP23X08::Caching_Driver<::picolibrary::Microchip::MCP23S08::Driver<Controller, Device_Selector>>{


### PR DESCRIPTION
Resolves #1229 (Add Microchip MCP23S08 output pin toggle interactive
test helper).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
