### PR TITLE
Remove cppcheck usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,20 +26,6 @@ on:
             - main
 
 jobs:
-    analyze-static-cppcheck:
-        name: Analyze (static) - cppcheck
-        runs-on: ubuntu-20.04
-        steps:
-            - uses: actions/checkout@v2
-              with:
-                  submodules: recursive
-            - name: Install dependencies
-              shell: bash
-              run: sudo apt update && sudo apt install cppcheck
-            - name: Analyze
-              shell: bash
-              run: ./ci/analyze --analyzer cppcheck
-
     analyze-static-clang-tidy:
         name: Analyze (static) - clang-tidy
         runs-on: ubuntu-20.04

--- a/ci/analyze
+++ b/ci/analyze
@@ -48,7 +48,6 @@ function display_help_text()
     echo "        Specify the analyzer to run against picolibrary. The following"
     echo "        analyzers are supported:"
     echo "            clang-tidy"
-    echo "            cppcheck"
     echo "            lizard"
     echo "            shellcheck"
     echo "    --help"
@@ -59,7 +58,6 @@ function display_help_text()
     echo "    $mnemonic --help"
     echo "    $mnemonic --version"
     echo "    $mnemonic --analyzer clang-tidy"
-    echo "    $mnemonic --analyzer cppcheck"
     echo "    $mnemonic --analyzer lizard"
     echo "    $mnemonic --analyzer shellcheck"
 }
@@ -74,21 +72,6 @@ function generate_compilation_database()
     local -r build_configuration="$repository/configuration/analysis/CMakeLists.txt"
 
     if ! cmake -C "$build_configuration" -S "$repository" -B "$build_directory"; then
-        abort
-    fi
-}
-
-function run_cppcheck()
-{
-    generate_compilation_database
-
-    local -r cppcheck_options=(
-        "--template=gcc"
-        "--project=$repository/build/analysis/compile_commands.json"
-        "-i$repository/googletest"
-    )
-
-    if ! cppcheck "${cppcheck_options[@]}"; then
         abort
     fi
 }
@@ -158,7 +141,7 @@ function main()
 
                 local -r analyzer="$1"; shift
 
-                if [[ "$analyzer" != "clang-tidy" && "$analyzer" != "cppcheck" && "$analyzer" != "lizard" && "$analyzer" != "shellcheck" ]]; then
+                if [[ "$analyzer" != "clang-tidy" && "$analyzer" != "lizard" && "$analyzer" != "shellcheck" ]]; then
                     abort "'$analyzer' is not a supported analyzer"
                 fi
                 ;;


### PR DESCRIPTION
Resolves #1450 (Remove cppcheck usage).

The readily available version of cppcheck (1.90) does not support C++17
which resulted in syntax errors when it was run against picolibrary.

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
