### PR TITLE
Refactor Microchip MCP23S08 internally pulled-up input pin state interactive test helper to use MCP23s08 types

### DIFF
--- a/include/picolibrary/testing/interactive/microchip/mcp23s08.h
+++ b/include/picolibrary/testing/interactive/microchip/mcp23s08.h
@@ -72,7 +72,7 @@ void state(
 
     controller.initialize();
 
-    auto mcp23s08 = ::picolibrary::Microchip::MCP23X08::Caching_Driver<::picolibrary::Microchip::MCP23S08::Driver<Controller, Device_Selector>>{
+    auto mcp23s08 = ::picolibrary::Microchip::MCP23S08::Caching_Driver<Controller, Device_Selector>{
         controller, configuration, std::move( device_selector ), std::move( address )
     };
 
@@ -80,7 +80,7 @@ void state(
 
     ::picolibrary::Testing::Interactive::GPIO::state(
         stream,
-        ::picolibrary::Microchip::MCP23X08::Internally_Pulled_Up_Input_Pin{ mcp23s08, mask },
+        ::picolibrary::Microchip::MCP23S08::Internally_Pulled_Up_Input_Pin{ mcp23s08, mask },
         std::move( delay ) );
 }
 


### PR DESCRIPTION
Resolves #1259 (Refactor Microchip MCP23S08 internally pulled-up input
pin state interactive test helper to use MCP23s08 types).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
