### PR TITLE
Add output stream flushing to SPI echo interactive test helper

### DIFF
--- a/include/picolibrary/testing/interactive/spi.h
+++ b/include/picolibrary/testing/interactive/spi.h
@@ -58,11 +58,18 @@ void echo( Output_Stream & stream, Controller controller, typename Controller::C
     for ( auto tx = std::uint8_t{};; ++tx ) {
         delay();
 
-        auto const rx     = controller.exchange( tx );
-        auto       result = stream.print(
-            "exchange( {} ) -> {}\n", Format::Hexadecimal{ tx }, Format::Hexadecimal{ rx } );
-        expect( not result.is_error(), result.error() );
-        expect( rx == tx, Generic_Error::RUNTIME_ERROR );
+        {
+            auto const rx     = controller.exchange( tx );
+            auto       result = stream.print(
+                "exchange( {} ) -> {}\n", Format::Hexadecimal{ tx }, Format::Hexadecimal{ rx } );
+            expect( not result.is_error(), result.error() );
+            expect( rx == tx, Generic_Error::RUNTIME_ERROR );
+        }
+
+        {
+            auto result = stream.flush();
+            expect( not result.is_error(), result.error() );
+        }
     } // for
 }
 


### PR DESCRIPTION
Resolves #1390 (Add output stream flushing to SPI echo interactive test
helper).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
