### PR TITLE
Replace static casts with enum underlying type conversion utility calls

### DIFF
--- a/include/picolibrary/error.h
+++ b/include/picolibrary/error.h
@@ -26,6 +26,7 @@
 #include <cstdint>
 #include <type_traits>
 
+#include "picolibrary/utility.h"
 #include "picolibrary/void.h"
 
 namespace picolibrary {
@@ -461,7 +462,7 @@ class Generic_Error_Category final : public Error_Category {
  */
 inline auto make_error_code( Generic_Error error ) noexcept
 {
-    return Error_Code{ Generic_Error_Category::instance(), static_cast<Error_ID>( error ) };
+    return Error_Code{ Generic_Error_Category::instance(), to_underlying( error ) };
 }
 
 /**

--- a/include/picolibrary/indicator.h
+++ b/include/picolibrary/indicator.h
@@ -26,6 +26,7 @@
 #include <cstdint>
 
 #include "picolibrary/gpio.h"
+#include "picolibrary/utility.h"
 
 /**
  * \brief Indicator facilities.
@@ -117,14 +118,14 @@ class GPIO_Output_Pin_Fixed_Intensity_Indicator : public GPIO_Output_Pin {
     void initialize( Initial_Indicator_State initial_indicator_state = Initial_Indicator_State::EXTINGUISHED ) noexcept
     {
         static_assert(
-            static_cast<std::uint_fast8_t>( Initial_Indicator_State::EXTINGUISHED )
-            == static_cast<std::uint_fast8_t>( GPIO::Initial_Pin_State::LOW ) );
+            to_underlying( Initial_Indicator_State::EXTINGUISHED )
+            == to_underlying( GPIO::Initial_Pin_State::LOW ) );
         static_assert(
-            static_cast<std::uint_fast8_t>( Initial_Indicator_State::ILLUMINATED )
-            == static_cast<std::uint_fast8_t>( GPIO::Initial_Pin_State::HIGH ) );
+            to_underlying( Initial_Indicator_State::ILLUMINATED )
+            == to_underlying( GPIO::Initial_Pin_State::HIGH ) );
 
-        GPIO_Output_Pin::initialize( static_cast<GPIO::Initial_Pin_State>(
-            static_cast<std::uint_fast8_t>( initial_indicator_state ) ) );
+        GPIO_Output_Pin::initialize(
+            static_cast<GPIO::Initial_Pin_State>( to_underlying( initial_indicator_state ) ) );
     }
 
     /**

--- a/include/picolibrary/microchip/mcp23s08.h
+++ b/include/picolibrary/microchip/mcp23s08.h
@@ -30,6 +30,7 @@
 #include "picolibrary/microchip/mcp23x08.h"
 #include "picolibrary/precondition.h"
 #include "picolibrary/spi.h"
+#include "picolibrary/utility.h"
 
 /**
  * \brief Microchip MCP23S08 facilities.
@@ -603,7 +604,7 @@ class Communication_Controller : public Device {
 
         auto const guard = SPI::Device_Selection_Guard{ this->device_selector() };
 
-        this->transmit( m_address.as_unsigned_integer() | static_cast<std::uint8_t>( Operation::READ ) );
+        this->transmit( m_address.as_unsigned_integer() | to_underlying( Operation::READ ) );
         this->transmit( register_address );
         return this->receive();
     }
@@ -620,7 +621,7 @@ class Communication_Controller : public Device {
 
         auto const guard = SPI::Device_Selection_Guard{ this->device_selector() };
 
-        this->transmit( m_address.as_unsigned_integer() | static_cast<std::uint8_t>( Operation::WRITE ) );
+        this->transmit( m_address.as_unsigned_integer() | to_underlying( Operation::WRITE ) );
         this->transmit( register_address );
         this->transmit( data );
     }

--- a/include/picolibrary/testing/unit/error.h
+++ b/include/picolibrary/testing/unit/error.h
@@ -28,6 +28,7 @@
 #include "gmock/gmock.h"
 #include "picolibrary/error.h"
 #include "picolibrary/testing/unit/random.h"
+#include "picolibrary/utility.h"
 
 namespace picolibrary::Testing::Unit {
 
@@ -91,7 +92,7 @@ class Mock_Error_Category : public Error_Category {
  */
 inline auto make_error_code( Mock_Error error ) noexcept
 {
-    return Error_Code{ Mock_Error_Category::instance(), static_cast<Error_ID>( error ) };
+    return Error_Code{ Mock_Error_Category::instance(), to_underlying( error ) };
 }
 
 } // namespace picolibrary::Testing::Unit

--- a/source/picolibrary/hsm.cc
+++ b/source/picolibrary/hsm.cc
@@ -23,21 +23,21 @@
 #include "picolibrary/hsm.h"
 
 #include "picolibrary/event.h"
+#include "picolibrary/utility.h"
 
 namespace picolibrary {
 
 HSM::Pseudo_Event_Category const HSM::Pseudo_Event_Category::INSTANCE{};
 
 Simple_Event const HSM::DISCOVERY{ Pseudo_Event_Category::instance(),
-                                   static_cast<Event_ID>( Pseudo_Event::DISCOVERY ) };
+                                   to_underlying( Pseudo_Event::DISCOVERY ) };
 
 Simple_Event const HSM::ENTRY{ Pseudo_Event_Category::instance(),
-                               static_cast<Event_ID>( Pseudo_Event::ENTRY ) };
+                               to_underlying( Pseudo_Event::ENTRY ) };
 
