### PR TITLE
Refactor Microchip MCP23S08 output pin toggle interactive test helper to use MCP23S08 types

### DIFF
--- a/include/picolibrary/testing/interactive/microchip/mcp23s08.h
+++ b/include/picolibrary/testing/interactive/microchip/mcp23s08.h
@@ -27,7 +27,6 @@
 #include <utility>
 
 #include "picolibrary/microchip/mcp23s08.h"
-#include "picolibrary/microchip/mcp23x08.h"
 #include "picolibrary/stream.h"
 #include "picolibrary/testing/interactive/gpio.h"
 
@@ -117,7 +116,7 @@ void toggle(
 
     controller.initialize();
 
-    auto mcp23s08 = ::picolibrary::Microchip::MCP23X08::Caching_Driver<::picolibrary::Microchip::MCP23S08::Driver<Controller, Device_Selector>>{
+    auto mcp23s08 = ::picolibrary::Microchip::MCP23S08::Caching_Driver<Controller, Device_Selector>{
         controller, configuration, std::move( device_selector ), std::move( address )
     };
 


### PR DESCRIPTION
Resolves #1260 (Refactor Microchip MCP23S08 output pin toggle
interactive test helper to use MCP23S08 types).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
