### PR TITLE
Add CRC augmented byte indexed lookup table calculator

### DIFF
--- a/include/picolibrary/crc.h
+++ b/include/picolibrary/crc.h
@@ -421,6 +421,163 @@ constexpr auto generate_byte_indexed_lookup_table( Register polynomial ) noexcep
     return lookup_table;
 }
 
+/**
+ * \brief Augmented byte indexed lookup table calculator.
+ *
+ * This calculator implementation processes messages one byte at a time, and requires a
+ * message augment to push the entirety of a message through the calculation. While this
+ * results in higher memory use than bitwise implementations and table driven
+ * implementations that process messages one nibble at a time, performance is higher due
+ * to the message processing loop requiring fewer iterations to process a message.
+ *
+ * \tparam Register_Type Calculation register type.
+ */
+template<typename Register_Type>
+class Augmented_Byte_Indexed_Lookup_Table_Calculator {
+  public:
+    /**
+     * \brief Calculation register type.
+     */
+    using Register = Register_Type;
+
+    /**
+     * \brief Constructor.
+     */
+    constexpr Augmented_Byte_Indexed_Lookup_Table_Calculator() noexcept = default;
+
+    /**
+     * \brief Constructor.
+     *
+     * \param[in] calculation_parameters The calculation parameters.
+     */
+    constexpr Augmented_Byte_Indexed_Lookup_Table_Calculator(
+        Calculation_Parameters<Register> const & calculation_parameters ) noexcept :
+        m_lookup_table{ generate_byte_indexed_lookup_table( calculation_parameters.polynomial ) },
+        m_initial_remainder{ calculation_parameters.initial_remainder },
+        m_process_input{ input_processor( calculation_parameters.input_is_reflected ) },
+        m_process_output{ output_processor<Register>( calculation_parameters.output_is_reflected ) },
+        m_xor_output{ calculation_parameters.xor_output }
+    {
+    }
+
+    /**
+     * \brief Constructor.
+     *
+     * \param[in] source The source of the move.
+     */
+    constexpr Augmented_Byte_Indexed_Lookup_Table_Calculator(
+        Augmented_Byte_Indexed_Lookup_Table_Calculator && source ) noexcept = default;
+
+    /**
+     * \brief Constructor.
+     *
+     * \param[in] original The original to copy.
+     */
+    constexpr Augmented_Byte_Indexed_Lookup_Table_Calculator(
+        Augmented_Byte_Indexed_Lookup_Table_Calculator const & original ) noexcept = default;
+
+    /**
+     * \brief Destructor.
+     */
+    ~Augmented_Byte_Indexed_Lookup_Table_Calculator() noexcept = default;
+
+    /**
+     * \brief Assignment operator.
+     *
+     * \param[in] expression The expression to be assigned.
+     *
+     * \return The assigned to object.
+     */
+    constexpr auto operator=( Augmented_Byte_Indexed_Lookup_Table_Calculator && expression ) noexcept
+        -> Augmented_Byte_Indexed_Lookup_Table_Calculator & = default;
+
+    /**
+     * \brief Assignment operator.
+     *
+     * \param[in] expression The expression to be assigned.
+     *
+     * \return The assigned to object.
+     */
+    constexpr auto operator=( Augmented_Byte_Indexed_Lookup_Table_Calculator const & expression ) noexcept
+        -> Augmented_Byte_Indexed_Lookup_Table_Calculator & = default;
+
+    /**
+     * \brief Calculate the remainder for a message.
+     *
+     * \tparam Iterator Message iterator. The iterated over type must be convertible to
+     *         std::uint8_t.
+     *
+     * \param[in] begin The beginning of the message.
+     * \param[in] end The end of the message.
+     *
+     * \return The remainder for the message.
+     */
+    template<typename Iterator>
+    constexpr auto calculate( Iterator begin, Iterator end ) const noexcept -> Register
+    {
+        return ( *m_process_output )( feed(
+                   feed( m_initial_remainder, begin, end ),
+                   MESSAGE_AUGMENT<Register>.begin(),
+                   MESSAGE_AUGMENT<Register>.end() ) )
+               ^ m_xor_output;
+    }
+
+  private:
+    /**
+     * \brief Calculation lookup table.
+     */
+    Byte_Indexed_Lookup_Table<Register> m_lookup_table{};
+
+    /**
+     * \brief Calculation initial remainder.
+     */
+    Register m_initial_remainder{};
+
+    /**
+     * \brief Calculation input processor.
+     */
+    Input_Processor m_process_input{};
+
+    /**
+     * \brief Calculation output processor.
+     */
+    Output_Processor<Register> m_process_output{};
+
+    /**
+     * \brief Calculation XOR output value.
+     */
+    Register m_xor_output{};
+
+    /**
+     * \brief Feed data into the calculation.
+     *
+     * \tparam Iterator Message / message augment iterator. The iterated over type must be
+     *         convertible to std::uint8_t.
+     *
+     * \param[in] remainder The current calculation remainder.
+     * \param[in] begin The beginning of the message / message augment.
+     * \param[in] end The end of the message / message augment.
+     *
+     * \return The new calculation remainder.
+     */
+    template<typename Iterator>
+    auto feed( Register remainder, Iterator begin, Iterator end ) const noexcept
+    {
+        for ( ; begin != end; ++begin ) {
+            auto const processed_input = ( *m_process_input )( *begin );
+
+            auto const i = static_cast<std::uint8_t>(
+                remainder
+                >> ( std::numeric_limits<Register>::digits - std::numeric_limits<std::uint8_t>::digits ) );
+
+            remainder = ( ( remainder << std::numeric_limits<std::uint8_t>::digits ) | processed_input )
+                        ^ m_lookup_table[ i ];
+        } // for
+
+        return remainder;
+    }
+};
+
 } // namespace picolibrary::CRC
 
 #endif // PICOLIBRARY_CRC_H

