### PR TITLE
Fix single reader/writer circular buffer back storage indexing

### DIFF
--- a/include/picolibrary/circular_buffer.h
+++ b/include/picolibrary/circular_buffer.h
@@ -179,7 +179,7 @@ class Circular_Buffer<T, Size_Type, N, Single_Reader_Writer, void> {
     auto back() noexcept -> Value &
     {
         return *std::launder( reinterpret_cast<Value *>(
-            &m_storage[ ( m_read - 1 ) & index_wrap_around_mask() ] ) );
+            &m_storage[ ( m_read + size() - 1 ) & index_wrap_around_mask() ] ) );
     }
 
     /**
@@ -193,7 +193,7 @@ class Circular_Buffer<T, Size_Type, N, Single_Reader_Writer, void> {
     auto back() const noexcept -> Value const &
     {
         return *std::launder( reinterpret_cast<Value const *>(
-            &m_storage[ ( m_read - 1 ) & index_wrap_around_mask() ] ) );
+            &m_storage[ ( m_read + size() - 1 ) & index_wrap_around_mask() ] ) );
     }
 
     /**


### PR DESCRIPTION
Resolves #1305 (Fix single reader/writer circular buffer back storage
indexing).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
