### PR TITLE
Add GPIO output pin based fixed intensity indicator

### DIFF
--- a/include/picolibrary/indicator.h
+++ b/include/picolibrary/indicator.h
@@ -25,6 +25,8 @@
 
 #include <cstdint>
 
+#include "picolibrary/gpio.h"
+
 /**
  * \brief Indicator facilities.
  */
@@ -95,6 +97,51 @@ class Fixed_Intensity_Indicator_Concept {
      * \brief Toggle the indicator state.
      */
     void toggle() noexcept;
+};
+
+/**
+ * \brief GPIO output pin based fixed intensity indicator.
+ *
+ * \tparam GPIO_Output_Pin The type of GPIO output pin used to manipulate the indicator.
+ */
+template<typename GPIO_Output_Pin>
+class GPIO_Output_Pin_Fixed_Intensity_Indicator : public GPIO_Output_Pin {
+  public:
+    using GPIO_Output_Pin::GPIO_Output_Pin;
+
+    /**
+     * \brief Initialize the indicator's hardware.
+     *
+     * \param[in] initial_indicator_state The initial state of the indicator.
+     */
+    void initialize( Initial_Indicator_State initial_indicator_state = Initial_Indicator_State::EXTINGUISHED ) noexcept
+    {
+        static_assert(
+            static_cast<std::uint_fast8_t>( Initial_Indicator_State::EXTINGUISHED )
+            == static_cast<std::uint_fast8_t>( GPIO::Initial_Pin_State::LOW ) );
+        static_assert(
+            static_cast<std::uint_fast8_t>( Initial_Indicator_State::ILLUMINATED )
+            == static_cast<std::uint_fast8_t>( GPIO::Initial_Pin_State::HIGH ) );
+
+        GPIO_Output_Pin::initialize( static_cast<GPIO::Initial_Pin_State>(
+            static_cast<std::uint_fast8_t>( initial_indicator_state ) ) );
+    }
+
+    /**
+     * \brief Extinguish the indicator.
+     */
+    void extinguish() noexcept
+    {
+        GPIO_Output_Pin::transition_to_low();
+    }
+
+    /**
+     * \brief Illuminate the indicator.
+     */
+    void illuminate() noexcept
+    {
+        GPIO_Output_Pin::transition_to_high();
+    }
 };
 
 } // namespace picolibrary::Indicator

--- a/test/unit/picolibrary/indicator/CMakeLists.txt
+++ b/test/unit/picolibrary/indicator/CMakeLists.txt
@@ -15,3 +15,6 @@
 
 # File: test/unit/picolibrary/indicator/CMakeLists.txt
 # Description: picolibrary::Indicator unit tests CMake rules.
+
+# build the picolibrary::Indicator::GPIO_Output_Pin_Fixed_Intensity_Indicator unit tests
+add_subdirectory( gpio_output_pin_fixed_intensity_indicator )

--- a/test/unit/picolibrary/indicator/gpio_output_pin_fixed_intensity_indicator/CMakeLists.txt
+++ b/test/unit/picolibrary/indicator/gpio_output_pin_fixed_intensity_indicator/CMakeLists.txt
@@ -1,0 +1,35 @@
+# picolibrary
+#
+# Copyright 2020-2022, Andrew Countryman <apcountryman@gmail.com> and the picolibrary
+# contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+# file except in compliance with the License. You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the specific language governing
+# permissions and limitations under the License.
+
+# File: test/unit/picolibrary/indicator/gpio_output_pin_fixed_intensity_indicator/CMakeLists.txt
+# Description: picolibrary::Indicator::GPIO_Output_Pin_Fixed_Intensity_Indicator unit
+#       tests CMake rules.
+
+# build the picolibrary::Indicator::GPIO_Output_Pin_Fixed_Intensity_Indicator unit tests
+if( ${PICOLIBRARY_ENABLE_UNIT_TESTING} )
+    add_executable(
+        test-unit-picolibrary-indicator-gpio_output_pin_fixed_intensity_indicator
+        main.cc
+    )
+    target_link_libraries(
+        test-unit-picolibrary-indicator-gpio_output_pin_fixed_intensity_indicator
+        picolibrary
+        picolibrary-testing-unit-fatal_error
+    )
+    add_test(
+        NAME    test-unit-picolibrary-indicator-gpio_output_pin_fixed_intensity_indicator
+        COMMAND test-unit-picolibrary-indicator-gpio_output_pin_fixed_intensity_indicator --gtest_color=yes
+    )
+endif( ${PICOLIBRARY_ENABLE_UNIT_TESTING} )

