### PR TITLE
Refactor Microchip MCP23008 output pin toggle interactive test helper to use MCP23008 types

### DIFF
--- a/include/picolibrary/testing/interactive/microchip/mcp23008.h
+++ b/include/picolibrary/testing/interactive/microchip/mcp23008.h
@@ -29,7 +29,6 @@
 #include "picolibrary/error.h"
 #include "picolibrary/i2c.h"
 #include "picolibrary/microchip/mcp23008.h"
-#include "picolibrary/microchip/mcp23x08.h"
 #include "picolibrary/stream.h"
 #include "picolibrary/testing/interactive/gpio.h"
 
@@ -97,8 +96,7 @@ void toggle(
 {
     controller.initialize();
 
-    auto mcp23008 = ::picolibrary::Microchip::MCP23X08::Caching_Driver<
-        ::picolibrary::Microchip::MCP23008::Driver<::picolibrary::I2C::Bus_Multiplexer_Aligner, Controller>>{
+    auto mcp23008 = ::picolibrary::Microchip::MCP23008::Caching_Driver<::picolibrary::I2C::Bus_Multiplexer_Aligner, Controller>{
         {}, controller, std::move( address ), Generic_Error::NONRESPONSIVE_DEVICE
     };
 


### PR DESCRIPTION
Resolves #1242 (Refactor Microchip MCP23008 output pin toggle
interactive test helper to use MCP23008 types).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
