### PR TITLE
Fix circular buffer use case enumerators ordering inconsistency

### DIFF
--- a/include/picolibrary/circular_buffer.h
+++ b/include/picolibrary/circular_buffer.h
@@ -47,13 +47,6 @@ enum class Circular_Buffer_Use_Case {
     INTERRUPT_READS_WRITES,
 
     /**
-     * An interrupt reads from the circular buffer. One or more other interrupts write to
-     * the circular buffer. The main thread of execution does not interact with the
-     * circular buffer.
-     */
-    INTERRUPT_READS_INTERRUPT_WRITES,
-
-    /**
      * The main thread of execution reads from the circular buffer. One or more interrupts
      * write to the circular buffer.
      */
@@ -64,6 +57,13 @@ enum class Circular_Buffer_Use_Case {
      * the circular buffer. The main thread of execution writes to the circular buffer.
      */
     INTERRUPT_READS_MAIN_WRITES,
+
+    /**
+     * An interrupt reads from the circular buffer. One or more other interrupts write to
+     * the circular buffer. The main thread of execution does not interact with the
+     * circular buffer.
+     */
+    INTERRUPT_READS_INTERRUPT_WRITES,
 
     /**
      * The main thread of execution reads from and writes to the circular buffer. One or


### PR DESCRIPTION
Resolves #1318 (Fix circular buffer use case enumerators ordering
inconsistency).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
