### PR TITLE
Add blocking, single sample ADC sample interactive test helper

### DIFF
--- a/include/picolibrary/testing/interactive/adc.h
+++ b/include/picolibrary/testing/interactive/adc.h
@@ -48,6 +48,8 @@ namespace picolibrary::Testing::Interactive::ADC {
 template<typename Blocking_Single_Sample_Converter, typename Delayer>
 void sample( Output_Stream & stream, Blocking_Single_Sample_Converter adc, Delayer delay ) noexcept
 {
+    // #lizard forgives the length
+
     adc.initialize();
 
     {

--- a/include/picolibrary/testing/interactive/adc.h
+++ b/include/picolibrary/testing/interactive/adc.h
@@ -54,7 +54,7 @@ void sample( Output_Stream & stream, Blocking_Single_Sample_Converter adc, Delay
 
     {
         auto const result = stream.print(
-            "ADC sample range: [{}, {}]\n",
+            "ADC sample range: [{},{}]\n",
             Format::Decimal{ Blocking_Single_Sample_Converter::Sample::min().as_unsigned_integer() },
             Format::Decimal{ Blocking_Single_Sample_Converter::Sample::max().as_unsigned_integer() } );
         expect( not result.is_error(), result.error() );


### PR DESCRIPTION
Resolves #1348 (Add blocking, single sample ADC sample interactive test
helper).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
