### PR TITLE
Fix interrupt controller concept save/restore interrupt enable state design error

### DIFF
--- a/include/picolibrary/testing/unit/interrupt.h
+++ b/include/picolibrary/testing/unit/interrupt.h
@@ -23,6 +23,8 @@
 #ifndef PICOLIBRARY_TESTING_UNIT_INTERRUPT_H
 #define PICOLIBRARY_TESTING_UNIT_INTERRUPT_H
 
+#include <cstdint>
+
 #include "gmock/gmock.h"
 #include "picolibrary/testing/unit/mock_handle.h"
 
@@ -36,8 +38,12 @@ namespace picolibrary::Testing::Unit::Interrupt {
  */
 class Mock_Controller {
   public:
+    using Interrupt_Enable_State = std::uint_fast8_t;
+
     class Handle : public Mock_Handle<Mock_Controller> {
       public:
+        using Interrupt_Enable_State = Mock_Controller::Interrupt_Enable_State;
+
         constexpr Handle() noexcept = default;
 
         constexpr Handle( Mock_Controller & mock ) noexcept :
@@ -65,14 +71,14 @@ class Mock_Controller {
             mock().enable_interrupt();
         }
 
-        void save_interrupt_enable_state() noexcept
+        auto save_interrupt_enable_state() const noexcept -> Interrupt_Enable_State
         {
-            mock().save_interrupt_enable_state();
+            return mock().save_interrupt_enable_state();
         }
 
-        void restore_interrupt_enable_state() noexcept
+        void restore_interrupt_enable_state( Interrupt_Enable_State interrupt_enable_state ) noexcept
         {
-            mock().restore_interrupt_enable_state();
+            mock().restore_interrupt_enable_state( interrupt_enable_state );
         }
     };
 
@@ -96,8 +102,8 @@ class Mock_Controller {
     MOCK_METHOD( void, disable_interrupt, () );
     MOCK_METHOD( void, enable_interrupt, () );
 
-    MOCK_METHOD( void, save_interrupt_enable_state, () );
-    MOCK_METHOD( void, restore_interrupt_enable_state, () );
+    MOCK_METHOD( Interrupt_Enable_State, save_interrupt_enable_state, (), ( const ) );
+    MOCK_METHOD( void, restore_interrupt_enable_state, ( Interrupt_Enable_State ) );
 };
 
 } // namespace picolibrary::Testing::Unit::Interrupt

--- a/test/unit/picolibrary/interrupt/critical_section_guard/main.cc
+++ b/test/unit/picolibrary/interrupt/critical_section_guard/main.cc
@@ -24,13 +24,16 @@
 #include "gtest/gtest.h"
 #include "picolibrary/interrupt.h"
 #include "picolibrary/testing/unit/interrupt.h"
+#include "picolibrary/testing/unit/random.h"
 
 namespace {
 
 using ::picolibrary::Interrupt::Critical_Section_Guard;
 using ::picolibrary::Interrupt::ENABLE_INTERRUPT;
 using ::picolibrary::Interrupt::RESTORE_INTERRUPT_ENABLE_STATE;
+using ::picolibrary::Testing::Unit::random;
 using ::picolibrary::Testing::Unit::Interrupt::Mock_Controller;
+using ::testing::Return;
 
 } // namespace
 
@@ -42,12 +45,14 @@ TEST( criticalSectionGuard, worksProperly )
     {
         auto controller = Mock_Controller{};
 
-        EXPECT_CALL( controller, save_interrupt_enable_state() );
+        auto const interrupt_enable_state = random<Mock_Controller::Interrupt_Enable_State>();
+
+        EXPECT_CALL( controller, save_interrupt_enable_state() ).WillOnce( Return( interrupt_enable_state ) );
         EXPECT_CALL( controller, disable_interrupt() );
 
         auto guard = Critical_Section_Guard{ controller, RESTORE_INTERRUPT_ENABLE_STATE };
 
-        EXPECT_CALL( controller, restore_interrupt_enable_state() );
+        EXPECT_CALL( controller, restore_interrupt_enable_state( interrupt_enable_state ) );
     }
 
     {

--- a/test/unit/picolibrary/interrupt/critical_section_guard/main.cc
+++ b/test/unit/picolibrary/interrupt/critical_section_guard/main.cc
@@ -50,7 +50,7 @@ TEST( criticalSectionGuard, worksProperly )
         EXPECT_CALL( controller, save_interrupt_enable_state() ).WillOnce( Return( interrupt_enable_state ) );
         EXPECT_CALL( controller, disable_interrupt() );
 
-        auto guard = Critical_Section_Guard{ controller, RESTORE_INTERRUPT_ENABLE_STATE };
+        auto const guard = Critical_Section_Guard{ controller, RESTORE_INTERRUPT_ENABLE_STATE };
 
         EXPECT_CALL( controller, restore_interrupt_enable_state( interrupt_enable_state ) );
     }
@@ -60,7 +60,7 @@ TEST( criticalSectionGuard, worksProperly )
 
         EXPECT_CALL( controller, disable_interrupt() );
 
-        auto guard = Critical_Section_Guard{ controller, ENABLE_INTERRUPT };
+        auto const guard = Critical_Section_Guard{ controller, ENABLE_INTERRUPT };
 
         EXPECT_CALL( controller, enable_interrupt() );
     }


### PR DESCRIPTION
Resolves #1333 (Fix interrupt controller concept save/restore interrupt
enable state design error).

The interrupt enable state needs to be saved on the stack by a critical
section guard to easily support nested critical sections.

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
