### PR TITLE
Make all constructors for device communication controllers and drivers noexcept

### DIFF
--- a/include/picolibrary/microchip/mcp23008.h
+++ b/include/picolibrary/microchip/mcp23008.h
@@ -85,7 +85,7 @@ class Driver : public Device {
     /**
      * \brief Constructor.
      */
-    constexpr Driver() = default;
+    constexpr Driver() noexcept = default;
 
     /**
      * \brief Constructor.

--- a/include/picolibrary/microchip/mcp23s08.h
+++ b/include/picolibrary/microchip/mcp23s08.h
@@ -547,7 +547,7 @@ class Communication_Controller : public Device {
     /**
      * \brief Constructor.
      */
-    constexpr Communication_Controller() = default;
+    constexpr Communication_Controller() noexcept = default;
 
     /**
      * \brief Constructor.
@@ -658,7 +658,7 @@ class Driver : public Communication_Controller {
     /**
      * \brief Constructor.
      */
-    constexpr Driver() = default;
+    constexpr Driver() noexcept = default;
 
     /**
      * \brief Constructor.

--- a/include/picolibrary/microchip/mcp3008.h
+++ b/include/picolibrary/microchip/mcp3008.h
@@ -82,7 +82,7 @@ class Driver : public Device {
     /**
      * \brief Constructor.
      */
-    constexpr Driver() = default;
+    constexpr Driver() noexcept = default;
 
     /**
      * \brief Constructor.

--- a/include/picolibrary/testing/automated/i2c.h
+++ b/include/picolibrary/testing/automated/i2c.h
@@ -354,9 +354,11 @@ class Mock_Controller : public Mock_Basic_Controller {
  */
 class Mock_Device {
   public:
-    Mock_Device() = default;
+    Mock_Device() noexcept
+    {
+    }
 
-    Mock_Device( std::function<void()>, Mock_Controller &, ::picolibrary::I2C::Address_Transmitted, Error_Code const & )
+    Mock_Device( std::function<void()>, Mock_Controller &, ::picolibrary::I2C::Address_Transmitted, Error_Code const & ) noexcept
     {
     }
 

--- a/include/picolibrary/testing/automated/microchip/mcp23s08.h
+++ b/include/picolibrary/testing/automated/microchip/mcp23s08.h
@@ -160,13 +160,15 @@ namespace picolibrary::Testing::Automated::Microchip::MCP23S08 {
  */
 class Mock_Communication_Controller : public SPI::Mock_Device {
   public:
-    Mock_Communication_Controller() = default;
+    Mock_Communication_Controller() noexcept
+    {
+    }
 
     Mock_Communication_Controller(
         SPI::Mock_Controller &,
         SPI::Mock_Controller::Configuration const &,
         SPI::Mock_Device_Selector::Handle,
-        ::picolibrary::Microchip::MCP23S08::Address_Transmitted )
+        ::picolibrary::Microchip::MCP23S08::Address_Transmitted ) noexcept
     {
     }
 

--- a/include/picolibrary/testing/automated/spi.h
+++ b/include/picolibrary/testing/automated/spi.h
@@ -286,9 +286,11 @@ class Mock_Device_Selector {
  */
 class Mock_Device {
   public:
-    Mock_Device() = default;
+    Mock_Device() noexcept
+    {
+    }
 
-    Mock_Device( Mock_Controller &, Mock_Controller::Configuration const &, Mock_Device_Selector::Handle )
+    Mock_Device( Mock_Controller &, Mock_Controller::Configuration const &, Mock_Device_Selector::Handle ) noexcept
     {
     }
 

--- a/test/automated/picolibrary/microchip/mcp23s08/communication_controller/main.cc
+++ b/test/automated/picolibrary/microchip/mcp23s08/communication_controller/main.cc
@@ -50,7 +50,7 @@ class Communication_Controller :
         Mock_Controller &                      controller,
         Mock_Controller::Configuration const & configuration,
         Mock_Device_Selector::Handle           device_selector,
-        Address_Transmitted                    address ) :
+        Address_Transmitted                    address ) noexcept :
         ::picolibrary::Microchip::MCP23S08::Communication_Controller<Mock_Controller, Mock_Device_Selector::Handle, Mock_Device>{
             controller,
             configuration,


### PR DESCRIPTION
Resolves #1474 (Make all constructors for device communication
controllers and drivers noexcept).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
