### PR TITLE
Fix inconsistent precondition documentation formatting

### DIFF
--- a/include/picolibrary/stream.h
+++ b/include/picolibrary/stream.h
@@ -676,7 +676,7 @@ class Output_Stream : public Stream {
      *            that type.
      * \param[in] values The values to format.
      *
-     * \pre All format specifications found in format are valid.
+     * \pre all format specifications found in format are valid
      *
      * \return The number of characters written to the stream if the write succeeded.
      * \return An error code if the write failed.
@@ -763,7 +763,7 @@ class Output_Stream : public Stream {
      * \param[in] format The format string specifying the format to use for each value to
      *            be formatted.
      *
-     * \pre All format specifications found in format are valid.
+     * \pre all format specifications found in format are valid
      *
      * \return The number of characters written to the stream if the write succeeded.
      * \return An error code if the write failed.
@@ -801,7 +801,7 @@ class Output_Stream : public Stream {
      * \param[in] value The value to format.
      * \param[in] values The values to format.
      *
-     * \pre All format specifications found in format are valid.
+     * \pre all format specifications found in format are valid
      *
      * \return The number of characters written to the stream if the write succeeded.
      * \return An error code if the write failed.

--- a/include/picolibrary/testing/interactive/gpio.h
+++ b/include/picolibrary/testing/interactive/gpio.h
@@ -43,7 +43,7 @@ namespace picolibrary::Testing::Interactive::GPIO {
  * \param[in] delay The nullary functor to call to introduce a delay each time the pin's
  *            state is gotten.
  *
- * \pre Writing to stream succeeds.
+ * \pre writing to the stream succeeds
  */
 template<typename Input_Pin, typename Delayer>
 void state( Output_Stream & stream, Input_Pin pin, Delayer delay ) noexcept


### PR DESCRIPTION
Resolves #1392 (Fix inconsistent precondition documentation formatting).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