-Simple_Event const HSM::EXIT{ Pseudo_Event_Category::instance(),
-                              static_cast<Event_ID>( Pseudo_Event::EXIT ) };
+Simple_Event const HSM::EXIT{ Pseudo_Event_Category::instance(), to_underlying( Pseudo_Event::EXIT ) };
 
 Simple_Event const HSM::NESTED_INITIAL_TRANSITION{ Pseudo_Event_Category::instance(),
-                                                   static_cast<Event_ID>( Pseudo_Event::NESTED_INITIAL_TRANSITION ) };
+                                                   to_underlying( Pseudo_Event::NESTED_INITIAL_TRANSITION ) };
 
 } // namespace picolibrary

--- a/source/picolibrary/state_machine.cc
+++ b/source/picolibrary/state_machine.cc
@@ -23,15 +23,16 @@
 #include "picolibrary/state_machine.h"
 
 #include "picolibrary/event.h"
+#include "picolibrary/utility.h"
 
 namespace picolibrary {
 
 State_Machine::Pseudo_Event_Category const State_Machine::Pseudo_Event_Category::INSTANCE{};
 
 Simple_Event const State_Machine::ENTRY{ Pseudo_Event_Category::instance(),
-                                         static_cast<Event_ID>( Pseudo_Event::ENTRY ) };
+                                         to_underlying( Pseudo_Event::ENTRY ) };
 
 Simple_Event const State_Machine::EXIT{ Pseudo_Event_Category::instance(),
-                                        static_cast<Event_ID>( Pseudo_Event::EXIT ) };
+                                        to_underlying( Pseudo_Event::EXIT ) };
 
 } // namespace picolibrary

--- a/test/unit/picolibrary/generic_error_category/main.cc
+++ b/test/unit/picolibrary/generic_error_category/main.cc
@@ -23,12 +23,14 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "picolibrary/error.h"
+#include "picolibrary/utility.h"
 
 namespace {
 
 using ::picolibrary::Error_ID;
 using ::picolibrary::Generic_Error;
 using ::picolibrary::Generic_Error_Category;
+using ::picolibrary::to_underlying;
 
 } // namespace
 
@@ -62,14 +64,13 @@ TEST( errorDescription, worksProperly )
 
     for ( auto const test_case : test_cases ) {
         EXPECT_STREQ(
-            Generic_Error_Category::instance().error_description(
-                static_cast<Error_ID>( test_case.id ) ),
+            Generic_Error_Category::instance().error_description( to_underlying( test_case.id ) ),
             test_case.description );
     } // for
 
     EXPECT_STREQ(
         Generic_Error_Category::instance().error_description(
-            static_cast<Error_ID>( Generic_Error::WOULD_UNDERFLOW ) + 1 ),
+            to_underlying( Generic_Error::WOULD_UNDERFLOW ) + 1 ),
         "UNKNOWN" );
 }
 

--- a/test/unit/picolibrary/output_stream/main.cc
+++ b/test/unit/picolibrary/output_stream/main.cc
@@ -35,6 +35,7 @@
 #include "picolibrary/testing/unit/error.h"
 #include "picolibrary/testing/unit/random.h"
 #include "picolibrary/testing/unit/stream.h"
+#include "picolibrary/utility.h"
 #include "picolibrary/void.h"
 
 namespace {
@@ -44,6 +45,7 @@ using ::picolibrary::Error_ID;
 using ::picolibrary::Generic_Error;
 using ::picolibrary::Output_Stream;
 using ::picolibrary::Result;
+using ::picolibrary::to_underlying;
 using ::picolibrary::Void;
 using ::picolibrary::Testing::Unit::Mock_Error;
 using ::picolibrary::Testing::Unit::Mock_Error_Category;
@@ -711,7 +713,7 @@ TEST( outputFormatterErrorCode, worksProperly )
 
     EXPECT_CALL( Mock_Error_Category::instance(), name() )
         .WillOnce( Return( error_category_name.c_str() ) );
-    EXPECT_CALL( Mock_Error_Category::instance(), error_description( static_cast<Error_ID>( error ) ) )
+    EXPECT_CALL( Mock_Error_Category::instance(), error_description( to_underlying( error ) ) )
         .WillOnce( Return( error_description.c_str() ) );
 
     auto const result = stream.print( "{}", Error_Code{ error } );
@@ -767,7 +769,7 @@ TEST( outputFormatterErrorCodeEnum, worksProperly )
 
     EXPECT_CALL( Mock_Error_Category::instance(), name() )
         .WillOnce( Return( error_category_name.c_str() ) );
-    EXPECT_CALL( Mock_Error_Category::instance(), error_description( static_cast<Error_ID>( error ) ) )
+    EXPECT_CALL( Mock_Error_Category::instance(), error_description( to_underlying( error ) ) )
         .WillOnce( Return( error_description.c_str() ) );
 
     auto const result = stream.print( "{}", error );


### PR DESCRIPTION
Resolves #1363 (Replace static casts with enum underlying type
conversion utility calls).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
