### PR TITLE
Disable clang-tidy readability-qualified-auto check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -41,6 +41,7 @@ Checks: >
     -readability-magic-numbers,
     -readability-named-parameter,
     -readability-non-const-parameter,
+    -readability-qualified-auto,
     -zircon*
 
 WarningsAsErrors: '*'


### PR DESCRIPTION
Resolves #1502 (Disable clang-tidy readability-qualified-auto check).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
