### PR TITLE
Replace return type deduction with explicit return types where reasonable

### DIFF
--- a/include/picolibrary/algorithm.h
+++ b/include/picolibrary/algorithm.h
@@ -64,7 +64,7 @@ struct Functor_Can_Fail_Discard_Functor {
  * \return The functor.
  */
 template<typename Iterator, typename Functor>
-constexpr auto for_each( Iterator begin, Iterator end, Functor functor ) noexcept
+constexpr auto for_each( Iterator begin, Iterator end, Functor functor ) noexcept -> Functor
 {
     for ( ; begin != end; ++begin ) { functor( *begin ); } // for
 
@@ -244,7 +244,7 @@ constexpr auto generate( Iterator begin, Iterator end, Functor functor ) noexcep
  *         will be returned.
  */
 template<typename T>
-constexpr auto const & min( T const & a, T const & b ) noexcept
+constexpr auto min( T const & a, T const & b ) noexcept -> T const &
 {
     return b < a ? b : a;
 }
@@ -261,7 +261,7 @@ constexpr auto const & min( T const & a, T const & b ) noexcept
  *         will be returned.
  */
 template<typename T>
-constexpr auto const & max( T const & a, T const & b ) noexcept
+constexpr auto max( T const & a, T const & b ) noexcept -> T const &
 {
     return b > a ? b : a;
 }

--- a/include/picolibrary/array.h
+++ b/include/picolibrary/array.h
@@ -263,7 +263,7 @@ class Array {
      *
      * \return An iterator to the first element of the array.
      */
-    constexpr auto begin() noexcept
+    constexpr auto begin() noexcept -> Iterator
     {
         return data();
     }
@@ -273,7 +273,7 @@ class Array {
      *
      * \return An iterator to the first element of the array.
      */
-    constexpr auto begin() const noexcept
+    constexpr auto begin() const noexcept -> Const_Iterator
     {
         return data();
     }
@@ -283,7 +283,7 @@ class Array {
      *
      * \return An iterator to the first element of the array.
      */
-    constexpr auto cbegin() const noexcept
+    constexpr auto cbegin() const noexcept -> Const_Iterator
     {
         return data();
     }
@@ -296,7 +296,7 @@ class Array {
      *
      * \return An iterator to the element following the last element of the array.
      */
-    constexpr auto end() noexcept
+    constexpr auto end() noexcept -> Iterator
     {
         return begin() + size();
     }
@@ -309,7 +309,7 @@ class Array {
      *
      * \return An iterator to the element following the last element of the array.
      */
-    constexpr auto end() const noexcept
+    constexpr auto end() const noexcept -> Const_Iterator
     {
         return begin() + size();
     }
@@ -322,7 +322,7 @@ class Array {
      *
      * \return An iterator to the element following the last element of the array.
      */
-    constexpr auto cend() const noexcept
+    constexpr auto cend() const noexcept -> Const_Iterator
     {
         return begin() + size();
     }
@@ -332,7 +332,7 @@ class Array {
      *
      * \return An iterator to the first element of the reversed array.
      */
-    constexpr auto rbegin() noexcept
+    constexpr auto rbegin() noexcept -> Reverse_Iterator
     {
         return Reverse_Iterator{ end() };
     }
@@ -342,7 +342,7 @@ class Array {
      *
      * \return An iterator to the first element of the reversed array.
      */
-    constexpr auto rbegin() const noexcept
+    constexpr auto rbegin() const noexcept -> Const_Reverse_Iterator
     {
         return Const_Reverse_Iterator{ end() };
     }
@@ -352,7 +352,7 @@ class Array {
      *
      * \return An iterator to the first element of the reversed array.
      */
-    constexpr auto crbegin() const noexcept
+    constexpr auto crbegin() const noexcept -> Const_Reverse_Iterator
     {
         return Const_Reverse_Iterator{ end() };
     }
@@ -367,7 +367,7 @@ class Array {
      * \return An iterator to the element following the last element of the reversed
      *         array.
      */
-    constexpr auto rend() noexcept
+    constexpr auto rend() noexcept -> Reverse_Iterator
     {
         return Reverse_Iterator{ begin() };
     }
@@ -382,7 +382,7 @@ class Array {
      * \return An iterator to the element following the last element of the reversed
      *         array.
      */
-    constexpr auto rend() const noexcept
+    constexpr auto rend() const noexcept -> Const_Reverse_Iterator
     {
         return Const_Reverse_Iterator{ begin() };
     }
@@ -397,7 +397,7 @@ class Array {
      * \return An iterator to the element following the last element of the reversed
      *         array.
      */
-    constexpr auto crend() const noexcept
+    constexpr auto crend() const noexcept -> Const_Reverse_Iterator
     {
         return Const_Reverse_Iterator{ begin() };
     }
@@ -408,7 +408,7 @@ class Array {
      * \return true if the array is empty.
      * \return false if the array is not empty.
      */
-    [[nodiscard]] constexpr auto empty() const noexcept
+    [[nodiscard]] constexpr auto empty() const noexcept -> bool
     {
         return not size();
     }
@@ -471,7 +471,7 @@ struct array_size<Array<T, N>> : std::integral_constant<std::size_t, N> {
  * \return false if lhs is not equal to rhs.
  */
 template<typename T, std::size_t N>
-constexpr auto operator==( Array<T, N> const & lhs, Array<T, N> const & rhs ) noexcept
+constexpr auto operator==( Array<T, N> const & lhs, Array<T, N> const & rhs ) noexcept -> bool
 {
     return ::picolibrary::equal( lhs.begin(), lhs.end(), rhs.begin() );
 }
@@ -491,7 +491,7 @@ constexpr auto operator==( Array<T, N> const & lhs, Array<T, N> const & rhs ) no
  * \return false if lhs is equal to rhs.
  */
 template<typename T, std::size_t N>
-constexpr auto operator!=( Array<T, N> const & lhs, Array<T, N> const & rhs ) noexcept
+constexpr auto operator!=( Array<T, N> const & lhs, Array<T, N> const & rhs ) noexcept -> bool
 {
     return not( lhs == rhs );
 }

--- a/include/picolibrary/asynchronous_serial/stream.h
+++ b/include/picolibrary/asynchronous_serial/stream.h
@@ -309,7 +309,7 @@ class Unbuffered_Output_Stream : public Output_Stream {
      *
      * \return The assigned to object.
      */
-    constexpr auto & operator=( Unbuffered_Output_Stream && expression ) noexcept
+    constexpr auto operator=( Unbuffered_Output_Stream && expression ) noexcept -> Unbuffered_Output_Stream &
     {
         if ( &expression != this ) {
             m_buffer = std::move( expression.m_buffer );

--- a/include/picolibrary/bit_manipulation.h
+++ b/include/picolibrary/bit_manipulation.h
@@ -40,7 +40,7 @@ namespace picolibrary {
  * \return The value's highest bit set.
  */
 template<typename T>
-constexpr auto highest_bit_set( T value )
+constexpr auto highest_bit_set( T value ) noexcept -> std::uint_fast8_t
 {
     static_assert( std::is_unsigned_v<T> );
 
@@ -62,13 +62,13 @@ constexpr auto highest_bit_set( T value )
  * \return The created bit mask.
  */
 template<typename T>
-constexpr auto mask( std::uint_fast8_t size, std::uint_fast8_t bit ) noexcept
+constexpr auto mask( std::uint_fast8_t size, std::uint_fast8_t bit ) noexcept -> T
 {
     static_assert( std::is_unsigned_v<T> );
 
-    return static_cast<T>(
-        ( static_cast<std::uintmax_t>( std::numeric_limits<T>::max() ) >> ( std::numeric_limits<T>::digits - size ) )
-        << bit );
+    return ( static_cast<std::uintmax_t>( std::numeric_limits<T>::max() )
+             >> ( std::numeric_limits<T>::digits - size ) )
+           << bit;
 }
 
 /**
@@ -81,7 +81,7 @@ constexpr auto mask( std::uint_fast8_t size, std::uint_fast8_t bit ) noexcept
  * \return The reflected value.
  */
 template<typename T>
-auto reflect( T value ) noexcept
+auto reflect( T value ) noexcept -> T
 {
     static_assert( std::is_unsigned_v<T> );
 
@@ -93,7 +93,7 @@ auto reflect( T value ) noexcept
         result |= value & 0b1;
     } // for
 
-    return static_cast<T>( result << remaining_shifts );
+    return result << remaining_shifts;
 }
 
 /**

--- a/include/picolibrary/error.h
+++ b/include/picolibrary/error.h
@@ -76,7 +76,7 @@ class Error_Category {
 #ifndef PICOLIBRARY_SUPPRESS_HUMAN_READABLE_ERROR_INFORMATION
     virtual auto name() const noexcept -> char const * = 0;
 #else  // PICOLIBRARY_SUPPRESS_HUMAN_READABLE_ERROR_INFORMATION
-    constexpr auto const * name() const noexcept
+    constexpr auto name() const noexcept -> char const *
     {
         return "";
     }
@@ -92,7 +92,7 @@ class Error_Category {
 #ifndef PICOLIBRARY_SUPPRESS_HUMAN_READABLE_ERROR_INFORMATION
     virtual auto error_description( Error_ID id ) const noexcept -> char const * = 0;
 #else  // PICOLIBRARY_SUPPRESS_HUMAN_READABLE_ERROR_INFORMATION
-    constexpr auto const * error_description( Error_ID id ) const noexcept
+    constexpr auto error_description( Error_ID id ) const noexcept -> char const *
     {
         static_cast<void>( id );
 
@@ -207,7 +207,7 @@ class Error_Code final {
      *
      * \return The error's category.
      */
-    constexpr auto const & category() const noexcept
+    constexpr auto category() const noexcept -> Error_Category const &
     {
         return *m_category;
     }
@@ -217,7 +217,7 @@ class Error_Code final {
      *
      * \return The error's ID.
      */
-    constexpr auto id() const noexcept
+    constexpr auto id() const noexcept -> Error_ID
     {
         return m_id;
     }
@@ -227,7 +227,7 @@ class Error_Code final {
      *
      * \return The error's description.
      */
-    auto const * description() const noexcept
+    auto description() const noexcept -> char const *
     {
         return category().error_description( id() );
     }
@@ -323,7 +323,7 @@ class Error_Code final {
  * \return true if lhs is equal to rhs.
  * \return false if lhs is not equal to rhs.
  */
-constexpr auto operator==( Error_Code const & lhs, Error_Code const & rhs ) noexcept
+constexpr auto operator==( Error_Code const & lhs, Error_Code const & rhs ) noexcept -> bool
 {
     return &lhs.category() == &rhs.category() and lhs.id() == rhs.id();
 }
@@ -339,7 +339,7 @@ constexpr auto operator==( Error_Code const & lhs, Error_Code const & rhs ) noex
  * \return true if lhs is not equal to rhs.
  * \return false if lhs is equal to rhs.
  */
-constexpr auto operator!=( Error_Code const & lhs, Error_Code const & rhs ) noexcept
+constexpr auto operator!=( Error_Code const & lhs, Error_Code const & rhs ) noexcept -> bool
 {
     return not( lhs == rhs );
 }
@@ -375,7 +375,7 @@ class Generic_Error_Category final : public Error_Category {
      *
      * \return A reference to the generic error category instance.
      */
-    static constexpr auto const & instance() noexcept
+    static constexpr auto instance() noexcept -> Generic_Error_Category const &
     {
         return INSTANCE;
     }
@@ -460,7 +460,7 @@ class Generic_Error_Category final : public Error_Category {
  *
  * \return The constructed error code.
  */
-inline auto make_error_code( Generic_Error error ) noexcept
+inline auto make_error_code( Generic_Error error ) noexcept -> Error_Code
 {
     return Error_Code{ Generic_Error_Category::instance(), to_underlying( error ) };
 }

--- a/include/picolibrary/event.h
+++ b/include/picolibrary/event.h
@@ -62,7 +62,7 @@ class Event_Category {
 #ifndef PICOLIBRARY_SUPPRESS_HUMAN_READABLE_EVENT_INFORMATION
     virtual auto name() const noexcept -> char const * = 0;
 #else  // PICOLIBRARY_SUPPRESS_HUMAN_READABLE_EVENT_INFORMATION
-    constexpr auto const * name() const noexcept
+    constexpr auto name() const noexcept -> char const *
     {
         return "";
     }
@@ -78,7 +78,7 @@ class Event_Category {
 #ifndef PICOLIBRARY_SUPPRESS_HUMAN_READABLE_EVENT_INFORMATION
     virtual auto event_description( Event_ID id ) const noexcept -> char const * = 0;
 #else  // PICOLIBRARY_SUPPRESS_HUMAN_READABLE_EVENT_INFORMATION
-    constexpr auto const * event_description( Event_ID id ) const noexcept
+    constexpr auto event_description( Event_ID id ) const noexcept -> char const *
     {
         static_cast<void>( id );
 
@@ -115,7 +115,7 @@ class Event {
      *
      * \return The event's category.
      */
-    constexpr auto const & category() const noexcept
+    constexpr auto category() const noexcept -> Event_Category const &
     {
         return *m_category;
     }
@@ -125,7 +125,7 @@ class Event {
      *
      * \return The event's ID.
      */
-    constexpr auto id() const noexcept
+    constexpr auto id() const noexcept -> Event_ID
     {
         return m_id;
     }
@@ -135,7 +135,7 @@ class Event {
      *
      * \return The event's description.
      */
-    auto const * description() const noexcept
+    auto description() const noexcept -> char const *
     {
         return category().event_description( id() );
     }
@@ -254,7 +254,7 @@ class Output_Formatter<Event> {
      *
      * \return format
      */
-    constexpr auto parse( char const * format ) noexcept
+    constexpr auto parse( char const * format ) noexcept -> char const *
     {
         return format;
     }
@@ -422,7 +422,7 @@ class Event_Storage {
      *
      * \return The stored event.
      */
-    auto & event() noexcept
+    auto event() noexcept -> Event &
     {
         return *std::launder( reinterpret_cast<Event *>( &m_storage ) );
     }
@@ -432,7 +432,7 @@ class Event_Storage {
      *
      * \return The stored event.
      */
-    auto const & event() const noexcept
+    auto event() const noexcept -> Event const &
     {
         return *std::launder( reinterpret_cast<Event const *>( &m_storage ) );
     }

--- a/include/picolibrary/fixed_capacity_vector.h
+++ b/include/picolibrary/fixed_capacity_vector.h
@@ -220,7 +220,7 @@ class Fixed_Capacity_Vector {
      *
      * \return The assigned to object.
      */
-    constexpr auto & operator=( std::initializer_list<Value> initializer_list ) noexcept
+    constexpr auto operator=( std::initializer_list<Value> initializer_list ) noexcept -> Fixed_Capacity_Vector
     {
         assign( initializer_list );
 
@@ -234,7 +234,7 @@ class Fixed_Capacity_Vector {
      *
      * \return The assigned to object.
      */
-    constexpr auto & operator=( Fixed_Capacity_Vector && expression ) noexcept
+    constexpr auto operator=( Fixed_Capacity_Vector && expression ) noexcept -> Fixed_Capacity_Vector
     {
         if ( &expression != this ) {
             clear();
@@ -259,7 +259,7 @@ class Fixed_Capacity_Vector {
      *
      * \return The assigned to object.
      */
-    constexpr auto & operator=( Fixed_Capacity_Vector const & expression ) noexcept
+    constexpr auto operator=( Fixed_Capacity_Vector const & expression ) noexcept -> Fixed_Capacity_Vector
     {
         if ( &expression != this ) {
             clear();
@@ -672,7 +672,7 @@ class Fixed_Capacity_Vector {
      *
      * \return An iterator to the inserted element.
      */
-    auto insert( Const_Iterator position, Value const & value ) noexcept
+    auto insert( Const_Iterator position, Value const & value ) noexcept -> Iterator
     {
         return insert( position, 1, value );
     }
@@ -690,7 +690,7 @@ class Fixed_Capacity_Vector {
      *
      * \return An iterator to the inserted element.
      */
-    auto insert( Const_Iterator position, Value && value ) noexcept
+    auto insert( Const_Iterator position, Value && value ) noexcept -> Iterator
     {
         expect( size() + 1 > size() and size() + 1 <= max_size(), Generic_Error::INSUFFICIENT_CAPACITY );
 
@@ -725,7 +725,7 @@ class Fixed_Capacity_Vector {
      *
      * \return An iterator to the inserted elements.
      */
-    auto insert( Const_Iterator position, Size n, Value const & value ) noexcept
+    auto insert( Const_Iterator position, Size n, Value const & value ) noexcept -> Iterator
     {
         expect( size() + n > size() and size() + n <= max_size(), Generic_Error::INSUFFICIENT_CAPACITY );
 
@@ -766,7 +766,7 @@ class Fixed_Capacity_Vector {
      * \return An iterator to the inserted elements.
      */
     template<typename Iterator>
-    auto insert( Const_Iterator position, Iterator begin, Iterator end ) noexcept
+    auto insert( Const_Iterator position, Iterator begin, Iterator end ) noexcept -> Iterator
     {
         auto const n = static_cast<Size>( end - begin );
 
@@ -805,7 +805,7 @@ class Fixed_Capacity_Vector {
      *
      * \return An iterator to the inserted elements.
      */
-    auto insert( Const_Iterator position, std::initializer_list<Value> initializer_list ) noexcept
+    auto insert( Const_Iterator position, std::initializer_list<Value> initializer_list ) noexcept -> Iterator
     {
         return insert( position, initializer_list.begin(), initializer_list.end() );
     }
@@ -826,7 +826,7 @@ class Fixed_Capacity_Vector {
      * \return An iterator to the emplaced element.
      */
     template<typename... Arguments>
-    auto emplace( Const_Iterator position, Arguments &&... arguments ) noexcept
+    auto emplace( Const_Iterator position, Arguments &&... arguments ) noexcept -> Iterator
     {
         expect( size() + 1 > size() and size() + 1 <= max_size(), Generic_Error::INSUFFICIENT_CAPACITY );
 
@@ -854,7 +854,7 @@ class Fixed_Capacity_Vector {
      *
      * \return An iterator to the element following the removed element.
      */
-    auto erase( Const_Iterator position ) noexcept
+    auto erase( Const_Iterator position ) noexcept -> Iterator
     {
         auto element = begin() + ( position - begin() );
 
@@ -879,7 +879,7 @@ class Fixed_Capacity_Vector {
      *
      * \return An iterator to the element following the removed elements.
      */
-    auto erase( Const_Iterator begin, Const_Iterator end ) noexcept
+    auto erase( Const_Iterator begin, Const_Iterator end ) noexcept -> Iterator
     {
         auto const n = end - begin();
 
@@ -1120,7 +1120,8 @@ constexpr auto operator==( Fixed_Capacity_Vector<T, LHS_N> const & lhs, Fixed_Ca
  * \return false if lhs is equal to rhs.
  */
 template<typename T, std::size_t LHS_N, std::size_t RHS_N>
-constexpr auto operator==( Fixed_Capacity_Vector<T, LHS_N> const & lhs, Fixed_Capacity_Vector<T, RHS_N> const & rhs ) noexcept
+constexpr auto operator!=( Fixed_Capacity_Vector<T, LHS_N> const & lhs, Fixed_Capacity_Vector<T, RHS_N> const & rhs ) noexcept
+    -> bool
 {
     return not( lhs == rhs );
 }

--- a/include/picolibrary/fixed_capacity_vector.h
+++ b/include/picolibrary/fixed_capacity_vector.h
@@ -220,7 +220,7 @@ class Fixed_Capacity_Vector {
      *
      * \return The assigned to object.
      */
-    constexpr auto operator=( std::initializer_list<Value> initializer_list ) noexcept -> Fixed_Capacity_Vector
+    constexpr auto operator=( std::initializer_list<Value> initializer_list ) noexcept -> Fixed_Capacity_Vector &
     {
         assign( initializer_list );
 
@@ -234,7 +234,7 @@ class Fixed_Capacity_Vector {
      *
      * \return The assigned to object.
      */
-    constexpr auto operator=( Fixed_Capacity_Vector && expression ) noexcept -> Fixed_Capacity_Vector
+    constexpr auto operator=( Fixed_Capacity_Vector && expression ) noexcept -> Fixed_Capacity_Vector &
     {
         if ( &expression != this ) {
             clear();
@@ -259,7 +259,7 @@ class Fixed_Capacity_Vector {
      *
      * \return The assigned to object.
      */
-    constexpr auto operator=( Fixed_Capacity_Vector const & expression ) noexcept -> Fixed_Capacity_Vector
+    constexpr auto operator=( Fixed_Capacity_Vector const & expression ) noexcept -> Fixed_Capacity_Vector &
     {
         if ( &expression != this ) {
             clear();

--- a/include/picolibrary/fixed_capacity_vector.h
+++ b/include/picolibrary/fixed_capacity_vector.h
@@ -220,7 +220,8 @@ class Fixed_Capacity_Vector {
      *
      * \return The assigned to object.
      */
-    constexpr auto operator=( std::initializer_list<Value> initializer_list ) noexcept -> Fixed_Capacity_Vector &
+    constexpr auto operator=( std::initializer_list<Value> initializer_list ) noexcept
+        -> Fixed_Capacity_Vector &
     {
         assign( initializer_list );
 

--- a/include/picolibrary/format.h
+++ b/include/picolibrary/format.h
@@ -305,7 +305,7 @@ class Output_Formatter<Format::Binary<Integer>> {
      *
      * \return format
      */
-    constexpr auto parse( char const * format ) noexcept
+    constexpr auto parse( char const * format ) noexcept -> char const *
     {
         return format;
     }
@@ -390,7 +390,7 @@ class Output_Formatter<Format::Decimal<Integer>, std::enable_if_t<std::is_signed
      *
      * \return format
      */
-    constexpr auto parse( char const * format ) noexcept
+    constexpr auto parse( char const * format ) noexcept -> char const *
     {
         return format;
     }
@@ -474,7 +474,7 @@ class Output_Formatter<Format::Decimal<Integer>, std::enable_if_t<std::is_unsign
      *
      * \return format
      */
-    constexpr auto parse( char const * format ) noexcept
+    constexpr auto parse( char const * format ) noexcept -> char const *
     {
         return format;
     }
@@ -547,7 +547,7 @@ class Output_Formatter<Format::Hexadecimal<Integer>> {
      *
      * \return format
      */
-    constexpr auto parse( char const * format ) noexcept
+    constexpr auto parse( char const * format ) noexcept -> char const *
     {
         return format;
     }

--- a/include/picolibrary/gpio.h
+++ b/include/picolibrary/gpio.h
@@ -367,7 +367,7 @@ class Active_Low_Input_Pin : public Input_Pin {
      * \return true if the pin is in the high state.
      * \return false if the pin is not in the high state.
      */
-    auto is_low() const noexcept
+    auto is_low() const noexcept -> bool
     {
         return Input_Pin::is_high();
     }
@@ -378,7 +378,7 @@ class Active_Low_Input_Pin : public Input_Pin {
      * \return true if the pin is in the low state.
      * \return false if the pin is not in the low state.
      */
-    auto is_high() const noexcept
+    auto is_high() const noexcept -> bool
     {
         return Input_Pin::is_low();
     }

--- a/include/picolibrary/hsm.h
+++ b/include/picolibrary/hsm.h
@@ -60,7 +60,7 @@ class HSM {
          *
          * \return A reference to the pseudo-event category instance.
          */
-        static constexpr auto const & instance() noexcept
+        static constexpr auto instance() noexcept -> Pseudo_Event_Category const &
         {
             return INSTANCE;
         }
@@ -318,7 +318,7 @@ class HSM {
      *
      * \return Event ignored event handling result.
      */
-    static constexpr auto top( HSM & hsm, Event const & event ) noexcept
+    static constexpr auto top( HSM & hsm, Event const & event ) noexcept -> Event_Handling_Result
     {
         return hsm.event_ignored( event );
     }
@@ -330,7 +330,7 @@ class HSM {
      *
      * \return Event handled event handling result.
      */
-    constexpr auto event_handled( Event const & handled_event ) const noexcept
+    constexpr auto event_handled( Event const & handled_event ) const noexcept -> Event_Handling_Result
     {
         static_cast<void>( handled_event );
 
@@ -347,6 +347,7 @@ class HSM {
      * \return State transition triggered event handling result.
      */
     constexpr auto transition_to( State_Event_Handler_Reference target_state, Event const & triggering_event ) noexcept
+        -> Event_Handling_Result
     {
         static_cast<void>( triggering_event );
 
@@ -365,6 +366,7 @@ class HSM {
      * \return Event handling deferred to superstate event handling result.
      */
     constexpr auto defer_event_handling_to( State_Event_Handler_Reference superstate, Event const & deferred_event ) noexcept
+        -> Event_Handling_Result
     {
         static_cast<void>( deferred_event );
 
@@ -485,7 +487,7 @@ class HSM {
      *
      * \return The state event handler for the currently active state.
      */
-    constexpr auto current_state() const noexcept
+    constexpr auto current_state() const noexcept -> State_Event_Handler_Pointer
     {
         return m_current_state;
     }
@@ -502,7 +504,7 @@ class HSM {
      * \return false if state is neither the state event handler for the currently active
      *         state nor any of its superstates.
      */
-    auto is_in( State_Event_Handler_Reference state ) noexcept
+    auto is_in( State_Event_Handler_Reference state ) noexcept -> bool
     {
         Path path;
 

--- a/include/picolibrary/i2c.h
+++ b/include/picolibrary/i2c.h
@@ -60,7 +60,7 @@ class Address_Numeric {
      *
      * \return The minimum valid address.
      */
-    static constexpr auto min() noexcept
+    static constexpr auto min() noexcept -> Address_Numeric
     {
         return Address_Numeric{ BYPASS_PRECONDITION_EXPECTATION_CHECKS, 0b0000000 };
     }
@@ -70,7 +70,7 @@ class Address_Numeric {
      *
      * \return The maximum valid address.
      */
-    static constexpr auto max() noexcept
+    static constexpr auto max() noexcept -> Address_Numeric
     {
         return Address_Numeric{ BYPASS_PRECONDITION_EXPECTATION_CHECKS, 0b1111111 };
     }
@@ -176,7 +176,7 @@ class Address_Transmitted {
      *
      * \return The minimum valid address.
      */
-    static constexpr auto min() noexcept
+    static constexpr auto min() noexcept -> Address_Transmitted
     {
         return Address_Transmitted{ BYPASS_PRECONDITION_EXPECTATION_CHECKS, 0b0000000'0 };
     }
@@ -186,7 +186,7 @@ class Address_Transmitted {
      *
      * \return The maximum valid address.
      */
-    static constexpr auto max() noexcept
+    static constexpr auto max() noexcept -> Address_Transmitted
     {
         return Address_Transmitted{ BYPASS_PRECONDITION_EXPECTATION_CHECKS, 0b1111111'0 };
     }
@@ -270,7 +270,7 @@ class Address_Transmitted {
      *
      * \return The address in its unsigned integer representation.
      */
-    constexpr auto as_unsigned_integer() const noexcept
+    constexpr auto as_unsigned_integer() const noexcept -> Unsigned_Integer
     {
         return m_address;
     }
@@ -298,7 +298,7 @@ constexpr Address_Numeric::Address_Numeric( Address_Transmitted address ) noexce
  * \return true if lhs is equal to rhs.
  * \return false if lhs is not equal to rhs.
  */
-constexpr auto operator==( Address_Numeric lhs, Address_Numeric rhs ) noexcept
+constexpr auto operator==( Address_Numeric lhs, Address_Numeric rhs ) noexcept -> bool
 {
     return lhs.as_unsigned_integer() == rhs.as_unsigned_integer();
 }
@@ -314,7 +314,7 @@ constexpr auto operator==( Address_Numeric lhs, Address_Numeric rhs ) noexcept
  * \return true if lhs is not equal to rhs.
  * \return false if lhs is equal to rhs.
  */
-constexpr auto operator!=( Address_Numeric lhs, Address_Numeric rhs ) noexcept
+constexpr auto operator!=( Address_Numeric lhs, Address_Numeric rhs ) noexcept -> bool
 {
     return not( lhs == rhs );
 }
@@ -330,7 +330,7 @@ constexpr auto operator!=( Address_Numeric lhs, Address_Numeric rhs ) noexcept
  * \return true if lhs is less than rhs.
  * \return false if lhs is not less than rhs.
  */
-constexpr auto operator<( Address_Numeric lhs, Address_Numeric rhs ) noexcept
+constexpr auto operator<( Address_Numeric lhs, Address_Numeric rhs ) noexcept -> bool
 {
     return lhs.as_unsigned_integer() < rhs.as_unsigned_integer();
 }
@@ -346,7 +346,7 @@ constexpr auto operator<( Address_Numeric lhs, Address_Numeric rhs ) noexcept
  * \return true if lhs is greater than rhs.
  * \return false if lhs is not greater than rhs.
  */
-constexpr auto operator>( Address_Numeric lhs, Address_Numeric rhs ) noexcept
+constexpr auto operator>( Address_Numeric lhs, Address_Numeric rhs ) noexcept -> bool
 {
     return rhs < lhs;
 }
@@ -362,7 +362,7 @@ constexpr auto operator>( Address_Numeric lhs, Address_Numeric rhs ) noexcept
  * \return true if lhs is less than or equal to rhs.
  * \return false if lhs is not less than or equal to rhs.
  */
-constexpr auto operator<=( Address_Numeric lhs, Address_Numeric rhs ) noexcept
+constexpr auto operator<=( Address_Numeric lhs, Address_Numeric rhs ) noexcept -> bool
 {
     return not( lhs > rhs );
 }
@@ -378,7 +378,7 @@ constexpr auto operator<=( Address_Numeric lhs, Address_Numeric rhs ) noexcept
  * \return true if lhs is greater than or equal to rhs.
  * \return false if lhs is not greater than or equal to rhs.
  */
-constexpr auto operator>=( Address_Numeric lhs, Address_Numeric rhs ) noexcept
+constexpr auto operator>=( Address_Numeric lhs, Address_Numeric rhs ) noexcept -> bool
 {
     return not( lhs < rhs );
 }
@@ -399,7 +399,7 @@ constexpr Address_Transmitted::Address_Transmitted( Address_Numeric address ) no
  * \return true if lhs is equal to rhs.
  * \return false if lhs is not equal to rhs.
  */
-constexpr auto operator==( Address_Transmitted lhs, Address_Transmitted rhs ) noexcept
+constexpr auto operator==( Address_Transmitted lhs, Address_Transmitted rhs ) noexcept -> bool
 {
     return lhs.as_unsigned_integer() == rhs.as_unsigned_integer();
 }
@@ -415,7 +415,7 @@ constexpr auto operator==( Address_Transmitted lhs, Address_Transmitted rhs ) no
  * \return true if lhs is not equal to rhs.
  * \return false if lhs is equal to rhs.
  */
-constexpr auto operator!=( Address_Transmitted lhs, Address_Transmitted rhs ) noexcept
+constexpr auto operator!=( Address_Transmitted lhs, Address_Transmitted rhs ) noexcept -> bool
 {
     return not( lhs == rhs );
 }
@@ -431,7 +431,7 @@ constexpr auto operator!=( Address_Transmitted lhs, Address_Transmitted rhs ) no
  * \return true if lhs is less than rhs.
  * \return false if lhs is not less than rhs.
  */
-constexpr auto operator<( Address_Transmitted lhs, Address_Transmitted rhs ) noexcept
+constexpr auto operator<( Address_Transmitted lhs, Address_Transmitted rhs ) noexcept -> bool
 {
     return lhs.as_unsigned_integer() < rhs.as_unsigned_integer();
 }
@@ -447,7 +447,7 @@ constexpr auto operator<( Address_Transmitted lhs, Address_Transmitted rhs ) noe
  * \return true if lhs is greater than rhs.
  * \return false if lhs is not greater than rhs.
  */
-constexpr auto operator>( Address_Transmitted lhs, Address_Transmitted rhs ) noexcept
+constexpr auto operator>( Address_Transmitted lhs, Address_Transmitted rhs ) noexcept -> bool
 {
     return rhs < lhs;
 }
@@ -463,7 +463,7 @@ constexpr auto operator>( Address_Transmitted lhs, Address_Transmitted rhs ) noe
  * \return true if lhs is less than or equal to rhs.
  * \return false if lhs is not less than or equal to rhs.
  */
-constexpr auto operator<=( Address_Transmitted lhs, Address_Transmitted rhs ) noexcept
+constexpr auto operator<=( Address_Transmitted lhs, Address_Transmitted rhs ) noexcept -> bool
 {
     return not( lhs > rhs );
 }
@@ -479,7 +479,7 @@ constexpr auto operator<=( Address_Transmitted lhs, Address_Transmitted rhs ) no
  * \return true if lhs is greater than or equal to rhs.
  * \return false if lhs is not greater than or equal to rhs.
  */
-constexpr auto operator>=( Address_Transmitted lhs, Address_Transmitted rhs ) noexcept
+constexpr auto operator>=( Address_Transmitted lhs, Address_Transmitted rhs ) noexcept -> bool
 {
     return not( lhs < rhs );
 }
@@ -820,6 +820,7 @@ class Bus_Control_Guard {
  */
 template<typename Controller>
 auto ping( Controller & controller, Address_Transmitted address, Operation operation ) noexcept
+    -> Response
 {
     auto const guard = Bus_Control_Guard{ controller };
 
@@ -844,7 +845,7 @@ auto ping( Controller & controller, Address_Transmitted address, Operation opera
  * \return picolibrary::I2C::Response::NACK if the device is not responsive.
  */
 template<typename Controller>
-auto ping( Controller & controller, Address_Transmitted address ) noexcept
+auto ping( Controller & controller, Address_Transmitted address ) noexcept -> Response
 {
     auto const response_read  = ping( controller, address, Operation::READ );
     auto const response_write = ping( controller, address, Operation::WRITE );
@@ -866,7 +867,7 @@ auto ping( Controller & controller, Address_Transmitted address ) noexcept
  * \return The functor.
  */
 template<typename Controller, typename Functor>
-auto scan( Controller & controller, Functor functor ) noexcept
+auto scan( Controller & controller, Functor functor ) noexcept -> Functor
 {
     Operation const operations[]{
         Operation::READ,
@@ -1030,7 +1031,7 @@ class Device_Address_Numeric : public Address_Numeric {
      *
      * \return The minimum valid address.
      */
-    static constexpr auto min() noexcept
+    static constexpr auto min() noexcept -> Device_Address_Numeric
     {
         return Device_Address_Numeric{ BYPASS_PRECONDITION_EXPECTATION_CHECKS, MIN };
     }
@@ -1040,7 +1041,7 @@ class Device_Address_Numeric : public Address_Numeric {
      *
      * \return The maximum valid address.
      */
-    static constexpr auto max() noexcept
+    static constexpr auto max() noexcept -> Device_Address_Numeric
     {
         return Device_Address_Numeric{ BYPASS_PRECONDITION_EXPECTATION_CHECKS, MAX };
     }
@@ -1146,7 +1147,7 @@ class Device_Address_Transmitted : public Address_Transmitted {
      *
      * \return The minimum valid address.
      */
-    static constexpr auto min() noexcept
+    static constexpr auto min() noexcept -> Device_Address_Transmitted
     {
         return Device_Address_Transmitted{ BYPASS_PRECONDITION_EXPECTATION_CHECKS, MIN };
     }
@@ -1156,7 +1157,7 @@ class Device_Address_Transmitted : public Address_Transmitted {
      *
      * \return The maximum valid address.
      */
-    static constexpr auto max() noexcept
+    static constexpr auto max() noexcept -> Device_Address_Transmitted
     {
         return Device_Address_Transmitted{ BYPASS_PRECONDITION_EXPECTATION_CHECKS, MAX };
     }
@@ -1314,7 +1315,7 @@ class Device {
      *
      * \return The device's address.
      */
-    constexpr auto address() const noexcept
+    constexpr auto address() const noexcept -> Address_Transmitted
     {
         return m_address;
     }
@@ -1326,7 +1327,7 @@ class Device {
      * \return The fatal error that occurs if the device does not respond when addressed
      *         or does not acknowledge a write.
      */
-    constexpr auto const & nonresponsive_device_error() const noexcept
+    constexpr auto nonresponsive_device_error() const noexcept -> Error_Code const &
     {
         return m_nonresponsive_device_error;
     }
@@ -1339,7 +1340,7 @@ class Device {
      * \return picolibrary::I2C::Response::ACK if the device is responsive.
      * \return picolibrary::I2C::Response::NACK if the device is not responsive.
      */
-    auto ping( Operation operation ) const noexcept
+    auto ping( Operation operation ) const noexcept -> Response
     {
         align_bus_multiplexer();
 
@@ -1352,7 +1353,7 @@ class Device {
      * \return picolibrary::I2C::Response::ACK if the device is responsive.
      * \return picolibrary::I2C::Response::NACK if the device is not responsive.
      */
-    auto ping() const noexcept
+    auto ping() const noexcept -> Response
     {
         align_bus_multiplexer();
 
@@ -1412,7 +1413,7 @@ class Device {
      *
      * \return The assigned to object.
      */
-    constexpr auto & operator=( Device && expression ) noexcept
+    constexpr auto operator=( Device && expression ) noexcept -> Device &
     {
         if ( &expression != this ) {
             m_align_bus_multiplexer = std::move( expression.m_align_bus_multiplexer );
@@ -1440,7 +1441,7 @@ class Device {
      *
      * \return The controller used to communicate with the device.
      */
-    constexpr auto & controller() const noexcept
+    constexpr auto controller() const noexcept -> Controller &
     {
         return *m_controller;
     }
@@ -1454,7 +1455,7 @@ class Device {
      *
      * \return The data read from the register.
      */
-    auto read( std::uint8_t register_address ) const noexcept
+    auto read( std::uint8_t register_address ) const noexcept -> std::uint8_t
     {
         m_align_bus_multiplexer();
 

--- a/include/picolibrary/microchip/mcp23008.h
+++ b/include/picolibrary/microchip/mcp23008.h
@@ -137,7 +137,7 @@ class Driver : public Device {
      *
      * \return The data read from the IODIR register.
      */
-    auto read_iodir() const noexcept
+    auto read_iodir() const noexcept -> std::uint8_t
     {
         return this->read( IODIR::ADDRESS );
     }
@@ -161,7 +161,7 @@ class Driver : public Device {
      *
      * \return The data read from the IPOL register.
      */
-    auto read_ipol() const noexcept
+    auto read_ipol() const noexcept -> std::uint8_t
     {
         return this->read( IPOL::ADDRESS );
     }
@@ -185,7 +185,7 @@ class Driver : public Device {
      *
      * \return The data read from the GPINTEN register.
      */
-    auto read_gpinten() const noexcept
+    auto read_gpinten() const noexcept -> std::uint8_t
     {
         return this->read( GPINTEN::ADDRESS );
     }
@@ -209,7 +209,7 @@ class Driver : public Device {
      *
      * \return The data read from the DEFVAL register.
      */
-    auto read_defval() const noexcept
+    auto read_defval() const noexcept -> std::uint8_t
     {
         return this->read( DEFVAL::ADDRESS );
     }
@@ -233,7 +233,7 @@ class Driver : public Device {
      *
      * \return The data read from the INTCON register.
      */
-    auto read_intcon() const noexcept
+    auto read_intcon() const noexcept -> std::uint8_t
     {
         return this->read( INTCON::ADDRESS );
     }
@@ -257,7 +257,7 @@ class Driver : public Device {
      *
      * \return The data read from the IOCON register.
      */
-    auto read_iocon() const noexcept
+    auto read_iocon() const noexcept -> std::uint8_t
     {
         return this->read( IOCON::ADDRESS );
     }
@@ -281,7 +281,7 @@ class Driver : public Device {
      *
      * \return The data read from the GPPU register.
      */
-    auto read_gppu() const noexcept
+    auto read_gppu() const noexcept -> std::uint8_t
     {
         return this->read( GPPU::ADDRESS );
     }
@@ -305,7 +305,7 @@ class Driver : public Device {
      *
      * \return The data read from the INTF register.
      */
-    auto read_intf() const noexcept
+    auto read_intf() const noexcept -> std::uint8_t
     {
         return this->read( INTF::ADDRESS );
     }
@@ -317,7 +317,7 @@ class Driver : public Device {
      *
      * \return The data read from the INTCAP register.
      */
-    auto read_intcap() const noexcept
+    auto read_intcap() const noexcept -> std::uint8_t
     {
         return this->read( INTCAP::ADDRESS );
     }
@@ -329,7 +329,7 @@ class Driver : public Device {
      *
      * \return The data read from the GPIO register.
      */
-    auto read_gpio() const noexcept
+    auto read_gpio() const noexcept -> std::uint8_t
     {
         return this->read( GPIO::ADDRESS );
     }
@@ -353,7 +353,7 @@ class Driver : public Device {
      *
      * \return The data read from the OLAT register.
      */
-    auto read_olat() const noexcept
+    auto read_olat() const noexcept -> std::uint8_t
     {
         return this->read( OLAT::ADDRESS );
     }

--- a/include/picolibrary/microchip/mcp23s08.h
+++ b/include/picolibrary/microchip/mcp23s08.h
@@ -81,7 +81,7 @@ class Address_Numeric {
      *
      * \return The minimum valid address.
      */
-    static constexpr auto min() noexcept
+    static constexpr auto min() noexcept -> Address_Numeric
     {
         return Address_Numeric{ BYPASS_PRECONDITION_EXPECTATION_CHECKS, 0b01000'00 };
     }
@@ -91,7 +91,7 @@ class Address_Numeric {
      *
      * \return The maximum valid address.
      */
-    static constexpr auto max() noexcept
+    static constexpr auto max() noexcept -> Address_Numeric
     {
         return Address_Numeric{ BYPASS_PRECONDITION_EXPECTATION_CHECKS, 0b01000'11 };
     }
@@ -200,7 +200,7 @@ class Address_Transmitted {
      *
      * \return The minimum valid address.
      */
-    static constexpr auto min() noexcept
+    static constexpr auto min() noexcept -> Address_Transmitted
     {
         return Address_Transmitted{ BYPASS_PRECONDITION_EXPECTATION_CHECKS, 0b01000'00'0 };
     }
@@ -210,7 +210,7 @@ class Address_Transmitted {
      *
      * \return The maximum valid address.
      */
-    static constexpr auto max() noexcept
+    static constexpr auto max() noexcept -> Address_Transmitted
     {
         return Address_Transmitted{ BYPASS_PRECONDITION_EXPECTATION_CHECKS, 0b01000'11'0 };
     }
@@ -327,7 +327,7 @@ constexpr Address_Numeric::Address_Numeric( Address_Transmitted address ) noexce
  * \return true if lhs is equal to rhs.
  * \return false if lhs is not equal to rhs.
  */
-constexpr auto operator==( Address_Numeric lhs, Address_Numeric rhs ) noexcept
+constexpr auto operator==( Address_Numeric lhs, Address_Numeric rhs ) noexcept -> bool
 {
     return lhs.as_unsigned_integer() == rhs.as_unsigned_integer();
 }
@@ -343,7 +343,7 @@ constexpr auto operator==( Address_Numeric lhs, Address_Numeric rhs ) noexcept
  * \return true if lhs is not equal to rhs.
  * \return false if lhs is equal to rhs.
  */
-constexpr auto operator!=( Address_Numeric lhs, Address_Numeric rhs ) noexcept
+constexpr auto operator!=( Address_Numeric lhs, Address_Numeric rhs ) noexcept -> bool
 {
     return not( lhs == rhs );
 }
@@ -359,7 +359,7 @@ constexpr auto operator!=( Address_Numeric lhs, Address_Numeric rhs ) noexcept
  * \return true if lhs is less than rhs.
  * \return false if lhs is not less than rhs.
  */
-constexpr auto operator<( Address_Numeric lhs, Address_Numeric rhs ) noexcept
+constexpr auto operator<( Address_Numeric lhs, Address_Numeric rhs ) noexcept -> bool
 {
     return lhs.as_unsigned_integer() < rhs.as_unsigned_integer();
 }
@@ -375,7 +375,7 @@ constexpr auto operator<( Address_Numeric lhs, Address_Numeric rhs ) noexcept
  * \return true if lhs is greater than rhs.
  * \return false if lhs is not greater than rhs.
  */
-constexpr auto operator>( Address_Numeric lhs, Address_Numeric rhs ) noexcept
+constexpr auto operator>( Address_Numeric lhs, Address_Numeric rhs ) noexcept -> bool
 {
     return rhs < lhs;
 }
@@ -391,7 +391,7 @@ constexpr auto operator>( Address_Numeric lhs, Address_Numeric rhs ) noexcept
  * \return true if lhs is less than or equal to rhs.
  * \return false if lhs is not less than or equal to rhs.
  */
-constexpr auto operator<=( Address_Numeric lhs, Address_Numeric rhs ) noexcept
+constexpr auto operator<=( Address_Numeric lhs, Address_Numeric rhs ) noexcept -> bool
 {
     return not( lhs > rhs );
 }
@@ -407,7 +407,7 @@ constexpr auto operator<=( Address_Numeric lhs, Address_Numeric rhs ) noexcept
  * \return true if lhs is greater than or equal to rhs.
  * \return false if lhs is not greater than or equal to rhs.
  */
-constexpr auto operator>=( Address_Numeric lhs, Address_Numeric rhs ) noexcept
+constexpr auto operator>=( Address_Numeric lhs, Address_Numeric rhs ) noexcept -> bool
 {
     return not( lhs < rhs );
 }
@@ -428,7 +428,7 @@ constexpr Address_Transmitted::Address_Transmitted( Address_Numeric address ) no
  * \return true if lhs is equal to rhs.
  * \return false if lhs is not equal to rhs.
  */
-constexpr auto operator==( Address_Transmitted lhs, Address_Transmitted rhs ) noexcept
+constexpr auto operator==( Address_Transmitted lhs, Address_Transmitted rhs ) noexcept -> bool
 {
     return lhs.as_unsigned_integer() == rhs.as_unsigned_integer();
 }
@@ -444,7 +444,7 @@ constexpr auto operator==( Address_Transmitted lhs, Address_Transmitted rhs ) no
  * \return true if lhs is not equal to rhs.
  * \return false if lhs is equal to rhs.
  */
-constexpr auto operator!=( Address_Transmitted lhs, Address_Transmitted rhs ) noexcept
+constexpr auto operator!=( Address_Transmitted lhs, Address_Transmitted rhs ) noexcept -> bool
 {
     return not( lhs == rhs );
 }
@@ -460,7 +460,7 @@ constexpr auto operator!=( Address_Transmitted lhs, Address_Transmitted rhs ) no
  * \return true if lhs is less than rhs.
  * \return false if lhs is not less than rhs.
  */
-constexpr auto operator<( Address_Transmitted lhs, Address_Transmitted rhs ) noexcept
+constexpr auto operator<( Address_Transmitted lhs, Address_Transmitted rhs ) noexcept -> bool
 {
     return lhs.as_unsigned_integer() < rhs.as_unsigned_integer();
 }
@@ -476,7 +476,7 @@ constexpr auto operator<( Address_Transmitted lhs, Address_Transmitted rhs ) noe
  * \return true if lhs is greater than rhs.
  * \return false if lhs is not greater than rhs.
  */
-constexpr auto operator>( Address_Transmitted lhs, Address_Transmitted rhs ) noexcept
+constexpr auto operator>( Address_Transmitted lhs, Address_Transmitted rhs ) noexcept -> bool
 {
     return rhs < lhs;
 }
@@ -492,7 +492,7 @@ constexpr auto operator>( Address_Transmitted lhs, Address_Transmitted rhs ) noe
  * \return true if lhs is less than or equal to rhs.
  * \return false if lhs is not less than or equal to rhs.
  */
-constexpr auto operator<=( Address_Transmitted lhs, Address_Transmitted rhs ) noexcept
+constexpr auto operator<=( Address_Transmitted lhs, Address_Transmitted rhs ) noexcept -> bool
 {
     return not( lhs > rhs );
 }
@@ -508,7 +508,7 @@ constexpr auto operator<=( Address_Transmitted lhs, Address_Transmitted rhs ) no
  * \return true if lhs is greater than or equal to rhs.
  * \return false if lhs is not greater than or equal to rhs.
  */
-constexpr auto operator>=( Address_Transmitted lhs, Address_Transmitted rhs ) noexcept
+constexpr auto operator>=( Address_Transmitted lhs, Address_Transmitted rhs ) noexcept -> bool
 {
     return not( lhs < rhs );
 }
@@ -536,7 +536,7 @@ class Communication_Controller : public Device {
      *
      * \return The device's address.
      */
-    constexpr auto address() const noexcept
+    constexpr auto address() const noexcept -> Address_Transmitted
     {
         return m_address;
     }
@@ -598,7 +598,7 @@ class Communication_Controller : public Device {
      *
      * \return The data read from the register.
      */
-    auto read( std::uint8_t register_address ) const noexcept
+    auto read( std::uint8_t register_address ) const noexcept -> std::uint8_t
     {
         this->configure();
 
@@ -709,7 +709,7 @@ class Driver : public Communication_Controller {
      *
      * \return The data read from the IODIR register.
      */
-    auto read_iodir() const noexcept
+    auto read_iodir() const noexcept -> std::uint8_t
     {
         return this->read( IODIR::ADDRESS );
     }
@@ -729,7 +729,7 @@ class Driver : public Communication_Controller {
      *
      * \return The data read from the IPOL register.
      */
-    auto read_ipol() const noexcept
+    auto read_ipol() const noexcept -> std::uint8_t
     {
         return this->read( IPOL::ADDRESS );
     }
@@ -749,7 +749,7 @@ class Driver : public Communication_Controller {
      *
      * \return The data read from the GPINTEN register.
      */
-    auto read_gpinten() const noexcept
+    auto read_gpinten() const noexcept -> std::uint8_t
     {
         return this->read( GPINTEN::ADDRESS );
     }
@@ -769,7 +769,7 @@ class Driver : public Communication_Controller {
      *
      * \return The data read from the DEFVAL register.
      */
-    auto read_defval() const noexcept
+    auto read_defval() const noexcept -> std::uint8_t
     {
         return this->read( DEFVAL::ADDRESS );
     }
@@ -789,7 +789,7 @@ class Driver : public Communication_Controller {
      *
      * \return The data read from the INTCON register.
      */
-    auto read_intcon() const noexcept
+    auto read_intcon() const noexcept -> std::uint8_t
     {
         return this->read( INTCON::ADDRESS );
     }
@@ -809,7 +809,7 @@ class Driver : public Communication_Controller {
      *
      * \return The data read from the IOCON register.
      */
-    auto read_iocon() const noexcept
+    auto read_iocon() const noexcept -> std::uint8_t
     {
         return this->read( IOCON::ADDRESS );
     }
@@ -829,7 +829,7 @@ class Driver : public Communication_Controller {
      *
      * \return The data read from the GPPU register.
      */
-    auto read_gppu() const noexcept
+    auto read_gppu() const noexcept -> std::uint8_t
     {
         return this->read( GPPU::ADDRESS );
     }
@@ -849,7 +849,7 @@ class Driver : public Communication_Controller {
      *
      * \return The data read from the INTF register.
      */
-    auto read_intf() const noexcept
+    auto read_intf() const noexcept -> std::uint8_t
     {
         return this->read( INTF::ADDRESS );
     }
@@ -859,7 +859,7 @@ class Driver : public Communication_Controller {
      *
      * \return The data read from the INTCAP register.
      */
-    auto read_intcap() const noexcept
+    auto read_intcap() const noexcept -> std::uint8_t
     {
         return this->read( INTCAP::ADDRESS );
     }
@@ -869,7 +869,7 @@ class Driver : public Communication_Controller {
      *
      * \return The data read from the GPIO register.
      */
-    auto read_gpio() const noexcept
+    auto read_gpio() const noexcept -> std::uint8_t
     {
         return this->read( GPIO::ADDRESS );
     }
@@ -889,7 +889,7 @@ class Driver : public Communication_Controller {
      *
      * \return The data read from the OLAT register.
      */
-    auto read_olat() const noexcept
+    auto read_olat() const noexcept -> std::uint8_t
     {
         return this->read( OLAT::ADDRESS );
     }

--- a/include/picolibrary/microchip/mcp23x08.h
+++ b/include/picolibrary/microchip/mcp23x08.h
@@ -685,7 +685,7 @@ class Caching_Driver : public Driver {
      *
      * \return The cached IODIR register value.
      */
-    constexpr auto iodir() const noexcept
+    constexpr auto iodir() const noexcept -> std::uint8_t
     {
         return m_iodir;
     }
@@ -707,7 +707,7 @@ class Caching_Driver : public Driver {
      *
      * \return The cached IPOL register value.
      */
-    constexpr auto ipol() const noexcept
+    constexpr auto ipol() const noexcept -> std::uint8_t
     {
         return m_ipol;
     }
@@ -729,7 +729,7 @@ class Caching_Driver : public Driver {
      *
      * \return The cached GPINTEN register value.
      */
-    constexpr auto gpinten() const noexcept
+    constexpr auto gpinten() const noexcept -> std::uint8_t
     {
         return m_gpinten;
     }
@@ -751,7 +751,7 @@ class Caching_Driver : public Driver {
      *
      * \return The cached DEFVAL register value.
      */
-    constexpr auto defval() const noexcept
+    constexpr auto defval() const noexcept -> std::uint8_t
     {
         return m_defval;
     }
@@ -773,7 +773,7 @@ class Caching_Driver : public Driver {
      *
      * \return The cached INTCON register value.
      */
-    constexpr auto intcon() const noexcept
+    constexpr auto intcon() const noexcept -> std::uint8_t
     {
         return m_intcon;
     }
@@ -795,7 +795,7 @@ class Caching_Driver : public Driver {
      *
      * \return The cached IOCON register value.
      */
-    constexpr auto iocon() const noexcept
+    constexpr auto iocon() const noexcept -> std::uint8_t
     {
         return m_iocon;
     }
@@ -817,7 +817,7 @@ class Caching_Driver : public Driver {
      *
      * \return The cached GPPU register value.
      */
-    constexpr auto gppu() const noexcept
+    constexpr auto gppu() const noexcept -> std::uint8_t
     {
         return m_gppu;
     }
@@ -851,7 +851,7 @@ class Caching_Driver : public Driver {
      *
      * \return The cached OLAT register value.
      */
-    constexpr auto olat() const noexcept
+    constexpr auto olat() const noexcept -> std::uint8_t
     {
         return m_olat;
     }
@@ -952,7 +952,7 @@ class Pin {
      *
      * \return The assigned to object.
      */
-    constexpr auto & operator=( Pin && expression ) noexcept
+    constexpr auto operator=( Pin && expression ) noexcept -> Pin &
     {
         if ( &expression != this ) {
             m_caching_driver = expression.m_caching_driver;
@@ -1011,7 +1011,7 @@ class Pin {
      * \return false if the internally pulled-up input pin's internal pull-up resistor is
      *         not disabled.
      */
-    auto pull_up_is_disabled() const noexcept
+    auto pull_up_is_disabled() const noexcept -> bool
     {
         return not pull_up_is_enabled();
     }
@@ -1052,7 +1052,7 @@ class Pin {
      * \return true if the pin is in the low state.
      * \return false if the pin is not in the low state.
      */
-    auto is_low() const noexcept
+    auto is_low() const noexcept -> bool
     {
         return not is_high();
     }
@@ -1179,7 +1179,8 @@ class Internally_Pulled_Up_Input_Pin {
      *
      * \return The assigned to object.
      */
-    constexpr auto & operator=( Internally_Pulled_Up_Input_Pin && expression ) noexcept
+    constexpr auto operator=( Internally_Pulled_Up_Input_Pin && expression ) noexcept
+        -> Internally_Pulled_Up_Input_Pin &
     {
         if ( &expression != this ) {
             disable();
@@ -1218,7 +1219,7 @@ class Internally_Pulled_Up_Input_Pin {
      * \return true if the pin's internal pull-up resistor is disabled.
      * \return false if the pin's internal pull-up resistor is not disabled.
      */
-    auto pull_up_is_disabled() const noexcept
+    auto pull_up_is_disabled() const noexcept -> bool
     {
         return m_pin.pull_up_is_disabled();
     }
@@ -1229,7 +1230,7 @@ class Internally_Pulled_Up_Input_Pin {
      * \return true if the pin's internal pull-up resistor is enabled.
      * \return false if the pin's internal pull-up resistor is not enabled.
      */
-    auto pull_up_is_enabled() const noexcept
+    auto pull_up_is_enabled() const noexcept -> bool
     {
         return m_pin.pull_up_is_enabled();
     }
@@ -1256,7 +1257,7 @@ class Internally_Pulled_Up_Input_Pin {
      * \return true if the pin is in the low state.
      * \return false if the pin is not in the low state.
      */
-    auto is_low() const noexcept
+    auto is_low() const noexcept -> bool
     {
         return m_pin.is_low();
     }
@@ -1267,7 +1268,7 @@ class Internally_Pulled_Up_Input_Pin {
      * \return true if the pin is in the high state.
      * \return false if the pin is not in the high state.
      */
-    auto is_high() const noexcept
+    auto is_high() const noexcept -> bool
     {
         return m_pin.is_high();
     }
@@ -1339,7 +1340,7 @@ class Open_Drain_IO_Pin {
      *
      * \return The assigned to object.
      */
-    constexpr auto & operator=( Open_Drain_IO_Pin && expression ) noexcept
+    constexpr auto operator=( Open_Drain_IO_Pin && expression ) noexcept -> Open_Drain_IO_Pin &
     {
         if ( &expression != this ) {
             disable();
@@ -1377,7 +1378,7 @@ class Open_Drain_IO_Pin {
      * \return true if the pin is in the low state.
      * \return false if the pin is not in the low state.
      */
-    auto is_low() const noexcept
+    auto is_low() const noexcept -> bool
     {
         return m_pin.is_low();
     }
@@ -1388,7 +1389,7 @@ class Open_Drain_IO_Pin {
      * \return true if the pin is in the high state.
      * \return false if the pin is not in the high state.
      */
-    auto is_high() const noexcept
+    auto is_high() const noexcept -> bool
     {
         return m_pin.is_high();
     }
@@ -1484,7 +1485,7 @@ class Push_Pull_IO_Pin {
      *
      * \return The assigned to object.
      */
-    constexpr auto & operator=( Push_Pull_IO_Pin && expression ) noexcept
+    constexpr auto operator=( Push_Pull_IO_Pin && expression ) noexcept -> Push_Pull_IO_Pin &
     {
         if ( &expression != this ) {
             disable();
@@ -1522,7 +1523,7 @@ class Push_Pull_IO_Pin {
      * \return true if the pin is in the low state.
      * \return false if the pin is not in the low state.
      */
-    auto is_low() const noexcept
+    auto is_low() const noexcept -> bool
     {
         return m_pin.is_low();
     }
@@ -1533,7 +1534,7 @@ class Push_Pull_IO_Pin {
      * \return true if the pin is in the high state.
      * \return false if the pin is not in the high state.
      */
-    auto is_high() const noexcept
+    auto is_high() const noexcept -> bool
     {
         return m_pin.is_high();
     }

--- a/include/picolibrary/result.h
+++ b/include/picolibrary/result.h
@@ -146,7 +146,7 @@ class [[nodiscard]] Result<Void, Void, true> final
      *
      * \return true (operation succeeded).
      */
-    [[nodiscard]] constexpr auto is_value() const noexcept
+    [[nodiscard]] constexpr auto is_value() const noexcept->bool
     {
         return true;
     }
@@ -156,7 +156,7 @@ class [[nodiscard]] Result<Void, Void, true> final
      *
      * \return false (operation succeeded).
      */
-    [[nodiscard]] constexpr auto is_error() const noexcept
+    [[nodiscard]] constexpr auto is_error() const noexcept->bool
     {
         return not is_value();
     }
@@ -169,7 +169,7 @@ class [[nodiscard]] Result<Void, Void, true> final
      *
      * \return picolibrary::Void
      */
-    [[nodiscard]] constexpr auto error() const noexcept
+    [[nodiscard]] constexpr auto error() const noexcept->Error
     {
         return Error{};
     }
@@ -272,7 +272,7 @@ class [[nodiscard]] Result<Void, Error_Code, true> final
      *
      * \return The assigned to object.
      */
-    constexpr auto & operator=( Result && expression ) noexcept
+    constexpr auto operator=( Result && expression ) noexcept->Result &
     {
         if ( &expression != this ) {
             if ( is_value() == expression.is_value() ) {
@@ -298,7 +298,7 @@ class [[nodiscard]] Result<Void, Error_Code, true> final
      *
      * \return The assigned to object.
      */
-    constexpr auto & operator=( Result const & expression ) noexcept
+    constexpr auto operator=( Result const & expression ) noexcept->Result &
     {
         if ( &expression != this ) {
             if ( is_value() == expression.is_value() ) {
@@ -347,7 +347,7 @@ class [[nodiscard]] Result<Void, Error_Code, true> final
      *
      * \return The error.
      */
-    [[nodiscard]] constexpr auto && error() && noexcept
+    [[nodiscard]] constexpr auto error() && noexcept->Error &&
     {
         return static_cast<Error &&>( m_error );
     }
@@ -360,7 +360,7 @@ class [[nodiscard]] Result<Void, Error_Code, true> final
      *
      * \return The error.
      */
-    [[nodiscard]] constexpr auto const && error() const && noexcept
+    [[nodiscard]] constexpr auto error() const && noexcept->Error const &&
     {
         return static_cast<Error const &&>( m_error );
     }
@@ -373,7 +373,7 @@ class [[nodiscard]] Result<Void, Error_Code, true> final
      *
      * \return The error.
      */
-    [[nodiscard]] constexpr auto & error() & noexcept
+    [[nodiscard]] constexpr auto error() & noexcept->Error &
     {
         return static_cast<Error &>( m_error );
     }
@@ -386,7 +386,7 @@ class [[nodiscard]] Result<Void, Error_Code, true> final
      *
      * \return The error.
      */
-    [[nodiscard]] constexpr auto const & error() const & noexcept
+    [[nodiscard]] constexpr auto error() const & noexcept->Error const &
     {
         return static_cast<Error const &>( m_error );
     }
@@ -501,7 +501,7 @@ class [[nodiscard]] Result<Value_Type, Void, true> final
      *
      * \return The assigned to object.
      */
-    constexpr auto & operator=( Result && expression ) noexcept
+    constexpr auto operator=( Result && expression ) noexcept->Result &
     {
         if ( &expression != this ) {
             m_value = std::move( expression.m_value );
@@ -517,7 +517,7 @@ class [[nodiscard]] Result<Value_Type, Void, true> final
      *
      * \return The assigned to object.
      */
-    constexpr auto & operator=( Result const & expression ) noexcept
+    constexpr auto operator=( Result const & expression ) noexcept->Result &
     {
         if ( &expression != this ) {
             m_value = expression.m_value;
@@ -531,7 +531,7 @@ class [[nodiscard]] Result<Value_Type, Void, true> final
      *
      * \return true (operation succeeded).
      */
-    [[nodiscard]] constexpr auto is_value() const noexcept
+    [[nodiscard]] constexpr auto is_value() const noexcept->bool
     {
         return true;
     }
@@ -541,7 +541,7 @@ class [[nodiscard]] Result<Value_Type, Void, true> final
      *
      * \return false (operation succeeded).
      */
-    [[nodiscard]] constexpr auto is_error() const noexcept
+    [[nodiscard]] constexpr auto is_error() const noexcept->bool
     {
         return not is_value();
     }
@@ -551,7 +551,7 @@ class [[nodiscard]] Result<Value_Type, Void, true> final
      *
      * \return The generated information.
      */
-    [[nodiscard]] constexpr auto && value() && noexcept
+    [[nodiscard]] constexpr auto value() && noexcept->Value &&
     {
         return static_cast<Value &&>( m_value );
     }
@@ -561,7 +561,7 @@ class [[nodiscard]] Result<Value_Type, Void, true> final
      *
      * \return The generated information.
      */
-    [[nodiscard]] constexpr auto const && value() const && noexcept
+    [[nodiscard]] constexpr auto value() const && noexcept->Value const &&
     {
         return static_cast<Value const &&>( m_value );
     }
@@ -571,7 +571,7 @@ class [[nodiscard]] Result<Value_Type, Void, true> final
      *
      * \return The generated information.
      */
-    [[nodiscard]] constexpr auto & value() & noexcept
+    [[nodiscard]] constexpr auto value() & noexcept->Value &
     {
         return static_cast<Value &>( m_value );
     }
@@ -581,7 +581,7 @@ class [[nodiscard]] Result<Value_Type, Void, true> final
      *
      * \return The generated information.
      */
-    [[nodiscard]] constexpr auto const & value() const & noexcept
+    [[nodiscard]] constexpr auto value() const & noexcept->Value const &
     {
         return static_cast<Value const &>( m_value );
     }
@@ -594,7 +594,7 @@ class [[nodiscard]] Result<Value_Type, Void, true> final
      *
      * \return picolibrary::Void
      */
-    [[nodiscard]] constexpr auto error() const noexcept
+    [[nodiscard]] constexpr auto error() const noexcept->Error
     {
         return Error{};
     }
@@ -707,7 +707,7 @@ class [[nodiscard]] Result<Value_Type, Void, false> final
      *
      * \return The assigned to object.
      */
-    constexpr auto & operator=( Result && expression ) noexcept
+    constexpr auto operator=( Result && expression ) noexcept->Result &
     {
         if ( &expression != this ) {
             m_value = std::move( expression.m_value );
@@ -723,7 +723,7 @@ class [[nodiscard]] Result<Value_Type, Void, false> final
      *
      * \return The assigned to object.
      */
-    constexpr auto & operator=( Result const & expression ) noexcept
+    constexpr auto operator=( Result const & expression ) noexcept->Result &
     {
         if ( &expression != this ) {
             m_value = expression.m_value;
@@ -737,7 +737,7 @@ class [[nodiscard]] Result<Value_Type, Void, false> final
      *
      * \return true (operation succeeded).
      */
-    [[nodiscard]] constexpr auto is_value() const noexcept
+    [[nodiscard]] constexpr auto is_value() const noexcept->bool
     {
         return true;
     }
@@ -747,7 +747,7 @@ class [[nodiscard]] Result<Value_Type, Void, false> final
      *
      * \return false (operation succeeded).
      */
-    [[nodiscard]] constexpr auto is_error() const noexcept
+    [[nodiscard]] constexpr auto is_error() const noexcept->bool
     {
         return not is_value();
     }
@@ -757,7 +757,7 @@ class [[nodiscard]] Result<Value_Type, Void, false> final
      *
      * \return The generated information.
      */
-    [[nodiscard]] constexpr auto && value() && noexcept
+    [[nodiscard]] constexpr auto value() && noexcept->Value &&
     {
         return static_cast<Value &&>( m_value );
     }
@@ -767,7 +767,7 @@ class [[nodiscard]] Result<Value_Type, Void, false> final
      *
      * \return The generated information.
      */
-    [[nodiscard]] constexpr auto const && value() const && noexcept
+    [[nodiscard]] constexpr auto value() const && noexcept->Value const &&
     {
         return static_cast<Value const &&>( m_value );
     }
@@ -777,7 +777,7 @@ class [[nodiscard]] Result<Value_Type, Void, false> final
      *
      * \return The generated information.
      */
-    [[nodiscard]] constexpr auto & value() & noexcept
+    [[nodiscard]] constexpr auto value() & noexcept->Value &
     {
         return static_cast<Value &>( m_value );
     }
@@ -787,7 +787,7 @@ class [[nodiscard]] Result<Value_Type, Void, false> final
      *
      * \return The generated information.
      */
-    [[nodiscard]] constexpr auto const & value() const & noexcept
+    [[nodiscard]] constexpr auto value() const & noexcept->Value const &
     {
         return static_cast<Value const &>( m_value );
     }
@@ -800,7 +800,7 @@ class [[nodiscard]] Result<Value_Type, Void, false> final
      *
      * \return picolibrary::Void
      */
-    [[nodiscard]] constexpr auto error() const noexcept
+    [[nodiscard]] constexpr auto error() const noexcept->Error
     {
         return Error{};
     }
@@ -964,7 +964,7 @@ class [[nodiscard]] Result<Value_Type, Error_Code, true> final
      *
      * \return The assigned to object.
      */
-    constexpr auto & operator=( Result && expression ) noexcept
+    constexpr auto operator=( Result && expression ) noexcept->Result &
     {
         if ( &expression != this ) {
             if ( is_value() == expression.is_value() ) {
@@ -994,7 +994,7 @@ class [[nodiscard]] Result<Value_Type, Error_Code, true> final
      *
      * \return The assigned to object.
      */
-    constexpr auto & operator=( Result const & expression ) noexcept
+    constexpr auto operator=( Result const & expression ) noexcept->Result &
     {
         if ( &expression != this ) {
             if ( is_value() == expression.is_value() ) {
@@ -1047,7 +1047,7 @@ class [[nodiscard]] Result<Value_Type, Error_Code, true> final
      *
      * \return The generated information.
      */
-    [[nodiscard]] constexpr auto && value() && noexcept
+    [[nodiscard]] constexpr auto value() && noexcept->Value &&
     {
         return static_cast<Value &&>( m_value );
     }
@@ -1060,7 +1060,7 @@ class [[nodiscard]] Result<Value_Type, Error_Code, true> final
      *
      * \return The generated information.
      */
-    [[nodiscard]] constexpr auto const && value() const && noexcept
+    [[nodiscard]] constexpr auto value() const && noexcept->Value const &&
     {
         return static_cast<Value const &&>( m_value );
     }
@@ -1073,7 +1073,7 @@ class [[nodiscard]] Result<Value_Type, Error_Code, true> final
      *
      * \return The generated information.
      */
-    [[nodiscard]] constexpr auto & value() & noexcept
+    [[nodiscard]] constexpr auto value() & noexcept->Value &
     {
         return static_cast<Value &>( m_value );
     }
@@ -1086,7 +1086,7 @@ class [[nodiscard]] Result<Value_Type, Error_Code, true> final
      *
      * \return The generated information.
      */
-    [[nodiscard]] constexpr auto const & value() const & noexcept
+    [[nodiscard]] constexpr auto value() const & noexcept->Value const &
     {
         return static_cast<Value const &>( m_value );
     }
@@ -1099,7 +1099,7 @@ class [[nodiscard]] Result<Value_Type, Error_Code, true> final
      *
      * \return The error.
      */
-    [[nodiscard]] constexpr auto && error() && noexcept
+    [[nodiscard]] constexpr auto error() && noexcept->Error &&
     {
         return static_cast<Error &&>( m_error );
     }
@@ -1112,7 +1112,7 @@ class [[nodiscard]] Result<Value_Type, Error_Code, true> final
      *
      * \return The error.
      */
-    [[nodiscard]] constexpr auto const && error() const && noexcept
+    [[nodiscard]] constexpr auto error() const && noexcept->Error const &&
     {
         return static_cast<Error const &&>( m_error );
     }
@@ -1125,7 +1125,7 @@ class [[nodiscard]] Result<Value_Type, Error_Code, true> final
      *
      * \return The error.
      */
-    [[nodiscard]] constexpr auto & error() & noexcept
+    [[nodiscard]] constexpr auto error() & noexcept->Error &
     {
         return static_cast<Error &>( m_error );
     }
@@ -1138,7 +1138,7 @@ class [[nodiscard]] Result<Value_Type, Error_Code, true> final
      *
      * \return The error.
      */
-    [[nodiscard]] constexpr auto const & error() const & noexcept
+    [[nodiscard]] constexpr auto error() const & noexcept->Error const &
     {
         return static_cast<Error const &>( m_error );
     }
@@ -1312,7 +1312,7 @@ class [[nodiscard]] Result<Value_Type, Error_Code, false> final
      *
      * \return The assigned to object.
      */
-    constexpr auto & operator=( Result && expression ) noexcept
+    constexpr auto operator=( Result && expression ) noexcept->Result &
     {
         if ( &expression != this ) {
             if ( is_value() == expression.is_value() ) {
@@ -1343,7 +1343,7 @@ class [[nodiscard]] Result<Value_Type, Error_Code, false> final
      *
      * \return The assigned to object.
      */
-    constexpr auto & operator=( Result const & expression ) noexcept
+    constexpr auto operator=( Result const & expression ) noexcept->Result &
     {
         if ( &expression != this ) {
             if ( is_value() == expression.is_value() ) {
@@ -1397,7 +1397,7 @@ class [[nodiscard]] Result<Value_Type, Error_Code, false> final
      *
      * \return The generated information.
      */
-    [[nodiscard]] constexpr auto && value() && noexcept
+    [[nodiscard]] constexpr auto value() && noexcept->Value &&
     {
         return static_cast<Value &&>( m_value );
     }
@@ -1410,7 +1410,7 @@ class [[nodiscard]] Result<Value_Type, Error_Code, false> final
      *
      * \return The generated information.
      */
-    [[nodiscard]] constexpr auto const && value() const && noexcept
+    [[nodiscard]] constexpr auto value() const && noexcept->Value const &&
     {
         return static_cast<Value const &&>( m_value );
     }
@@ -1423,7 +1423,7 @@ class [[nodiscard]] Result<Value_Type, Error_Code, false> final
      *
      * \return The generated information.
      */
-    [[nodiscard]] constexpr auto & value() & noexcept
+    [[nodiscard]] constexpr auto value() & noexcept->Value &
     {
         return static_cast<Value &>( m_value );
     }
@@ -1436,7 +1436,7 @@ class [[nodiscard]] Result<Value_Type, Error_Code, false> final
      *
      * \return The generated information.
      */
-    [[nodiscard]] constexpr auto const & value() const & noexcept
+    [[nodiscard]] constexpr auto value() const & noexcept->Value const &
     {
         return static_cast<Value const &>( m_value );
     }
@@ -1449,7 +1449,7 @@ class [[nodiscard]] Result<Value_Type, Error_Code, false> final
      *
      * \return The error.
      */
-    [[nodiscard]] constexpr auto && error() && noexcept
+    [[nodiscard]] constexpr auto error() && noexcept->Error &&
     {
         return static_cast<Error &&>( m_error );
     }
@@ -1462,7 +1462,7 @@ class [[nodiscard]] Result<Value_Type, Error_Code, false> final
      *
      * \return The error.
      */
-    [[nodiscard]] constexpr auto const && error() const && noexcept
+    [[nodiscard]] constexpr auto error() const && noexcept->Error const &&
     {
         return static_cast<Error const &&>( m_error );
     }
@@ -1475,7 +1475,7 @@ class [[nodiscard]] Result<Value_Type, Error_Code, false> final
      *
      * \return The error.
      */
-    [[nodiscard]] constexpr auto & error() & noexcept
+    [[nodiscard]] constexpr auto error() & noexcept->Error &
     {
         return static_cast<Error &>( m_error );
     }
@@ -1488,7 +1488,7 @@ class [[nodiscard]] Result<Value_Type, Error_Code, false> final
      *
      * \return The error.
      */
-    [[nodiscard]] constexpr auto const & error() const & noexcept
+    [[nodiscard]] constexpr auto error() const & noexcept->Error const &
     {
         return static_cast<Error const &>( m_error );
     }

--- a/include/picolibrary/spi.h
+++ b/include/picolibrary/spi.h
@@ -246,7 +246,7 @@ class Controller : public Basic_Controller {
      *
      * \return The data received from the device.
      */
-    auto receive() noexcept
+    auto receive() noexcept -> std::uint8_t
     {
         return exchange( 0x00 );
     }
@@ -471,7 +471,7 @@ class Device {
      *
      * \return The assigned to object.
      */
-    constexpr auto & operator=( Device && expression ) noexcept
+    constexpr auto operator=( Device && expression ) noexcept -> Device &
     {
         if ( &expression != this ) {
             m_controller      = expression.m_controller;
@@ -506,7 +506,7 @@ class Device {
      *
      * \return The device selector used to select and deselect the device.
      */
-    constexpr auto & device_selector() const noexcept
+    constexpr auto device_selector() const noexcept -> Device_Selector &
     {
         return m_device_selector;
     }
@@ -518,7 +518,7 @@ class Device {
      *
      * \return The data received from the device.
      */
-    auto exchange( std::uint8_t data ) const noexcept
+    auto exchange( std::uint8_t data ) const noexcept -> std::uint8_t
     {
         return m_controller->exchange( data );
     }
@@ -544,7 +544,7 @@ class Device {
      *
      * \return The data received from the device.
      */
-    auto receive() const noexcept
+    auto receive() const noexcept -> std::uint8_t
     {
         return m_controller->receive();
     }

--- a/include/picolibrary/state_machine.h
+++ b/include/picolibrary/state_machine.h
@@ -55,7 +55,7 @@ class State_Machine {
          *
          * \return A reference to the pseudo-event category instance.
          */
-        static constexpr auto const & instance() noexcept
+        static constexpr auto instance() noexcept -> Pseudo_Event_Category const &
         {
             return INSTANCE;
         }
@@ -239,7 +239,7 @@ class State_Machine {
      *
      * \return Event handled event handling result.
      */
-    constexpr auto event_handled( Event const & handled_event ) const noexcept
+    constexpr auto event_handled( Event const & handled_event ) const noexcept -> Event_Handling_Result
     {
         static_cast<void>( handled_event );
 
@@ -256,6 +256,7 @@ class State_Machine {
      * \return State transition triggered event handling result.
      */
     constexpr auto transition_to( State_Event_Handler_Reference target_state, Event const & triggering_event ) noexcept
+        -> Event_Handling_Result
     {
         static_cast<void>( triggering_event );
 
@@ -371,7 +372,7 @@ class State_Machine {
      *
      * \return The state event handler for the currently active state.
      */
-    constexpr auto current_state() const noexcept
+    constexpr auto current_state() const noexcept -> State_Event_Handler_Pointer
     {
         return m_current_state;
     }
@@ -387,7 +388,7 @@ class State_Machine {
      * \return false if state is not the state event handler for the currently active
      *         state.
      */
-    constexpr auto is_in( State_Event_Handler_Reference state ) noexcept
+    constexpr auto is_in( State_Event_Handler_Reference state ) noexcept -> bool
     {
         return m_current_state == &state;
     }

--- a/include/picolibrary/stream.h
+++ b/include/picolibrary/stream.h
@@ -216,7 +216,7 @@ class Stream {
      * \return true if the stream is nominal.
      * \return false if the stream is not nominal.
      */
-    constexpr auto is_nominal() const noexcept
+    constexpr auto is_nominal() const noexcept -> bool
     {
         return not m_state;
     }
@@ -375,7 +375,7 @@ class Stream {
      *
      * \brief The I/O stream device access buffer associated with the I/O stream.
      */
-    constexpr auto buffer() noexcept
+    constexpr auto buffer() noexcept -> Stream_Buffer *
     {
         return m_buffer;
     }
@@ -888,7 +888,7 @@ class Output_Formatter<char> {
      *
      * \return format
      */
-    constexpr auto parse( char const * format ) noexcept
+    constexpr auto parse( char const * format ) noexcept -> char const *
     {
         return format;
     }
@@ -948,7 +948,7 @@ class Output_Formatter<char const *> {
      *
      * \return format
      */
-    constexpr auto parse( char const * format ) noexcept
+    constexpr auto parse( char const * format ) noexcept -> char const *
     {
         return format;
     }
@@ -1007,7 +1007,7 @@ class Output_Formatter<Void> {
      *
      * \return format
      */
-    constexpr auto parse( char const * format ) noexcept
+    constexpr auto parse( char const * format ) noexcept -> char const *
     {
         return format;
     }
@@ -1058,7 +1058,7 @@ class Output_Formatter<Error_Code> {
      *
      * \return format
      */
-    constexpr auto parse( char const * format ) noexcept
+    constexpr auto parse( char const * format ) noexcept -> char const *
     {
         return format;
     }
@@ -1073,6 +1073,7 @@ class Output_Formatter<Error_Code> {
      * \return An error code if the write failed.
      */
     auto print( Output_Stream & stream, Error_Code const & error ) noexcept
+        -> Result<std::size_t, Error_Code>
     {
         return stream.print( "{}::{}", error.category().name(), error.description() );
     }

--- a/include/picolibrary/testing/unit/adc.h
+++ b/include/picolibrary/testing/unit/adc.h
@@ -45,7 +45,7 @@ namespace picolibrary::Testing::Unit {
 template<>
 inline auto random<ADC::Sample<std::uint_fast8_t, 8>>(
     ADC::Sample<std::uint_fast8_t, 8> min,
-    ADC::Sample<std::uint_fast8_t, 8> max )
+    ADC::Sample<std::uint_fast8_t, 8> max ) -> ADC::Sample<std::uint_fast8_t, 8>
 {
     return ADC::Sample<std::uint_fast8_t, 8>{ random<ADC::Sample<std::uint_fast8_t, 8>::Unsigned_Integer>(
         min.as_unsigned_integer(), max.as_unsigned_integer() ) };
@@ -62,6 +62,7 @@ inline auto random<ADC::Sample<std::uint_fast8_t, 8>>(
  */
 template<>
 inline auto random<ADC::Sample<std::uint_fast8_t, 8>>( ADC::Sample<std::uint_fast8_t, 8> min )
+    -> ADC::Sample<std::uint_fast8_t, 8>
 {
     return random<ADC::Sample<std::uint_fast8_t, 8>>( min, ADC::Sample<std::uint_fast8_t, 8>::max() );
 }
@@ -74,7 +75,7 @@ inline auto random<ADC::Sample<std::uint_fast8_t, 8>>( ADC::Sample<std::uint_fas
  *         8>::min(),picolibrary::ADC::Sample<std::uint_fast8_t, 8>::max()].
  */
 template<>
-inline auto random<ADC::Sample<std::uint_fast8_t, 8>>()
+inline auto random<ADC::Sample<std::uint_fast8_t, 8>>() -> ADC::Sample<std::uint_fast8_t, 8>
 {
     return random<ADC::Sample<std::uint_fast8_t, 8>>(
         ADC::Sample<std::uint_fast8_t, 8>::min(), ADC::Sample<std::uint_fast8_t, 8>::max() );
@@ -93,7 +94,7 @@ inline auto random<ADC::Sample<std::uint_fast8_t, 8>>()
 template<>
 inline auto random<ADC::Sample<std::uint_fast16_t, 10>>(
     ADC::Sample<std::uint_fast16_t, 10> min,
-    ADC::Sample<std::uint_fast16_t, 10> max )
+    ADC::Sample<std::uint_fast16_t, 10> max ) -> ADC::Sample<std::uint_fast16_t, 10>
 {
     return ADC::Sample<std::uint_fast16_t, 10>{ random<ADC::Sample<std::uint_fast16_t, 10>::Unsigned_Integer>(
         min.as_unsigned_integer(), max.as_unsigned_integer() ) };
@@ -111,6 +112,7 @@ inline auto random<ADC::Sample<std::uint_fast16_t, 10>>(
  */
 template<>
 inline auto random<ADC::Sample<std::uint_fast16_t, 10>>( ADC::Sample<std::uint_fast16_t, 10> min )
+    -> ADC::Sample<std::uint_fast16_t, 10>
 {
     return random<ADC::Sample<std::uint_fast16_t, 10>>(
         min, ADC::Sample<std::uint_fast16_t, 10>::max() );
@@ -124,7 +126,7 @@ inline auto random<ADC::Sample<std::uint_fast16_t, 10>>( ADC::Sample<std::uint_f
  *         10>::min(),picolibrary::ADC::Sample<std::uint_fast16_t, 10>::max()].
  */
 template<>
-inline auto random<ADC::Sample<std::uint_fast16_t, 10>>()
+inline auto random<ADC::Sample<std::uint_fast16_t, 10>>() -> ADC::Sample<std::uint_fast16_t, 10>
 {
     return random<ADC::Sample<std::uint_fast16_t, 10>>(
         ADC::Sample<std::uint_fast16_t, 10>::min(), ADC::Sample<std::uint_fast16_t, 10>::max() );
@@ -143,7 +145,7 @@ inline auto random<ADC::Sample<std::uint_fast16_t, 10>>()
 template<>
 inline auto random<ADC::Sample<std::uint_fast16_t, 12>>(
     ADC::Sample<std::uint_fast16_t, 12> min,
-    ADC::Sample<std::uint_fast16_t, 12> max )
+    ADC::Sample<std::uint_fast16_t, 12> max ) -> ADC::Sample<std::uint_fast16_t, 12>
 {
     return ADC::Sample<std::uint_fast16_t, 12>{ random<ADC::Sample<std::uint_fast16_t, 12>::Unsigned_Integer>(
         min.as_unsigned_integer(), max.as_unsigned_integer() ) };
@@ -161,6 +163,7 @@ inline auto random<ADC::Sample<std::uint_fast16_t, 12>>(
  */
 template<>
 inline auto random<ADC::Sample<std::uint_fast16_t, 12>>( ADC::Sample<std::uint_fast16_t, 12> min )
+    -> ADC::Sample<std::uint_fast16_t, 12>
 {
     return random<ADC::Sample<std::uint_fast16_t, 12>>(
         min, ADC::Sample<std::uint_fast16_t, 12>::max() );
@@ -174,7 +177,7 @@ inline auto random<ADC::Sample<std::uint_fast16_t, 12>>( ADC::Sample<std::uint_f
  *         12>::min(),picolibrary::ADC::Sample<std::uint_fast16_t, 12>::max()].
  */
 template<>
-inline auto random<ADC::Sample<std::uint_fast16_t, 12>>()
+inline auto random<ADC::Sample<std::uint_fast16_t, 12>>() -> ADC::Sample<std::uint_fast16_t, 12>
 {
     return random<ADC::Sample<std::uint_fast16_t, 12>>(
         ADC::Sample<std::uint_fast16_t, 12>::min(), ADC::Sample<std::uint_fast16_t, 12>::max() );
@@ -193,7 +196,7 @@ inline auto random<ADC::Sample<std::uint_fast16_t, 12>>()
 template<>
 inline auto random<ADC::Sample<std::uint_fast16_t, 14>>(
     ADC::Sample<std::uint_fast16_t, 14> min,
-    ADC::Sample<std::uint_fast16_t, 14> max )
+    ADC::Sample<std::uint_fast16_t, 14> max ) -> ADC::Sample<std::uint_fast16_t, 14>
 {
     return ADC::Sample<std::uint_fast16_t, 14>{ random<ADC::Sample<std::uint_fast16_t, 14>::Unsigned_Integer>(
         min.as_unsigned_integer(), max.as_unsigned_integer() ) };
@@ -211,6 +214,7 @@ inline auto random<ADC::Sample<std::uint_fast16_t, 14>>(
  */
 template<>
 inline auto random<ADC::Sample<std::uint_fast16_t, 14>>( ADC::Sample<std::uint_fast16_t, 14> min )
+    -> ADC::Sample<std::uint_fast16_t, 14>
 {
     return random<ADC::Sample<std::uint_fast16_t, 14>>(
         min, ADC::Sample<std::uint_fast16_t, 14>::max() );
@@ -224,7 +228,7 @@ inline auto random<ADC::Sample<std::uint_fast16_t, 14>>( ADC::Sample<std::uint_f
  *         14>::min(),picolibrary::ADC::Sample<std::uint_fast16_t, 14>::max()].
  */
 template<>
-inline auto random<ADC::Sample<std::uint_fast16_t, 14>>()
+inline auto random<ADC::Sample<std::uint_fast16_t, 14>>() -> ADC::Sample<std::uint_fast16_t, 14>
 {
     return random<ADC::Sample<std::uint_fast16_t, 14>>(
         ADC::Sample<std::uint_fast16_t, 14>::min(), ADC::Sample<std::uint_fast16_t, 14>::max() );
@@ -243,7 +247,7 @@ inline auto random<ADC::Sample<std::uint_fast16_t, 14>>()
 template<>
 inline auto random<ADC::Sample<std::uint_fast16_t, 16>>(
     ADC::Sample<std::uint_fast16_t, 16> min,
-    ADC::Sample<std::uint_fast16_t, 16> max )
+    ADC::Sample<std::uint_fast16_t, 16> max ) -> ADC::Sample<std::uint_fast16_t, 16>
 {
     return ADC::Sample<std::uint_fast16_t, 16>{ random<ADC::Sample<std::uint_fast16_t, 16>::Unsigned_Integer>(
         min.as_unsigned_integer(), max.as_unsigned_integer() ) };
@@ -261,6 +265,7 @@ inline auto random<ADC::Sample<std::uint_fast16_t, 16>>(
  */
 template<>
 inline auto random<ADC::Sample<std::uint_fast16_t, 16>>( ADC::Sample<std::uint_fast16_t, 16> min )
+    -> ADC::Sample<std::uint_fast16_t, 16>
 {
     return random<ADC::Sample<std::uint_fast16_t, 16>>(
         min, ADC::Sample<std::uint_fast16_t, 16>::max() );
@@ -274,7 +279,7 @@ inline auto random<ADC::Sample<std::uint_fast16_t, 16>>( ADC::Sample<std::uint_f
  *         16>::min(),picolibrary::ADC::Sample<std::uint_fast16_t, 16>::max()].
  */
 template<>
-inline auto random<ADC::Sample<std::uint_fast16_t, 16>>()
+inline auto random<ADC::Sample<std::uint_fast16_t, 16>>() -> ADC::Sample<std::uint_fast16_t, 16>
 {
     return random<ADC::Sample<std::uint_fast16_t, 16>>(
         ADC::Sample<std::uint_fast16_t, 16>::min(), ADC::Sample<std::uint_fast16_t, 16>::max() );
@@ -293,7 +298,7 @@ inline auto random<ADC::Sample<std::uint_fast16_t, 16>>()
 template<>
 inline auto random<ADC::Sample<std::uint_fast32_t, 18>>(
     ADC::Sample<std::uint_fast32_t, 18> min,
-    ADC::Sample<std::uint_fast32_t, 18> max )
+    ADC::Sample<std::uint_fast32_t, 18> max ) -> ADC::Sample<std::uint_fast32_t, 18>
 {
     return ADC::Sample<std::uint_fast32_t, 18>{ random<ADC::Sample<std::uint_fast32_t, 18>::Unsigned_Integer>(
         min.as_unsigned_integer(), max.as_unsigned_integer() ) };
@@ -311,6 +316,7 @@ inline auto random<ADC::Sample<std::uint_fast32_t, 18>>(
  */
 template<>
 inline auto random<ADC::Sample<std::uint_fast32_t, 18>>( ADC::Sample<std::uint_fast32_t, 18> min )
+    -> ADC::Sample<std::uint_fast32_t, 18>
 {
     return random<ADC::Sample<std::uint_fast32_t, 18>>(
         min, ADC::Sample<std::uint_fast32_t, 18>::max() );
@@ -324,7 +330,7 @@ inline auto random<ADC::Sample<std::uint_fast32_t, 18>>( ADC::Sample<std::uint_f
  *         18>::min(),picolibrary::ADC::Sample<std::uint_fast32_t, 18>::max()].
  */
 template<>
-inline auto random<ADC::Sample<std::uint_fast32_t, 18>>()
+inline auto random<ADC::Sample<std::uint_fast32_t, 18>>() -> ADC::Sample<std::uint_fast32_t, 18>
 {
     return random<ADC::Sample<std::uint_fast32_t, 18>>(
         ADC::Sample<std::uint_fast32_t, 18>::min(), ADC::Sample<std::uint_fast32_t, 18>::max() );
@@ -343,7 +349,7 @@ inline auto random<ADC::Sample<std::uint_fast32_t, 18>>()
 template<>
 inline auto random<ADC::Sample<std::uint_fast32_t, 20>>(
     ADC::Sample<std::uint_fast32_t, 20> min,
-    ADC::Sample<std::uint_fast32_t, 20> max )
+    ADC::Sample<std::uint_fast32_t, 20> max ) -> ADC::Sample<std::uint_fast32_t, 20>
 {
     return ADC::Sample<std::uint_fast32_t, 20>{ random<ADC::Sample<std::uint_fast32_t, 20>::Unsigned_Integer>(
         min.as_unsigned_integer(), max.as_unsigned_integer() ) };
@@ -361,6 +367,7 @@ inline auto random<ADC::Sample<std::uint_fast32_t, 20>>(
  */
 template<>
 inline auto random<ADC::Sample<std::uint_fast32_t, 20>>( ADC::Sample<std::uint_fast32_t, 20> min )
+    -> ADC::Sample<std::uint_fast32_t, 20>
 {
     return random<ADC::Sample<std::uint_fast32_t, 20>>(
         min, ADC::Sample<std::uint_fast32_t, 20>::max() );
@@ -374,7 +381,7 @@ inline auto random<ADC::Sample<std::uint_fast32_t, 20>>( ADC::Sample<std::uint_f
  *         20>::min(),picolibrary::ADC::Sample<std::uint_fast32_t, 20>::max()].
  */
 template<>
-inline auto random<ADC::Sample<std::uint_fast32_t, 20>>()
+inline auto random<ADC::Sample<std::uint_fast32_t, 20>>() -> ADC::Sample<std::uint_fast32_t, 20>
 {
     return random<ADC::Sample<std::uint_fast32_t, 20>>(
         ADC::Sample<std::uint_fast32_t, 20>::min(), ADC::Sample<std::uint_fast32_t, 20>::max() );
@@ -393,7 +400,7 @@ inline auto random<ADC::Sample<std::uint_fast32_t, 20>>()
 template<>
 inline auto random<ADC::Sample<std::uint_fast32_t, 24>>(
     ADC::Sample<std::uint_fast32_t, 24> min,
-    ADC::Sample<std::uint_fast32_t, 24> max )
+    ADC::Sample<std::uint_fast32_t, 24> max ) -> ADC::Sample<std::uint_fast32_t, 24>
 {
     return ADC::Sample<std::uint_fast32_t, 24>{ random<ADC::Sample<std::uint_fast32_t, 24>::Unsigned_Integer>(
         min.as_unsigned_integer(), max.as_unsigned_integer() ) };
@@ -411,6 +418,7 @@ inline auto random<ADC::Sample<std::uint_fast32_t, 24>>(
  */
 template<>
 inline auto random<ADC::Sample<std::uint_fast32_t, 24>>( ADC::Sample<std::uint_fast32_t, 24> min )
+    -> ADC::Sample<std::uint_fast32_t, 24>
 {
     return random<ADC::Sample<std::uint_fast32_t, 24>>(
         min, ADC::Sample<std::uint_fast32_t, 24>::max() );
@@ -424,7 +432,7 @@ inline auto random<ADC::Sample<std::uint_fast32_t, 24>>( ADC::Sample<std::uint_f
  *         24>::min(),picolibrary::ADC::Sample<std::uint_fast32_t, 24>::max()].
  */
 template<>
-inline auto random<ADC::Sample<std::uint_fast32_t, 24>>()
+inline auto random<ADC::Sample<std::uint_fast32_t, 24>>() -> ADC::Sample<std::uint_fast32_t, 24>
 {
     return random<ADC::Sample<std::uint_fast32_t, 24>>(
         ADC::Sample<std::uint_fast32_t, 24>::min(), ADC::Sample<std::uint_fast32_t, 24>::max() );
@@ -492,7 +500,7 @@ class Mock_Blocking_Single_Sample_Converter {
 
     auto operator=( Mock_Blocking_Single_Sample_Converter const & ) = delete;
 
-    auto handle() noexcept
+    auto handle() noexcept -> Handle
     {
         return Handle{ *this };
     }
@@ -567,7 +575,7 @@ class Mock_Non_Blocking_Single_Sample_Converter {
 
     auto operator=( Mock_Non_Blocking_Single_Sample_Converter const & ) = delete;
 
-    auto handle() noexcept
+    auto handle() noexcept -> Handle
     {
         return Handle{ *this };
     }
@@ -644,7 +652,7 @@ class Mock_Blocking_Free_Running_Converter {
 
     auto operator=( Mock_Blocking_Free_Running_Converter const & ) = delete;
 
-    auto handle() noexcept
+    auto handle() noexcept -> Handle
     {
         return Handle{ *this };
     }
@@ -726,7 +734,7 @@ class Mock_Non_Blocking_Free_Running_Converter {
 
     auto operator=( Mock_Non_Blocking_Free_Running_Converter const & ) = delete;
 
-    auto handle() noexcept
+    auto handle() noexcept -> Handle
     {
         return Handle{ *this };
     }

--- a/include/picolibrary/testing/unit/asynchronous_serial.h
+++ b/include/picolibrary/testing/unit/asynchronous_serial.h
@@ -87,7 +87,7 @@ class Mock_Basic_Transmitter {
 
     auto operator=( Mock_Basic_Transmitter const & ) = delete;
 
-    auto handle() noexcept
+    auto handle() noexcept -> Handle
     {
         return Handle{ *this };
     }
@@ -128,12 +128,12 @@ class Mock_Transmitter : public Mock_Basic_Transmitter<Data_Type> {
 
         auto operator=( Handle const & ) = delete;
 
-        auto & mock() noexcept
+        auto mock() noexcept -> Mock_Transmitter &
         {
             return static_cast<Mock_Transmitter &>( Mock_Basic_Transmitter<Data_Type>::Handle::mock() );
         }
 
-        auto const & mock() const noexcept
+        auto mock() const noexcept -> Mock_Transmitter const &
         {
             return static_cast<Mock_Transmitter const &>(
                 Mock_Basic_Transmitter<Data_Type>::Handle::mock() );
@@ -159,7 +159,7 @@ class Mock_Transmitter : public Mock_Basic_Transmitter<Data_Type> {
 
     auto operator=( Mock_Transmitter const & ) = delete;
 
-    auto handle() noexcept
+    auto handle() noexcept -> Handle
     {
         return Handle{ *this };
     }

--- a/include/picolibrary/testing/unit/error.h
+++ b/include/picolibrary/testing/unit/error.h
@@ -47,7 +47,7 @@ enum class Mock_Error : Error_ID {};
  * \return A pseudo-randomly generated picolibrary::Testing::Unit::Mock_Error.
  */
 template<>
-inline auto random<Mock_Error>()
+inline auto random<Mock_Error>() -> Mock_Error
 {
     return static_cast<Mock_Error>( random<Error_ID>() );
 }
@@ -57,7 +57,7 @@ inline auto random<Mock_Error>()
  */
 class Mock_Error_Category : public Error_Category {
   public:
-    static auto const & instance()
+    static auto instance() -> Mock_Error_Category const &
     {
         static auto category = Mock_Error_Category{};
 
@@ -90,7 +90,7 @@ class Mock_Error_Category : public Error_Category {
  *
  * \return The constructed error code.
  */
-inline auto make_error_code( Mock_Error error ) noexcept
+inline auto make_error_code( Mock_Error error ) noexcept -> Error_Code
 {
     return Error_Code{ Mock_Error_Category::instance(), to_underlying( error ) };
 }

--- a/include/picolibrary/testing/unit/event.h
+++ b/include/picolibrary/testing/unit/event.h
@@ -39,9 +39,9 @@ namespace picolibrary::Testing::Unit {
  */
 class Mock_Event_Category : public Event_Category {
   public:
-    static auto const & instance()
+    static auto instance() -> Mock_Event_Category const &
     {
-        static auto category = Mock_Event_Category{};
+        static auto const category = Mock_Event_Category{};
 
         return category;
     }

--- a/include/picolibrary/testing/unit/gpio.h
+++ b/include/picolibrary/testing/unit/gpio.h
@@ -36,7 +36,7 @@ namespace picolibrary::Testing::Unit {
  * \return A pseudo-randomly generated picolibrary::GPIO::Initial_Pull_Up_State.
  */
 template<>
-inline auto random<GPIO::Initial_Pull_Up_State>()
+inline auto random<GPIO::Initial_Pull_Up_State>() -> GPIO::Initial_Pull_Up_State
 {
     return random<bool>() ? GPIO::Initial_Pull_Up_State::DISABLED
                           : GPIO::Initial_Pull_Up_State::ENABLED;
@@ -48,7 +48,7 @@ inline auto random<GPIO::Initial_Pull_Up_State>()
  * \return A pseudo-randomly generated picolibrary::GPIO::Initial_Pin_State.
  */
 template<>
-inline auto random<GPIO::Initial_Pin_State>()
+inline auto random<GPIO::Initial_Pin_State>() -> GPIO::Initial_Pin_State
 {
     return random<bool>() ? GPIO::Initial_Pin_State::LOW : GPIO::Initial_Pin_State::HIGH;
 }
@@ -89,12 +89,12 @@ class Mock_Input_Pin {
             mock().initialize();
         }
 
-        auto is_low() const
+        auto is_low() const -> bool
         {
             return mock().is_low();
         }
 
-        auto is_high() const
+        auto is_high() const -> bool
         {
             return mock().is_high();
         }
@@ -112,7 +112,7 @@ class Mock_Input_Pin {
 
     auto operator=( Mock_Input_Pin const & ) = delete;
 
-    auto handle() noexcept
+    auto handle() noexcept -> Handle
     {
         return Handle{ *this };
     }
@@ -147,12 +147,12 @@ class Mock_Internally_Pulled_Up_Input_Pin : public Mock_Input_Pin {
 
         auto operator=( Handle const & ) = delete;
 
-        auto & mock() noexcept
+        auto mock() noexcept -> Mock_Internally_Pulled_Up_Input_Pin &
         {
             return static_cast<Mock_Internally_Pulled_Up_Input_Pin &>( Mock_Input_Pin::Handle::mock() );
         }
 
-        auto const & mock() const noexcept
+        auto mock() const noexcept -> Mock_Internally_Pulled_Up_Input_Pin const &
         {
             return static_cast<Mock_Internally_Pulled_Up_Input_Pin const &>(
                 Mock_Input_Pin::Handle::mock() );
@@ -165,12 +165,12 @@ class Mock_Internally_Pulled_Up_Input_Pin : public Mock_Input_Pin {
             mock().initialize( initial_pull_up_state );
         }
 
-        auto pull_up_is_disabled() const
+        auto pull_up_is_disabled() const -> bool
         {
             return mock().pull_up_is_disabled();
         }
 
-        auto pull_up_is_enabled() const
+        auto pull_up_is_enabled() const -> bool
         {
             return mock().pull_up_is_enabled();
         }
@@ -198,7 +198,7 @@ class Mock_Internally_Pulled_Up_Input_Pin : public Mock_Input_Pin {
 
     auto operator=( Mock_Internally_Pulled_Up_Input_Pin const & ) = delete;
 
-    auto handle() noexcept
+    auto handle() noexcept -> Handle
     {
         return Handle{ *this };
     }
@@ -277,7 +277,7 @@ class Mock_Output_Pin {
 
     auto operator=( Mock_Output_Pin const & ) = delete;
 
-    auto handle() noexcept
+    auto handle() noexcept -> Handle
     {
         return Handle{ *this };
     }
@@ -323,12 +323,12 @@ class Mock_IO_Pin {
             mock().initialize( initial_pin_state );
         }
 
-        auto is_low() const
+        auto is_low() const -> bool
         {
             return mock().is_low();
         }
 
-        auto is_high() const
+        auto is_high() const -> bool
         {
             return mock().is_high();
         }
@@ -361,7 +361,7 @@ class Mock_IO_Pin {
 
     auto operator=( Mock_IO_Pin const & ) = delete;
 
-    auto handle() noexcept
+    auto handle() noexcept -> Handle
     {
         return Handle{ *this };
     }

--- a/include/picolibrary/testing/unit/i2c.h
+++ b/include/picolibrary/testing/unit/i2c.h
@@ -47,6 +47,7 @@ namespace picolibrary::Testing::Unit {
  */
 template<>
 inline auto random<I2C::Address_Numeric>( I2C::Address_Numeric min, I2C::Address_Numeric max )
+    -> I2C::Address_Numeric
 {
     return I2C::Address_Numeric{ random<I2C::Address_Numeric::Unsigned_Integer>(
         min.as_unsigned_integer(), max.as_unsigned_integer() ) };
@@ -62,7 +63,7 @@ inline auto random<I2C::Address_Numeric>( I2C::Address_Numeric min, I2C::Address
  *         [min,picolibrary::I2C::Address_Numeric::max()].
  */
 template<>
-inline auto random<I2C::Address_Numeric>( I2C::Address_Numeric min )
+inline auto random<I2C::Address_Numeric>( I2C::Address_Numeric min ) -> I2C::Address_Numeric
 {
     return random<I2C::Address_Numeric>( min, I2C::Address_Numeric::max() );
 }
@@ -74,7 +75,7 @@ inline auto random<I2C::Address_Numeric>( I2C::Address_Numeric min )
  *         [picolibrary::I2C::Address_Numeric::min(),picolibrary::I2C::Address_Numeric::max()].
  */
 template<>
-inline auto random<I2C::Address_Numeric>()
+inline auto random<I2C::Address_Numeric>() -> I2C::Address_Numeric
 {
     return random<I2C::Address_Numeric>( I2C::Address_Numeric::min(), I2C::Address_Numeric::max() );
 }
@@ -90,6 +91,7 @@ inline auto random<I2C::Address_Numeric>()
  */
 template<>
 inline auto random<I2C::Address_Transmitted>( I2C::Address_Transmitted min, I2C::Address_Transmitted max )
+    -> I2C::Address_Transmitted
 {
     return I2C::Address_Transmitted{ static_cast<I2C::Address_Transmitted::Unsigned_Integer>(
         random<I2C::Address_Transmitted::Unsigned_Integer>( min.as_unsigned_integer(), max.as_unsigned_integer() )
@@ -106,7 +108,7 @@ inline auto random<I2C::Address_Transmitted>( I2C::Address_Transmitted min, I2C:
  *         [min,picolibrary::I2C::Address_Transmitted::max()].
  */
 template<>
-inline auto random<I2C::Address_Transmitted>( I2C::Address_Transmitted min )
+inline auto random<I2C::Address_Transmitted>( I2C::Address_Transmitted min ) -> I2C::Address_Transmitted
 {
     return random<I2C::Address_Transmitted>( min, I2C::Address_Transmitted::max() );
 }
@@ -118,7 +120,7 @@ inline auto random<I2C::Address_Transmitted>( I2C::Address_Transmitted min )
  *         [picolibrary::I2C::Address_Transmitted::min(),picolibrary::I2C::Address_Transmitted::max()].
  */
 template<>
-inline auto random<I2C::Address_Transmitted>()
+inline auto random<I2C::Address_Transmitted>() -> I2C::Address_Transmitted
 {
     return random<I2C::Address_Transmitted>(
         I2C::Address_Transmitted::min(), I2C::Address_Transmitted::max() );
@@ -130,7 +132,7 @@ inline auto random<I2C::Address_Transmitted>()
  * \return A pseudo-randomly generated picolibrary::I2C::Operation.
  */
 template<>
-inline auto random<I2C::Operation>()
+inline auto random<I2C::Operation>() -> I2C::Operation
 {
     return random<bool>() ? I2C::Operation::READ : I2C::Operation::WRITE;
 }
@@ -141,7 +143,7 @@ inline auto random<I2C::Operation>()
  * \return A pseudo-randomly generated picolibrary::I2C::Response.
  */
 template<>
-inline auto random<I2C::Response>()
+inline auto random<I2C::Response>() -> I2C::Response
 {
     return random<bool>() ? I2C::Response::ACK : I2C::Response::NACK;
 }
@@ -182,7 +184,7 @@ class Mock_Basic_Controller {
             Mock_Handle<Mock_Basic_Controller>::mock().initialize();
         }
 
-        auto bus_error_present() const
+        auto bus_error_present() const -> bool
         {
             return Mock_Handle<Mock_Basic_Controller>::mock().bus_error_present();
         }
@@ -203,16 +205,17 @@ class Mock_Basic_Controller {
         }
 
         auto address( ::picolibrary::I2C::Address_Transmitted address, ::picolibrary::I2C::Operation operation )
+            -> ::picolibrary::I2C::Response
         {
             return Mock_Handle<Mock_Basic_Controller>::mock().address( address, operation );
         }
 
-        auto read( ::picolibrary::I2C::Response response )
+        auto read( ::picolibrary::I2C::Response response ) -> std::uint8_t
         {
             return Mock_Handle<Mock_Basic_Controller>::mock().read( response );
         }
 
-        auto write( std::uint8_t data )
+        auto write( std::uint8_t data ) -> ::picolibrary::I2C::Response
         {
             return Mock_Handle<Mock_Basic_Controller>::mock().write( data );
         }
@@ -230,7 +233,7 @@ class Mock_Basic_Controller {
 
     auto operator=( Mock_Basic_Controller const & ) = delete;
 
-    auto handle() noexcept
+    auto handle() noexcept -> Handle
     {
         return Handle{ *this };
     }
@@ -279,12 +282,12 @@ class Mock_Controller : public Mock_Basic_Controller {
 
         auto operator=( Handle const & ) = delete;
 
-        auto & mock() noexcept
+        auto mock() noexcept -> Mock_Controller &
         {
             return static_cast<Mock_Controller &>( Mock_Basic_Controller::Handle::mock() );
         }
 
-        auto const & mock() const noexcept
+        auto mock() const noexcept -> Mock_Controller const &
         {
             return static_cast<Mock_Controller const &>( Mock_Basic_Controller::Handle::mock() );
         }
@@ -298,7 +301,7 @@ class Mock_Controller : public Mock_Basic_Controller {
 
         using Mock_Basic_Controller::Handle::write;
 
-        auto write( std::uint8_t const * begin, std::uint8_t const * end )
+        auto write( std::uint8_t const * begin, std::uint8_t const * end ) -> ::picolibrary::I2C::Response
         {
             return mock().write( begin, end );
         }
@@ -316,7 +319,7 @@ class Mock_Controller : public Mock_Basic_Controller {
 
     auto operator=( Mock_Controller const & ) = delete;
 
-    auto handle() noexcept
+    auto handle() noexcept -> Handle
     {
         return Handle{ *this };
     }

--- a/include/picolibrary/testing/unit/indicator.h
+++ b/include/picolibrary/testing/unit/indicator.h
@@ -36,7 +36,7 @@ namespace picolibrary::Testing::Unit {
  * \return A pseudo-randomly generated picolibrary::Indicator::Initial_Indicator_State.
  */
 template<>
-inline auto random<Indicator::Initial_Indicator_State>()
+inline auto random<Indicator::Initial_Indicator_State>() -> Indicator::Initial_Indicator_State
 {
     return random<bool>() ? Indicator::Initial_Indicator_State::EXTINGUISHED
                           : Indicator::Initial_Indicator_State::ILLUMINATED;
@@ -111,7 +111,7 @@ class Mock_Fixed_Intensity_Indicator {
 
     auto operator=( Mock_Fixed_Intensity_Indicator const & ) = delete;
 
-    auto handle() noexcept
+    auto handle() noexcept -> Handle
     {
         return Handle{ *this };
     }

--- a/include/picolibrary/testing/unit/interrupt.h
+++ b/include/picolibrary/testing/unit/interrupt.h
@@ -94,7 +94,7 @@ class Mock_Controller {
 
     auto operator=( Mock_Controller const & ) = delete;
 
-    auto handle() noexcept
+    auto handle() noexcept -> Handle
     {
         return Handle{ *this };
     }

--- a/include/picolibrary/testing/unit/microchip/mcp23s08.h
+++ b/include/picolibrary/testing/unit/microchip/mcp23s08.h
@@ -47,6 +47,7 @@ template<>
 inline auto random<::picolibrary::Microchip::MCP23S08::Address_Numeric>(
     ::picolibrary::Microchip::MCP23S08::Address_Numeric min,
     ::picolibrary::Microchip::MCP23S08::Address_Numeric max )
+    -> ::picolibrary::Microchip::MCP23S08::Address_Numeric
 {
     return ::picolibrary::Microchip::MCP23S08::Address_Numeric{
         random<::picolibrary::Microchip::MCP23S08::Address_Numeric::Unsigned_Integer>(
@@ -67,6 +68,7 @@ inline auto random<::picolibrary::Microchip::MCP23S08::Address_Numeric>(
 template<>
 inline auto random<::picolibrary::Microchip::MCP23S08::Address_Numeric>(
     ::picolibrary::Microchip::MCP23S08::Address_Numeric min )
+    -> ::picolibrary::Microchip::MCP23S08::Address_Numeric
 {
     return random<::picolibrary::Microchip::MCP23S08::Address_Numeric>(
         min, ::picolibrary::Microchip::MCP23S08::Address_Numeric::max() );
@@ -80,6 +82,7 @@ inline auto random<::picolibrary::Microchip::MCP23S08::Address_Numeric>(
  */
 template<>
 inline auto random<::picolibrary::Microchip::MCP23S08::Address_Numeric>()
+    -> ::picolibrary::Microchip::MCP23S08::Address_Numeric
 {
     return random<::picolibrary::Microchip::MCP23S08::Address_Numeric>(
         ::picolibrary::Microchip::MCP23S08::Address_Numeric::min(),
@@ -100,6 +103,7 @@ template<>
 inline auto random<::picolibrary::Microchip::MCP23S08::Address_Transmitted>(
     ::picolibrary::Microchip::MCP23S08::Address_Transmitted min,
     ::picolibrary::Microchip::MCP23S08::Address_Transmitted max )
+    -> ::picolibrary::Microchip::MCP23S08::Address_Transmitted
 {
     return ::picolibrary::Microchip::MCP23S08::Address_Transmitted{
         static_cast<::picolibrary::Microchip::MCP23S08::Address_Transmitted::Unsigned_Integer>(
@@ -122,6 +126,7 @@ inline auto random<::picolibrary::Microchip::MCP23S08::Address_Transmitted>(
 template<>
 inline auto random<::picolibrary::Microchip::MCP23S08::Address_Transmitted>(
     ::picolibrary::Microchip::MCP23S08::Address_Transmitted min )
+    -> ::picolibrary::Microchip::MCP23S08::Address_Transmitted
 {
     return random<::picolibrary::Microchip::MCP23S08::Address_Transmitted>(
         min, ::picolibrary::Microchip::MCP23S08::Address_Transmitted::max() );
@@ -136,6 +141,7 @@ inline auto random<::picolibrary::Microchip::MCP23S08::Address_Transmitted>(
  */
 template<>
 inline auto random<::picolibrary::Microchip::MCP23S08::Address_Transmitted>()
+    -> ::picolibrary::Microchip::MCP23S08::Address_Transmitted
 {
     return random<::picolibrary::Microchip::MCP23S08::Address_Transmitted>(
         ::picolibrary::Microchip::MCP23S08::Address_Transmitted::min(),

--- a/include/picolibrary/testing/unit/microchip/mcp3008.h
+++ b/include/picolibrary/testing/unit/microchip/mcp3008.h
@@ -36,7 +36,7 @@ namespace picolibrary::Testing::Unit {
  * \return A pseudo-randomly generated picolibrary::Microchip::MCP3008::Input.
  */
 template<>
-inline auto random<Microchip::MCP3008::Input>()
+inline auto random<Microchip::MCP3008::Input>() -> Microchip::MCP3008::Input
 {
     return static_cast<Microchip::MCP3008::Input>( random<std::uint_fast8_t>( 0b0'000, 0b1'111 ) << 4 );
 }

--- a/include/picolibrary/testing/unit/mock_handle.h
+++ b/include/picolibrary/testing/unit/mock_handle.h
@@ -42,7 +42,7 @@ class Mock_Handle {
      *
      * \return The mock.
      */
-    auto & mock() noexcept
+    auto mock() noexcept -> Mock &
     {
         return *m_mock;
     }
@@ -52,7 +52,7 @@ class Mock_Handle {
      *
      * \return The mock.
      */
-    auto const & mock() const noexcept
+    auto mock() const noexcept -> Mock const &
     {
         return *m_mock;
     }
@@ -94,7 +94,7 @@ class Mock_Handle {
      *
      * \return The assigned to object.
      */
-    constexpr auto & operator=( Mock_Handle && expression ) noexcept
+    constexpr auto operator=( Mock_Handle && expression ) noexcept -> Mock_Handle &
     {
         if ( &expression != this ) {
             m_mock = expression.m_mock;

--- a/include/picolibrary/testing/unit/random.h
+++ b/include/picolibrary/testing/unit/random.h
@@ -37,7 +37,7 @@ namespace picolibrary::Testing::Unit {
  *
  * \return The unit testing pseudo-random number generator.
  */
-inline auto & pseudo_random_number_generator()
+inline auto pseudo_random_number_generator() -> std::mt19937 &
 {
     static auto generator = std::mt19937{ std::random_device{}() };
 
@@ -55,7 +55,7 @@ inline auto & pseudo_random_number_generator()
  * \return A pseudo-random value in the range [min,max].
  */
 template<typename T>
-auto random( T min, T max )
+auto random( T min, T max ) -> T
 {
     return std::uniform_int_distribution<T>{ min, max }( pseudo_random_number_generator() );
 }
@@ -70,7 +70,7 @@ auto random( T min, T max )
  * \return A pseudo-random value in the range [min,std::numeric_limits<T>::max()].
  */
 template<typename T>
-auto random( T min )
+auto random( T min ) -> T
 {
     return random<T>( min, std::numeric_limits<T>::max() );
 }
@@ -84,7 +84,7 @@ auto random( T min )
  *         [std::numeric_limits<T>::min(),std::numeric_limits<T>::max()].
  */
 template<typename T>
-auto random()
+auto random() -> T
 {
     return random<T>( std::numeric_limits<T>::min(), std::numeric_limits<T>::max() );
 }
@@ -95,9 +95,9 @@ auto random()
  * \return A pseudo-random bool.
  */
 template<>
-inline auto random<bool>()
+inline auto random<bool>() -> bool
 {
-    return static_cast<bool>( random<std::uint_fast8_t>( 0, 1 ) );
+    return random<std::uint_fast8_t>( 0, 1 );
 }
 
 /**
@@ -106,7 +106,7 @@ inline auto random<bool>()
  * \return A pseudo-random char in the range [' ','~'].
  */
 template<>
-inline auto random<char>()
+inline auto random<char>() -> char
 {
     return random<char>( ' ', '~' );
 }
@@ -119,7 +119,7 @@ inline auto random<char>()
  * \return A pair of pseudo-random values that are unique.
  */
 template<typename T>
-auto random_unique_pair()
+auto random_unique_pair() -> std::pair<T, T>
 {
     auto const a = random<T>();
     auto const b = random<T>();
@@ -142,7 +142,7 @@ auto random_unique_pair()
  * \return The generated container.
  */
 template<typename Container, typename Value_Generator>
-auto random_container( std::size_t size, Value_Generator generate_value )
+auto random_container( std::size_t size, Value_Generator generate_value ) -> Container
 {
     auto container = Container{};
 
@@ -164,7 +164,7 @@ auto random_container( std::size_t size, Value_Generator generate_value )
  * \return The generated container.
  */
 template<typename Container>
-auto random_container( std::size_t size = random<std::size_t>( 0, 15 ) )
+auto random_container( std::size_t size = random<std::size_t>( 0, 15 ) ) -> Container
 {
     return random_container<Container>(
         size, []() { return random<typename Container::value_type>(); } );
@@ -182,6 +182,7 @@ auto random_container( std::size_t size = random<std::size_t>( 0, 15 ) )
  */
 template<typename Container>
 auto random_unique_container_pair( std::size_t size = random<std::size_t>( 1, 15 ) )
+    -> std::pair<Container, Container>
 {
     if ( not( size > 0 ) ) {
         throw std::invalid_argument{

--- a/include/picolibrary/testing/unit/spi.h
+++ b/include/picolibrary/testing/unit/spi.h
@@ -73,7 +73,7 @@ class Mock_Basic_Controller {
             Mock_Handle<Mock_Basic_Controller>::mock().configure( configuration );
         }
 
-        auto exchange( std::uint8_t data )
+        auto exchange( std::uint8_t data ) -> std::uint8_t
         {
             return Mock_Handle<Mock_Basic_Controller>::mock().exchange( data );
         }
@@ -91,7 +91,7 @@ class Mock_Basic_Controller {
 
     auto operator=( Mock_Basic_Controller const & ) = delete;
 
-    auto handle() noexcept
+    auto handle() noexcept -> Handle
     {
         return Handle{ *this };
     }
@@ -127,12 +127,12 @@ class Mock_Controller : public Mock_Basic_Controller {
 
         auto operator=( Handle const & ) = delete;
 
-        auto & mock() noexcept
+        auto mock() noexcept -> Mock_Controller &
         {
             return static_cast<Mock_Controller &>( Mock_Basic_Controller::Handle::mock() );
         }
 
-        auto const & mock() const noexcept
+        auto mock() const noexcept -> Mock_Controller const &
         {
             return static_cast<Mock_Controller const &>( Mock_Basic_Controller::Handle::mock() );
         }
@@ -144,7 +144,7 @@ class Mock_Controller : public Mock_Basic_Controller {
             mock().exchange( tx_begin, tx_end, rx_begin, rx_end );
         }
 
-        auto receive()
+        auto receive() -> std::uint8_t
         {
             return mock().receive();
         }
@@ -177,7 +177,7 @@ class Mock_Controller : public Mock_Basic_Controller {
 
     auto operator=( Mock_Controller const & ) = delete;
 
-    auto handle() noexcept
+    auto handle() noexcept -> Handle
     {
         return Handle{ *this };
     }
@@ -269,7 +269,7 @@ class Mock_Device_Selector {
 
     auto operator=( Mock_Device_Selector const & ) = delete;
 
-    auto handle() noexcept
+    auto handle() noexcept -> Handle
     {
         return Handle{ *this };
     }

--- a/include/picolibrary/testing/unit/stream.h
+++ b/include/picolibrary/testing/unit/stream.h
@@ -96,7 +96,7 @@ class Mock_Stream_Buffer : public Stream_Buffer {
  *
  * \return The generated std::string.
  */
-inline auto random_format_string( std::size_t size = random<std::size_t>( 0, 15 ) )
+inline auto random_format_string( std::size_t size = random<std::size_t>( 0, 15 ) ) -> std::string
 {
     return random_container<std::string>( size, []() { return random<char>( ' ', 'z' ); } );
 }
@@ -127,7 +127,7 @@ class Mock_Output_Stream : public Output_Stream {
     using ::picolibrary::Stream::clear_fatal_error;
     using ::picolibrary::Stream::report_fatal_error;
 
-    auto & buffer() noexcept
+    auto buffer() noexcept -> Mock_Stream_Buffer &
     {
         return m_buffer;
     }
@@ -164,7 +164,7 @@ class String_Stream_Buffer final : public Stream_Buffer {
      *
      * \return The string abstracted by the device access buffer.
      */
-    auto const & string() const noexcept
+    auto string() const noexcept -> std::string const &
     {
         return m_string;
     }
@@ -259,7 +259,7 @@ class Output_String_Stream : public Output_Stream {
      *
      * \return The string abstracted by the stream.
      */
-    auto const & string() const noexcept
+    auto string() const noexcept -> std::string const &
     {
         return m_buffer.string();
     }

--- a/test/unit/picolibrary/format/binary/main.cc
+++ b/test/unit/picolibrary/format/binary/main.cc
@@ -48,7 +48,7 @@ using ::testing::A;
 using ::testing::Return;
 
 template<typename Integer>
-auto binary( Integer value )
+auto binary( Integer value ) -> std::string
 {
     using U = std::make_unsigned_t<Integer>;
 

--- a/test/unit/picolibrary/format/decimal/main.cc
+++ b/test/unit/picolibrary/format/decimal/main.cc
@@ -45,7 +45,7 @@ using ::testing::A;
 using ::testing::Return;
 
 template<typename Integer>
-auto decimal( Integer value )
+auto decimal( Integer value ) -> std::string
 {
     auto stream = std::ostringstream{};
 

--- a/test/unit/picolibrary/format/hexadecimal/main.cc
+++ b/test/unit/picolibrary/format/hexadecimal/main.cc
@@ -49,7 +49,7 @@ using ::testing::A;
 using ::testing::Return;
 
 template<typename Integer>
-auto hexadecimal( Integer value )
+auto hexadecimal( Integer value ) -> std::string
 {
     using U = std::make_unsigned_t<Integer>;
 

--- a/test/unit/picolibrary/i2c/address_numeric/main.cc
+++ b/test/unit/picolibrary/i2c/address_numeric/main.cc
@@ -37,11 +37,13 @@ using ::picolibrary::I2C::Address_Transmitted;
 using ::picolibrary::Testing::Unit::random;
 
 auto random_address( Address_Numeric::Unsigned_Integer min = 0b0000000, Address_Numeric::Unsigned_Integer max = 0b1111111 )
+    -> Address_Numeric::Unsigned_Integer
 {
     return random<Address_Numeric::Unsigned_Integer>( min, max );
 }
 
 auto random_unique_address_pair()
+    -> std::pair<Address_Numeric::Unsigned_Integer, Address_Numeric::Unsigned_Integer>
 {
     auto const a = random_address();
     auto const b = random_address();

--- a/test/unit/picolibrary/i2c/address_transmitted/main.cc
+++ b/test/unit/picolibrary/i2c/address_transmitted/main.cc
@@ -36,13 +36,16 @@ using ::picolibrary::I2C::Address_Numeric;
 using ::picolibrary::I2C::Address_Transmitted;
 using ::picolibrary::Testing::Unit::random;
 
-auto random_address( Address_Transmitted::Unsigned_Integer min = 0b0000000'0, Address_Transmitted::Unsigned_Integer max = 0b1111111'0 )
+auto random_address(
+    Address_Transmitted::Unsigned_Integer min = 0b0000000'0,
+    Address_Transmitted::Unsigned_Integer max = 0b1111111'0 ) -> Address_Transmitted::Unsigned_Integer
 {
     return static_cast<Address_Transmitted::Unsigned_Integer>(
         random<Address_Transmitted::Unsigned_Integer>( min, max ) & 0b1111111'0 );
 }
 
 auto random_unique_address_pair()
+    -> std::pair<Address_Transmitted::Unsigned_Integer, Address_Transmitted::Unsigned_Integer>
 {
     auto const a = random_address();
     auto const b = random_address();

--- a/test/unit/picolibrary/microchip/mcp23s08/address_numeric/main.cc
+++ b/test/unit/picolibrary/microchip/mcp23s08/address_numeric/main.cc
@@ -37,11 +37,13 @@ using ::picolibrary::Microchip::MCP23S08::Address_Transmitted;
 using ::picolibrary::Testing::Unit::random;
 
 auto random_address( Address_Numeric::Unsigned_Integer min = 0b01000'00, Address_Numeric::Unsigned_Integer max = 0b01000'11 )
+    -> Address_Numeric::Unsigned_Integer
 {
     return random<Address_Numeric::Unsigned_Integer>( min, max );
 }
 
 auto random_unique_address_pair()
+    -> std::pair<Address_Numeric::Unsigned_Integer, Address_Numeric::Unsigned_Integer>
 {
     auto const a = random_address();
     auto const b = random_address();

--- a/test/unit/picolibrary/microchip/mcp23s08/address_transmitted/main.cc
+++ b/test/unit/picolibrary/microchip/mcp23s08/address_transmitted/main.cc
@@ -36,13 +36,16 @@ using ::picolibrary::Microchip::MCP23S08::Address_Numeric;
 using ::picolibrary::Microchip::MCP23S08::Address_Transmitted;
 using ::picolibrary::Testing::Unit::random;
 
-auto random_address( Address_Transmitted::Unsigned_Integer min = 0b01000'00'0, Address_Transmitted::Unsigned_Integer max = 0b01000'11'0 )
+auto random_address(
+    Address_Transmitted::Unsigned_Integer min = 0b01000'00'0,
+    Address_Transmitted::Unsigned_Integer max = 0b01000'11'0 ) -> Address_Transmitted::Unsigned_Integer
 {
     return static_cast<Address_Transmitted::Unsigned_Integer>(
         random<Address_Transmitted::Unsigned_Integer>( min, max ) & 0b11111'11'0 );
 }
 
 auto random_unique_address_pair()
+    -> std::pair<Address_Transmitted::Unsigned_Integer, Address_Transmitted::Unsigned_Integer>
 {
     auto const a = random_address();
     auto const b = random_address();

--- a/test/unit/picolibrary/output_stream/main.cc
+++ b/test/unit/picolibrary/output_stream/main.cc
@@ -66,7 +66,7 @@ enum class Foo {};
 
 class Mock_Output_Formatter {
   public:
-    static auto & instance()
+    static auto instance() -> Mock_Output_Formatter &
     {
         if ( not INSTANCE ) {
             throw std::logic_error{
@@ -123,19 +123,19 @@ class picolibrary::Output_Formatter<::Foo> {
 
     auto operator=( Output_Formatter const & ) = delete;
 
-    auto parse( char const * format ) noexcept
+    auto parse( char const * format ) noexcept -> char const *
     {
         return ::Mock_Output_Formatter::instance().parse( format );
     }
 
-    auto print( Output_Stream & stream, ::Foo const & foo ) noexcept
+    auto print( Output_Stream & stream, ::Foo const & foo ) noexcept -> Result<std::size_t, Error_Code>
     {
         return ::Mock_Output_Formatter::instance().print( stream, foo );
     }
 };
 
 template<>
-inline auto picolibrary::Testing::Unit::random<::Foo>()
+inline auto picolibrary::Testing::Unit::random<::Foo>() -> ::Foo
 {
     return static_cast<::Foo>( random<std::underlying_type_t<::Foo>>() );
 }


### PR DESCRIPTION
Resolves #1379 (Replace return type deduction with explicit return types
where reasonable).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
