### PR TITLE
Refactor Microchip MCP23008 internally pulled-up input pin state interactive test helper to use MCP23008 types

### DIFF
--- a/include/picolibrary/testing/interactive/microchip/mcp23008.h
+++ b/include/picolibrary/testing/interactive/microchip/mcp23008.h
@@ -64,14 +64,13 @@ void state(
 {
     controller.initialize();
 
-    auto mcp23008 = ::picolibrary::Microchip::MCP23X08::Caching_Driver<
-        ::picolibrary::Microchip::MCP23008::Driver<::picolibrary::I2C::Bus_Multiplexer_Aligner, Controller>>{
+    auto mcp23008 = ::picolibrary::Microchip::MCP23008::Caching_Driver<::picolibrary::I2C::Bus_Multiplexer_Aligner, Controller>{
         {}, controller, std::move( address ), Generic_Error::NONRESPONSIVE_DEVICE
     };
 
     ::picolibrary::Testing::Interactive::GPIO::state(
         stream,
-        ::picolibrary::Microchip::MCP23X08::Internally_Pulled_Up_Input_Pin{ mcp23008, mask },
+        ::picolibrary::Microchip::MCP23008::Internally_Pulled_Up_Input_Pin{ mcp23008, mask },
         std::move( delay ) );
 }
 


### PR DESCRIPTION
Resolves #1241 (Refactor Microchip MCP23008 internally pulled-up input
pin state interactive test helper to use MCP23008 types).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
