### PR TITLE
Add Microchip MCP23S08 open-drain I/O pin

### DIFF
--- a/include/picolibrary/microchip/mcp23s08.h
+++ b/include/picolibrary/microchip/mcp23s08.h
@@ -918,6 +918,8 @@ using MCP23X08::Pin;
 
 using MCP23X08::Internally_Pulled_Up_Input_Pin;
 
+using MCP23X08::Open_Drain_IO_Pin;
+
 } // namespace picolibrary::Microchip::MCP23S08
 
 #endif // PICOLIBRARY_MICROCHIP_MCP23S08_H


### PR DESCRIPTION
Resolves #1257 (Add Microchip MCP23S08 open-drain I/O pin).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