--- a/test/unit/picolibrary/indicator/gpio_output_pin_fixed_intensity_indicator/main.cc
+++ b/test/unit/picolibrary/indicator/gpio_output_pin_fixed_intensity_indicator/main.cc
@@ -1,0 +1,120 @@
+/**
+ * picolibrary
+ *
+ * Copyright 2020-2022, Andrew Countryman <apcountryman@gmail.com> and the picolibrary
+ * contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/**
+ * \file
+ * \brief picolibrary::Indicator::GPIO_Output_Pin_Fixed_Intensity_Indicator unit test
+ *        program.
+ */
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "picolibrary/gpio.h"
+#include "picolibrary/indicator.h"
+#include "picolibrary/testing/unit/gpio.h"
+
+namespace {
+
+using ::picolibrary::GPIO::Initial_Pin_State;
+using ::picolibrary::Indicator::Initial_Indicator_State;
+
+using Indicator =
+    ::picolibrary::Indicator::GPIO_Output_Pin_Fixed_Intensity_Indicator<::picolibrary::Testing::Unit::GPIO::Mock_Output_Pin>;
+
+} // namespace
+
+/**
+ * \brief Verify
+ *        picolibrary::Indicator::GPIO_Output_Pin_Fixed_Intensity_Indicator::initialize()
+ *        works properly.
+ */
+TEST( initialize, worksProperly )
+{
+    {
+        auto indicator = Indicator{};
+
+        EXPECT_CALL( indicator, initialize( Initial_Pin_State::LOW ) );
+
+        indicator.initialize();
+    }
+
+    {
+        struct {
+            Initial_Indicator_State initial_indicator_state;
+            Initial_Pin_State       initial_pin_state;
+        } const test_cases[]{
+            // clang-format off
+
+            { Initial_Indicator_State::EXTINGUISHED, Initial_Pin_State::LOW  },
+            { Initial_Indicator_State::ILLUMINATED,  Initial_Pin_State::HIGH },
+
+            // clang-format on
+        };
+
+        for ( auto const test_case : test_cases ) {
+            auto indicator = Indicator{};
+
+            EXPECT_CALL( indicator, initialize( test_case.initial_pin_state ) );
+
+            indicator.initialize( test_case.initial_indicator_state );
+        } // for
+    }
+}
+
+/**
+ * \brief Verify
+ *        picolibrary::Indicator::GPIO_Output_Pin_Fixed_Intensity_Indicator::extinguish()
+ *        works properly.
+ */
+TEST( extinguish, worksProperly )
+{
+    auto indicator = Indicator{};
+
+    EXPECT_CALL( indicator, transition_to_low() );
+
+    indicator.extinguish();
+}
+
+/**
+ * \brief Verify
+ *        picolibrary::Indicator::GPIO_Output_Pin_Fixed_Intensity_Indicator::illuminate()
+ *        works properly.
+ */
+TEST( illuminate, worksProperly )
+{
+    auto indicator = Indicator{};
+
+    EXPECT_CALL( indicator, transition_to_high() );
+
+    indicator.illuminate();
+}
+
+/**
+ * \brief Execute the picolibrary::Indicator::GPIO_Output_Pin_Fixed_Intensity_Indicator
+ *        unit tests.
+ *
+ * \param[in] argc The number of arguments to pass to testing::InitGoogleMock().
+ * \param[in] argc The array of arguments to pass to testing::InitGoogleMock().
+ *
+ * \return See Google Test's RUN_ALL_TESTS().
+ */
+int main( int argc, char * argv[] )
+{
+    ::testing::InitGoogleMock( &argc, argv );
+
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Resolves #1275 (Add GPIO output pin based fixed intensity indicator).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
