### PR TITLE
Fix single reader/writer circular buffer empty/full check nodiscard inconsistency

### DIFF
--- a/include/picolibrary/circular_buffer.h
+++ b/include/picolibrary/circular_buffer.h
@@ -212,7 +212,7 @@ class Circular_Buffer<T, Size_Type, N, Single_Reader_Writer, void> {
      * \return true if the circular buffer is full.
      * \return false if the circular buffer is not full.
      */
-    auto full() const noexcept -> bool
+    [[nodiscard]] auto full() const noexcept -> bool
     {
         return size() == max_size();
     }


### PR DESCRIPTION
Resolves #1302 (Fix single reader/writer circular buffer empty/full
check nodiscard inconsistency).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