--- a/test/automated/picolibrary/crc/augmented_byte_indexed_lookup_table_calculator/CMakeLists.txt
+++ b/test/automated/picolibrary/crc/augmented_byte_indexed_lookup_table_calculator/CMakeLists.txt
@@ -13,28 +13,23 @@
 # KIND, either express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-# Description: picolibrary::CRC automated tests CMake rules.
+# Description: picolibrary::CRC::Augmented_Byte_Indexed_Lookup_Table_Calculator automated
+#       tests CMake rules.
 
 # build the picolibrary::CRC::Augmented_Byte_Indexed_Lookup_Table_Calculator automated
 # tests
-add_subdirectory( augmented_byte_indexed_lookup_table_calculator )
-
-# build the picolibrary::CRC::Bitwise_Calculator automated tests
-add_subdirectory( bitwise_calculator )
-
-# build the picolibrary::CRC automated tests
 if( ${PICOLIBRARY_ENABLE_AUTOMATED_TESTING} )
     add_executable(
-        test-automated-picolibrary-crc
+        test-automated-picolibrary-crc-augmented_byte_indexed_lookup_table_calculator
         main.cc
     )
     target_link_libraries(
-        test-automated-picolibrary-crc
+        test-automated-picolibrary-crc-augmented_byte_indexed_lookup_table_calculator
         picolibrary
         picolibrary-testing-automated-fatal_error
     )
     add_test(
-        NAME    test-automated-picolibrary-crc
-        COMMAND test-automated-picolibrary-crc --gtest_color=yes
+        NAME    test-automated-picolibrary-crc-augmented_byte_indexed_lookup_table_calculator
+        COMMAND test-automated-picolibrary-crc-augmented_byte_indexed_lookup_table_calculator --gtest_color=yes
     )
 endif( ${PICOLIBRARY_ENABLE_AUTOMATED_TESTING} )

--- a/test/automated/picolibrary/crc/augmented_byte_indexed_lookup_table_calculator/main.cc
+++ b/test/automated/picolibrary/crc/augmented_byte_indexed_lookup_table_calculator/main.cc
@@ -1,0 +1,78 @@
+/**
+ * picolibrary
+ *
+ * Copyright 2020-2022, Andrew Countryman <apcountryman@gmail.com> and the picolibrary
+ * contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/**
+ * \file
+ * \brief picolibrary::CRC::Augmented_Byte_Indexed_Lookup_Table_Calculator automated test
+ *        program.
+ */
+
+#include <cstdint>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "picolibrary/crc.h"
+#include "picolibrary/testing/automated/crc.h"
+
+namespace {
+
+using ::picolibrary::CRC::Augmented_Byte_Indexed_Lookup_Table_Calculator;
+
+} // namespace
+
+/**
+ * \brief Verify picolibrary::CRC::Augmented_Byte_Indexed_Lookup_Table_Calculator works
+ *        properly.
+ */
+INSTANTIATE_TYPED_TEST_SUITE_P(
+    augmentedByteIndexedLookupTable,
+    calculatorUint8Register,
+    Augmented_Byte_Indexed_Lookup_Table_Calculator<std::uint8_t> );
+
+/**
+ * \brief Verify picolibrary::CRC::Augmented_Byte_Indexed_Lookup_Table_Calculator works
+ *        properly.
+ */
+INSTANTIATE_TYPED_TEST_SUITE_P(
+    augmentedByteIndexedLookupTable,
+    calculatorUint16Register,
+    Augmented_Byte_Indexed_Lookup_Table_Calculator<std::uint16_t> );
+
+/**
+ * \brief Verify picolibrary::CRC::Augmented_Byte_Indexed_Lookup_Table_Calculator works
+ *        properly.
+ */
+INSTANTIATE_TYPED_TEST_SUITE_P(
+    augmentedByteIndexedLookupTable,
+    calculatorUint32Register,
+    Augmented_Byte_Indexed_Lookup_Table_Calculator<std::uint32_t> );
+
+/**
+ * \brief Execute the picolibrary::CRC::Augmented_Byte_Indexed_Lookup_Table_Calculator
+ *        automated tests.
+ *
+ * \param[in] argc The number of arguments to pass to testing::InitGoogleMock().
+ * \param[in] argc The array of arguments to pass to testing::InitGoogleMock().
+ *
+ * \return See Google Test's RUN_ALL_TESTS().
+ */
+int main( int argc, char * argv[] )
+{
+    ::testing::InitGoogleMock( &argc, argv );
+
+    return RUN_ALL_TESTS();
+}

--- a/test/automated/picolibrary/crc/main.cc
+++ b/test/automated/picolibrary/crc/main.cc
@@ -30,6 +30,7 @@
 
 namespace {
 
+using ::picolibrary::CRC::Augmented_Byte_Indexed_Lookup_Table_Calculator;
 using ::picolibrary::CRC::Bitwise_Calculator;
 using ::picolibrary::CRC::Calculation_Parameters;
 using ::picolibrary::Testing::Automated::random;
@@ -83,7 +84,10 @@ TYPED_TEST( calculatorImplementations, areEquivalent )
         auto const remainder = Bitwise_Calculator{ test_case.calculation_parameters }.calculate(
             message.begin(), message.end() );
 
-        static_cast<void>( remainder );
+        EXPECT_EQ(
+            Augmented_Byte_Indexed_Lookup_Table_Calculator{ test_case.calculation_parameters }
+                .calculate( message.begin(), message.end() ),
+            remainder );
     } // for
 }
 


### PR DESCRIPTION
Resolves #1432 (Add CRC augmented byte indexed lookup table calculator).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
