### PR TITLE
Replace formatted output format strings with directly constructed output formatters

### DIFF
--- a/include/picolibrary/event.h
+++ b/include/picolibrary/event.h
@@ -222,8 +222,6 @@ class Event {
 
 /**
  * \brief picolibrary::Event output formatter.
- *
- * picolibrary::Event only supports the default format specification ("{}").
  */
 template<>
 class Output_Formatter<Event> {
@@ -233,31 +231,43 @@ class Output_Formatter<Event> {
      */
     constexpr Output_Formatter() noexcept = default;
 
-    Output_Formatter( Output_Formatter && ) = delete;
+    /**
+     * \brief Constructor.
+     *
+     * \param[in] source The source of the move.
+     */
+    constexpr Output_Formatter( Output_Formatter && source ) = default;
 
-    Output_Formatter( Output_Formatter const & ) = delete;
+    /**
+     * \brief Constructor.
+     *
+     * \param[in] original The original to copy.
+     */
+    constexpr Output_Formatter( Output_Formatter const & original ) = default;
 
     /**
      * \brief Destructor.
      */
     ~Output_Formatter() noexcept = default;
 
-    auto operator=( Output_Formatter && ) = delete;
-
-    auto operator=( Output_Formatter const & ) = delete;
+    /**
+     * \brief Assignment operator.
+     *
+     * \param[in] expression The expression to be assigned.
+     *
+     * \return The assigned to object.
+     */
+    constexpr auto operator=( Output_Formatter && expression ) noexcept -> Output_Formatter & = default;
 
     /**
-     * \brief Parse the format specification for the picolibrary::Event to be formatted.
+     * \brief Assignment operator.
      *
-     * \param[in] format The format specification for the picolibrary::Event to be
-     *            formatted.
+     * \param[in] expression The expression to be assigned.
      *
-     * \return format
+     * \return The assigned to object.
      */
-    constexpr auto parse( char const * format ) noexcept -> char const *
-    {
-        return format;
-    }
+    constexpr auto operator   =( Output_Formatter const & expression ) noexcept
+        -> Output_Formatter & = default;
 
     /**
      * \brief Write the formatted picolibrary::Event to the stream.
@@ -268,12 +278,13 @@ class Output_Formatter<Event> {
      * \return The number of characters written to the stream if the write succeeded.
      * \return An error code if the write failed.
      */
-    auto print( Output_Stream & stream, Event const & event ) noexcept -> Result<std::size_t, Error_Code>
+    auto print( Output_Stream & stream, Event const & event ) const noexcept
+        -> Result<std::size_t, Error_Code>
     {
         auto characters_written = std::size_t{};
 
         {
-            auto result = stream.print( "{}::{}", event.category().name(), event.description() );
+            auto result = stream.print( event.category().name(), "::", event.description() );
             if ( result.is_error() ) {
                 return result.error();
             } // if

--- a/include/picolibrary/event.h
+++ b/include/picolibrary/event.h
@@ -236,14 +236,14 @@ class Output_Formatter<Event> {
      *
      * \param[in] source The source of the move.
      */
-    constexpr Output_Formatter( Output_Formatter && source ) = default;
+    constexpr Output_Formatter( Output_Formatter && source ) noexcept = default;
 
     /**
      * \brief Constructor.
      *
      * \param[in] original The original to copy.
      */
-    constexpr Output_Formatter( Output_Formatter const & original ) = default;
+    constexpr Output_Formatter( Output_Formatter const & original ) noexcept = default;
 
     /**
      * \brief Destructor.

--- a/include/picolibrary/format.h
+++ b/include/picolibrary/format.h
@@ -271,8 +271,6 @@ namespace picolibrary {
 /**
  * \brief picolibrary::Format::Binary output formatter.
  *
- * picolibrary::Format::Binary only supports the default format specification ("{}").
- *
  * \tparam Integer The type of integer to print.
  */
 template<typename Integer>
@@ -283,32 +281,43 @@ class Output_Formatter<Format::Binary<Integer>> {
      */
     constexpr Output_Formatter() noexcept = default;
 
-    Output_Formatter( Output_Formatter && ) = delete;
+    /**
+     * \brief Constructor.
+     *
+     * \param[in] source The source of the move.
+     */
+    constexpr Output_Formatter( Output_Formatter && source ) = default;
 
-    Output_Formatter( Output_Formatter const & ) = delete;
+    /**
+     * \brief Constructor.
+     *
+     * \param[in] original The original to copy.
+     */
+    constexpr Output_Formatter( Output_Formatter const & original ) = default;
 
     /**
      * \brief Destructor.
      */
     ~Output_Formatter() noexcept = default;
 
-    auto operator=( Output_Formatter && ) = delete;
-
-    auto operator=( Output_Formatter const & ) = delete;
+    /**
+     * \brief Assignment operator.
+     *
+     * \param[in] expression The expression to be assigned.
+     *
+     * \return The assigned to object.
+     */
+    constexpr auto operator=( Output_Formatter && expression ) noexcept -> Output_Formatter & = default;
 
     /**
-     * \brief Parse the format specification for the picolibrary::Format::Binary to be
-     *        formatted.
+     * \brief Assignment operator.
      *
-     * \param[in] format The format specification for the picolibrary::Format::Binary to
-     *            be formatted.
+     * \param[in] expression The expression to be assigned.
      *
-     * \return format
+     * \return The assigned to object.
      */
-    constexpr auto parse( char const * format ) noexcept -> char const *
-    {
-        return format;
-    }
+    constexpr auto operator   =( Output_Formatter const & expression ) noexcept
+        -> Output_Formatter & = default;
 
     /**
      * \brief Write the formatted picolibrary::Format::Binary to the stream.
@@ -320,7 +329,7 @@ class Output_Formatter<Format::Binary<Integer>> {
      * \return An error code if the write failed.
      */
     // NOLINTNEXTLINE(readability-function-size)
-    auto print( Output_Stream & stream, Integer value ) noexcept -> Result<std::size_t, Error_Code>
+    auto print( Output_Stream & stream, Integer value ) const noexcept -> Result<std::size_t, Error_Code>
     {
         // #lizard forgives the length
 
@@ -357,8 +366,6 @@ class Output_Formatter<Format::Binary<Integer>> {
 /**
  * \brief picolibrary::Format::Decimal output formatter.
  *
- * picolibrary::Format::Decimal only supports the default format specification ("{}").
- *
  * \tparam Integer The type of integer to print.
  */
 template<typename Integer>
@@ -369,32 +376,43 @@ class Output_Formatter<Format::Decimal<Integer>, std::enable_if_t<std::is_signed
      */
     constexpr Output_Formatter() noexcept = default;
 
-    Output_Formatter( Output_Formatter && ) = delete;
+    /**
+     * \brief Constructor.
+     *
+     * \param[in] source The source of the move.
+     */
+    constexpr Output_Formatter( Output_Formatter && source ) = default;
 
-    Output_Formatter( Output_Formatter const & ) = delete;
+    /**
+     * \brief Constructor.
+     *
+     * \param[in] original The original to copy.
+     */
+    constexpr Output_Formatter( Output_Formatter const & original ) = default;
 
     /**
      * \brief Destructor.
      */
     ~Output_Formatter() noexcept = default;
 
-    auto operator=( Output_Formatter && ) = delete;
-
-    auto operator=( Output_Formatter const & ) = delete;
+    /**
+     * \brief Assignment operator.
+     *
+     * \param[in] expression The expression to be assigned.
+     *
+     * \return The assigned to object.
+     */
+    constexpr auto operator=( Output_Formatter && expression ) noexcept -> Output_Formatter & = default;
 
     /**
-     * \brief Parse the format specification for the picolibrary::Format::Decimal to be
-     *        formatted.
+     * \brief Assignment operator.
      *
-     * \param[in] format The format specification for the picolibrary::Format::Decimal to
-     *            be formatted.
+     * \param[in] expression The expression to be assigned.
      *
-     * \return format
+     * \return The assigned to object.
      */
-    constexpr auto parse( char const * format ) noexcept -> char const *
-    {
-        return format;
-    }
+    constexpr auto operator   =( Output_Formatter const & expression ) noexcept
+        -> Output_Formatter & = default;
 
     /**
      * \brief Write the formatted picolibrary::Format::Decimal to the stream.
@@ -407,7 +425,7 @@ class Output_Formatter<Format::Decimal<Integer>, std::enable_if_t<std::is_signed
      * \return An error code if the write failed.
      */
     // NOLINTNEXTLINE(readability-function-size)
-    auto print( Output_Stream & stream, Integer value ) noexcept -> Result<std::size_t, Error_Code>
+    auto print( Output_Stream & stream, Integer value ) const noexcept -> Result<std::size_t, Error_Code>
     {
         // #lizard forgives the length
 
@@ -442,8 +460,6 @@ class Output_Formatter<Format::Decimal<Integer>, std::enable_if_t<std::is_signed
 /**
  * \brief picolibrary::Format::Decimal output formatter.
  *
- * picolibrary::Format::Decimal only supports the default format specification ("{}").
- *
  * \tparam Integer The type of integer to print.
  */
 template<typename Integer>
@@ -454,32 +470,43 @@ class Output_Formatter<Format::Decimal<Integer>, std::enable_if_t<std::is_unsign
      */
     constexpr Output_Formatter() noexcept = default;
 
-    Output_Formatter( Output_Formatter && ) = delete;
+    /**
+     * \brief Constructor.
+     *
+     * \param[in] source The source of the move.
+     */
+    constexpr Output_Formatter( Output_Formatter && source ) = default;
 
-    Output_Formatter( Output_Formatter const & ) = delete;
+    /**
+     * \brief Constructor.
+     *
+     * \param[in] original The original to copy.
+     */
+    constexpr Output_Formatter( Output_Formatter const & original ) = default;
 
     /**
      * \brief Destructor.
      */
     ~Output_Formatter() noexcept = default;
 
-    auto operator=( Output_Formatter && ) = delete;
-
-    auto operator=( Output_Formatter const & ) = delete;
+    /**
+     * \brief Assignment operator.
+     *
+     * \param[in] expression The expression to be assigned.
+     *
+     * \return The assigned to object.
+     */
+    constexpr auto operator=( Output_Formatter && expression ) noexcept -> Output_Formatter & = default;
 
     /**
-     * \brief Parse the format specification for the picolibrary::Format::Decimal to be
-     *        formatted.
+     * \brief Assignment operator.
      *
-     * \param[in] format The format specification for the picolibrary::Format::Decimal to
-     *            be formatted.
+     * \param[in] expression The expression to be assigned.
      *
-     * \return format
+     * \return The assigned to object.
      */
-    constexpr auto parse( char const * format ) noexcept -> char const *
-    {
-        return format;
-    }
+    constexpr auto operator   =( Output_Formatter const & expression ) noexcept
+        -> Output_Formatter & = default;
 
     /**
      * \brief Write the formatted picolibrary::Format::Decimal to the stream.
@@ -491,7 +518,7 @@ class Output_Formatter<Format::Decimal<Integer>, std::enable_if_t<std::is_unsign
      * \return The number of characters written to the stream if the write succeeded.
      * \return An error code if the write failed.
      */
-    auto print( Output_Stream & stream, Integer value ) noexcept -> Result<std::size_t, Error_Code>
+    auto print( Output_Stream & stream, Integer value ) const noexcept -> Result<std::size_t, Error_Code>
     {
         Array<char, std::numeric_limits<Integer>::digits10 + 1> decimal;
 
@@ -515,8 +542,6 @@ class Output_Formatter<Format::Decimal<Integer>, std::enable_if_t<std::is_unsign
 /**
  * \brief picolibrary::Format::Hexadecimal output formatter.
  *
- * picolibrary::Format::Hexadecimal only supports the default format specification ("{}").
- *
  * \tparam Integer The type of integer to print.
  */
 template<typename Integer>
@@ -527,32 +552,43 @@ class Output_Formatter<Format::Hexadecimal<Integer>> {
      */
     constexpr Output_Formatter() noexcept = default;
 
-    Output_Formatter( Output_Formatter && ) = delete;
+    /**
+     * \brief Constructor.
+     *
+     * \param[in] source The source of the move.
+     */
+    constexpr Output_Formatter( Output_Formatter && source ) = default;
 
-    Output_Formatter( Output_Formatter const & ) = delete;
+    /**
+     * \brief Constructor.
+     *
+     * \param[in] original The original to copy.
+     */
+    constexpr Output_Formatter( Output_Formatter const & original ) = default;
 
     /**
      * \brief Destructor.
      */
     ~Output_Formatter() noexcept = default;
 
-    auto operator=( Output_Formatter && ) = delete;
-
-    auto operator=( Output_Formatter const & ) = delete;
+    /**
+     * \brief Assignment operator.
+     *
+     * \param[in] expression The expression to be assigned.
+     *
+     * \return The assigned to object.
+     */
+    constexpr auto operator=( Output_Formatter && expression ) noexcept -> Output_Formatter & = default;
 
     /**
-     * \brief Parse the format specification for the picolibrary::Format::Hexadecimal to
-     *        be formatted.
+     * \brief Assignment operator.
      *
-     * \param[in] format The format specification for the picolibrary::Format::Hexadecimal
-     *            to be formatted.
+     * \param[in] expression The expression to be assigned.
      *
-     * \return format
+     * \return The assigned to object.
      */
-    constexpr auto parse( char const * format ) noexcept -> char const *
-    {
-        return format;
-    }
+    constexpr auto operator   =( Output_Formatter const & expression ) noexcept
+        -> Output_Formatter & = default;
 
     /**
      * \brief Write the formatted picolibrary::Format::Hexadecimal to the stream.
@@ -565,7 +601,7 @@ class Output_Formatter<Format::Hexadecimal<Integer>> {
      * \return An error code if the write failed.
      */
     // NOLINTNEXTLINE(readability-function-size)
-    auto print( Output_Stream & stream, Integer value ) noexcept -> Result<std::size_t, Error_Code>
+    auto print( Output_Stream & stream, Integer value ) const noexcept -> Result<std::size_t, Error_Code>
     {
         // #lizard forgives the length
 

--- a/include/picolibrary/format.h
+++ b/include/picolibrary/format.h
@@ -286,14 +286,14 @@ class Output_Formatter<Format::Binary<Integer>> {
      *
      * \param[in] source The source of the move.
      */
-    constexpr Output_Formatter( Output_Formatter && source ) = default;
+    constexpr Output_Formatter( Output_Formatter && source ) noexcept = default;
 
     /**
      * \brief Constructor.
      *
      * \param[in] original The original to copy.
      */
-    constexpr Output_Formatter( Output_Formatter const & original ) = default;
+    constexpr Output_Formatter( Output_Formatter const & original ) noexcept = default;
 
     /**
      * \brief Destructor.
@@ -381,14 +381,14 @@ class Output_Formatter<Format::Decimal<Integer>, std::enable_if_t<std::is_signed
      *
      * \param[in] source The source of the move.
      */
-    constexpr Output_Formatter( Output_Formatter && source ) = default;
+    constexpr Output_Formatter( Output_Formatter && source ) noexcept = default;
 
     /**
      * \brief Constructor.
      *
      * \param[in] original The original to copy.
      */
-    constexpr Output_Formatter( Output_Formatter const & original ) = default;
+    constexpr Output_Formatter( Output_Formatter const & original ) noexcept = default;
 
     /**
      * \brief Destructor.
@@ -475,14 +475,14 @@ class Output_Formatter<Format::Decimal<Integer>, std::enable_if_t<std::is_unsign
      *
      * \param[in] source The source of the move.
      */
-    constexpr Output_Formatter( Output_Formatter && source ) = default;
+    constexpr Output_Formatter( Output_Formatter && source ) noexcept = default;
 
     /**
      * \brief Constructor.
      *
      * \param[in] original The original to copy.
      */
-    constexpr Output_Formatter( Output_Formatter const & original ) = default;
+    constexpr Output_Formatter( Output_Formatter const & original ) noexcept = default;
 
     /**
      * \brief Destructor.
@@ -557,14 +557,14 @@ class Output_Formatter<Format::Hexadecimal<Integer>> {
      *
      * \param[in] source The source of the move.
      */
-    constexpr Output_Formatter( Output_Formatter && source ) = default;
+    constexpr Output_Formatter( Output_Formatter && source ) noexcept = default;
 
     /**
      * \brief Constructor.
      *
      * \param[in] original The original to copy.
      */
-    constexpr Output_Formatter( Output_Formatter const & original ) = default;
+    constexpr Output_Formatter( Output_Formatter const & original ) noexcept = default;
 
     /**
      * \brief Destructor.

--- a/include/picolibrary/ipv4.h
+++ b/include/picolibrary/ipv4.h
@@ -353,8 +353,6 @@ namespace picolibrary {
 
 /**
  * \brief picolibrary::IPv4::Address output formatter.
- *
- * picolibrary::IPv4::Address only supports the default format specification ("{}").
  */
 template<>
 class Output_Formatter<IPv4::Address> {
@@ -364,32 +362,43 @@ class Output_Formatter<IPv4::Address> {
      */
     constexpr Output_Formatter() noexcept = default;
 
-    Output_Formatter( Output_Formatter && ) = delete;
+    /**
+     * \brief Constructor.
+     *
+     * \param[in] source The source of the move.
+     */
+    constexpr Output_Formatter( Output_Formatter && source ) = default;
 
-    Output_Formatter( Output_Formatter const & ) = delete;
+    /**
+     * \brief Constructor.
+     *
+     * \param[in] original The original to copy.
+     */
+    constexpr Output_Formatter( Output_Formatter const & original ) = default;
 
     /**
      * \brief Destructor.
      */
     ~Output_Formatter() noexcept = default;
 
-    auto operator=( Output_Formatter && ) = delete;
-
-    auto operator=( Output_Formatter const & ) = delete;
+    /**
+     * \brief Assignment operator.
+     *
+     * \param[in] expression The expression to be assigned.
+     *
+     * \return The assigned to object.
+     */
+    constexpr auto operator=( Output_Formatter && expression ) noexcept -> Output_Formatter & = default;
 
     /**
-     * \brief Parse the format specification for the picolibrary::IPv4::Address to be
-     *        formatted.
+     * \brief Assignment operator.
      *
-     * \param[in] format The format specification for the picolibrary::IPv4::Address to be
-     *            formatted.
+     * \param[in] expression The expression to be assigned.
      *
-     * \return format
+     * \return The assigned to object.
      */
-    constexpr auto parse( char const * format ) noexcept -> char const *
-    {
-        return format;
-    }
+    constexpr auto operator   =( Output_Formatter const & expression ) noexcept
+        -> Output_Formatter & = default;
 
     /**
      * \brief Write the formatted picolibrary::IPv4::Address to the stream.
@@ -400,14 +409,16 @@ class Output_Formatter<IPv4::Address> {
      * \return The number of characters written to the stream if the write succeeded.
      * \return An error code if the write failed.
      */
-    auto print( Output_Stream & stream, IPv4::Address const & address ) noexcept
+    auto print( Output_Stream & stream, IPv4::Address const & address ) const noexcept
         -> Result<std::size_t, Error_Code>
     {
         return stream.print(
-            "{}.{}.{}.{}",
             Format::Decimal{ address.as_byte_array()[ 0 ] },
+            '.',
             Format::Decimal{ address.as_byte_array()[ 1 ] },
+            '.',
             Format::Decimal{ address.as_byte_array()[ 2 ] },
+            '.',
             Format::Decimal{ address.as_byte_array()[ 3 ] } );
     }
 };

--- a/include/picolibrary/ipv4.h
+++ b/include/picolibrary/ipv4.h
@@ -367,14 +367,14 @@ class Output_Formatter<IPv4::Address> {
      *
      * \param[in] source The source of the move.
      */
-    constexpr Output_Formatter( Output_Formatter && source ) = default;
+    constexpr Output_Formatter( Output_Formatter && source ) noexcept = default;
 
     /**
      * \brief Constructor.
      *
      * \param[in] original The original to copy.
      */
-    constexpr Output_Formatter( Output_Formatter const & original ) = default;
+    constexpr Output_Formatter( Output_Formatter const & original ) noexcept = default;
 
     /**
      * \brief Destructor.

--- a/include/picolibrary/mac_address.h
+++ b/include/picolibrary/mac_address.h
@@ -369,14 +369,14 @@ class Output_Formatter<MAC_Address> {
      *
      * \param[in] source The source of the move.
      */
-    constexpr Output_Formatter( Output_Formatter && source ) = default;
+    constexpr Output_Formatter( Output_Formatter && source ) noexcept = default;
 
     /**
      * \brief Constructor.
      *
      * \param[in] original The original to copy.
      */
-    constexpr Output_Formatter( Output_Formatter const & original ) = default;
+    constexpr Output_Formatter( Output_Formatter const & original ) noexcept = default;
 
     /**
      * \brief Destructor.

--- a/include/picolibrary/mac_address.h
+++ b/include/picolibrary/mac_address.h
@@ -355,8 +355,6 @@ constexpr auto operator>=( MAC_Address const & lhs, MAC_Address const & rhs ) no
 
 /**
  * \brief picolibrary::MAC_Address output formatter.
- *
- * picolibrary::MAC_Address only supports the default format specification ("{}").
  */
 template<>
 class Output_Formatter<MAC_Address> {
@@ -366,32 +364,43 @@ class Output_Formatter<MAC_Address> {
      */
     constexpr Output_Formatter() noexcept = default;
 
-    Output_Formatter( Output_Formatter && ) = delete;
+    /**
+     * \brief Constructor.
+     *
+     * \param[in] source The source of the move.
+     */
+    constexpr Output_Formatter( Output_Formatter && source ) = default;
 
-    Output_Formatter( Output_Formatter const & ) = delete;
+    /**
+     * \brief Constructor.
+     *
+     * \param[in] original The original to copy.
+     */
+    constexpr Output_Formatter( Output_Formatter const & original ) = default;
 
     /**
      * \brief Destructor.
      */
     ~Output_Formatter() noexcept = default;
 
-    auto operator=( Output_Formatter && ) = delete;
-
-    auto operator=( Output_Formatter const & ) = delete;
+    /**
+     * \brief Assignment operator.
+     *
+     * \param[in] expression The expression to be assigned.
+     *
+     * \return The assigned to object.
+     */
+    constexpr auto operator=( Output_Formatter && expression ) noexcept -> Output_Formatter & = default;
 
     /**
-     * \brief Parse the format specification for the picolibrary::MAC_Address to be
-     *        formatted.
+     * \brief Assignment operator.
      *
-     * \param[in] format The format specification for the picolibrary::MAC_Address to be
-     *            formatted.
+     * \param[in] expression The expression to be assigned.
      *
-     * \return format
+     * \return The assigned to object.
      */
-    constexpr auto parse( char const * format ) noexcept -> char const *
-    {
-        return format;
-    }
+    constexpr auto operator   =( Output_Formatter const & expression ) noexcept
+        -> Output_Formatter & = default;
 
     /**
      * \brief Write the formatted picolibrary::MAC_Address to the stream.
@@ -403,7 +412,7 @@ class Output_Formatter<MAC_Address> {
      * \return An error code if the write failed.
      */
     // NOLINTNEXTLINE(readability-function-size)
-    auto print( Output_Stream & stream, MAC_Address const & address ) noexcept
+    auto print( Output_Stream & stream, MAC_Address const & address ) const noexcept
         -> Result<std::size_t, Error_Code>
     {
         // #lizard forgives the length

--- a/include/picolibrary/stream.h
+++ b/include/picolibrary/stream.h
@@ -444,31 +444,44 @@ class Output_Formatter {
     /**
      * \brief Constructor.
      */
-    constexpr Output_Formatter() noexcept = default;
+    Output_Formatter() noexcept = default;
 
-    Output_Formatter( Output_Formatter && ) = delete;
+    /**
+     * \brief Constructor.
+     *
+     * \param[in] source The source of the move.
+     */
+    Output_Formatter( Output_Formatter && source ) = default;
 
-    Output_Formatter( Output_Formatter const & ) = delete;
+    /**
+     * \brief Constructor.
+     *
+     * \param[in] original The original to copy.
+     */
+    Output_Formatter( Output_Formatter const & original ) = default;
 
     /**
      * \brief Destructor.
      */
     ~Output_Formatter() noexcept = default;
 
-    auto operator=( Output_Formatter && ) = delete;
-
-    auto operator=( Output_Formatter const & ) = delete;
+    /**
+     * \brief Assignment operator.
+     *
+     * \param[in] expression The expression to be assigned.
+     *
+     * \return The assigned to object.
+     */
+    auto operator=( Output_Formatter && expression ) noexcept -> Output_Formatter & = default;
 
     /**
-     * \brief Parse the format specification for the value to be formatted.
+     * \brief Assignment operator.
      *
-     * \param[in] format The format specification for the value to be formatted.
+     * \param[in] expression The expression to be assigned.
      *
-     * \pre format is a valid format specification for the value to be formatted.
-     *
-     * \return A pointer to the end of the format specification ('}').
+     * \return The assigned to object.
      */
-    auto parse( char const * format ) noexcept -> char const *;
+    auto operator=( Output_Formatter const & expression ) noexcept -> Output_Formatter & = default;
 
     /**
      * \brief Write the formatted value to the stream.
@@ -479,7 +492,8 @@ class Output_Formatter {
      * \return The number of characters written to the stream if the write succeeded.
      * \return An error code if the write failed.
      */
-    auto print( Output_Stream & stream, T const & value ) noexcept -> Result<std::size_t, Error_Code>;
+    auto print( Output_Stream & stream, T const & value ) const noexcept
+        -> Result<std::size_t, Error_Code>;
 };
 
 /**
@@ -666,27 +680,21 @@ class Output_Stream : public Stream {
      *
      * \tparam Types The types to print.
      *
-     * \param[in] format The format string specifying the format to use for each value to
-     *            be formatted. Format string syntax is based on the Python format string
-     *            syntax. Named and positional arguments are not supported. The format
-     *            specification for each value to be formatted is delimited by '{' and
-     *            '}'. Use "{{" to write a literal '{'. Use "}}" to write a literal '}'.
-     *            The format specification syntax for a particular type is defined by the
-     *            specialization of picolibrary::Output_Formatter that is applicable to
-     *            that type.
-     * \param[in] values The values to format.
-     *
-     * \pre all format specifications found in format are valid
+     * \param[in] values The values to format. If a value is followed by an output
+     *            formatter, the output formatter will be used to format the value and
+     *            write the formatted value to the stream. If a value is not followed by
+     *            an output formatter, a default constructed output formatter will be used
+     *            to format the value and write the formatted value to the stream.
      *
      * \return The number of characters written to the stream if the write succeeded.
      * \return An error code if the write failed.
      */
     template<typename... Types>
-    auto print( char const * format, Types &&... values ) noexcept -> Result<std::size_t, Error_Code>
+    auto print( Types &&... values ) noexcept -> Result<std::size_t, Error_Code>
     {
         expect( is_nominal(), Generic_Error::IO_STREAM_DEGRADED );
 
-        return print_implementation( std::size_t{ 0 }, format, std::forward<Types>( values )... );
+        return print_implementation( std::size_t{ 0 }, std::forward<Types>( values )... );
     }
 
     /**
@@ -760,32 +768,11 @@ class Output_Stream : public Stream {
      * \brief Write formatted output to the stream.
      *
      * \param[in] n The number of characters that have been written to the stream.
-     * \param[in] format The format string specifying the format to use for each value to
-     *            be formatted.
      *
-     * \pre all format specifications found in format are valid
-     *
-     * \return The number of characters written to the stream if the write succeeded.
-     * \return An error code if the write failed.
+     * \return The number of characters written to the stream.
      */
-    auto print_implementation( std::size_t n, char const * format ) noexcept
-        -> Result<std::size_t, Error_Code>
+    auto print_implementation( std::size_t n ) noexcept -> Result<std::size_t, Error_Code>
     {
-        for ( ; *format; ++format ) {
-            if ( *format == '{' or *format == '}' ) {
-                expect( *( format + 1 ) == *format, Generic_Error::INVALID_FORMAT );
-
-                ++format;
-            } // if
-
-            auto result = put( *format );
-            if ( result.is_error() ) {
-                return result.error();
-            } // if
-
-            ++n;
-        } // for
-
         return n;
     }
 
@@ -796,70 +783,55 @@ class Output_Stream : public Stream {
      * \tparam Types The types to print.
      *
      * \param[in] n The number of characters that have been written to the stream.
-     * \param[in] format The format string specifying the format to use for each value to
-     *            be formatted.
      * \param[in] value The value to format.
+     * \param[in] formatter The output formatter to use to format the value and write the
+     *            formatted value to the stream.
      * \param[in] values The values to format.
-     *
-     * \pre all format specifications found in format are valid
      *
      * \return The number of characters written to the stream if the write succeeded.
      * \return An error code if the write failed.
      */
     template<typename Type, typename... Types>
-    // NOLINTNEXTLINE(readability-function-size)
-    auto print_implementation( std::size_t n, char const * format, Type && value, Types &&... values ) noexcept
+    auto print_implementation( std::size_t n, Type && value, Output_Formatter<std::decay_t<Type>> formatter, Types &&... values ) noexcept
         -> Result<std::size_t, Error_Code>
     {
-        // #lizard forgives the length
+        auto result = formatter.print( *this, value );
+        if ( result.is_error() ) {
+            report_fatal_error();
 
-        for ( ; *format; ++format ) {
-            if ( *format == '{' ) {
-                ++format;
+            return result.error();
+        } // if
 
-                if ( *format != '{' ) {
-                    auto formatter = Output_Formatter<std::decay_t<Type>>{};
+        return print_implementation( n + result.value(), std::forward<Types>( values )... );
+    }
 
-                    format = formatter.parse( format );
-                    expect( *format == '}', Generic_Error::INVALID_FORMAT );
-
-                    ++format;
-
-                    auto result = formatter.print( *this, value );
-                    if ( result.is_error() ) {
-                        report_fatal_error();
-
-                        return result.error();
-                    } // if
-
-                    n += result.value();
-
-                    return print_implementation( n, format, std::forward<Types>( values )... );
-                } // if
-            } else if ( *format == '}' ) {
-                ++format;
-
-                expect( *format == '}', Generic_Error::INVALID_FORMAT );
-            } // else if
-
-            auto result = put( *format );
-            if ( result.is_error() ) {
-                return result.error();
-            } // if
-
-            ++n;
-        } // for
-
-        expect( false, Generic_Error::INVALID_FORMAT );
-
-        return std::size_t{ 0 }; // unreachable
+    /**
+     * \brief Write formatted output to the stream.
+     *
+     * \tparam Type The type to print.
+     * \tparam Types The types to print.
+     *
+     * \param[in] n The number of characters that have been written to the stream.
+     * \param[in] value The value to format.
+     * \param[in] values The values to format.
+     *
+     * \return The number of characters written to the stream if the write succeeded.
+     * \return An error code if the write failed.
+     */
+    template<typename Type, typename... Types>
+    auto print_implementation( std::size_t n, Type && value, Types &&... values ) noexcept
+        -> Result<std::size_t, Error_Code>
+    {
+        return print_implementation(
+            n,
+            std::forward<Type>( value ),
+            Output_Formatter<std::decay_t<Type>>{},
+            std::forward<Types>( values )... );
     }
 };
 
 /**
  * \brief Character output formatter.
- *
- * Characters only support the default format specification ("{}").
  */
 template<>
 class Output_Formatter<char> {
@@ -869,30 +841,43 @@ class Output_Formatter<char> {
      */
     constexpr Output_Formatter() noexcept = default;
 
-    Output_Formatter( Output_Formatter && ) = delete;
+    /**
+     * \brief Constructor.
+     *
+     * \param[in] source The source of the move.
+     */
+    constexpr Output_Formatter( Output_Formatter && source ) = default;
 
-    Output_Formatter( Output_Formatter const & ) = delete;
+    /**
+     * \brief Constructor.
+     *
+     * \param[in] original The original to copy.
+     */
+    constexpr Output_Formatter( Output_Formatter const & original ) = default;
 
     /**
      * \brief Destructor.
      */
     ~Output_Formatter() noexcept = default;
 
-    auto operator=( Output_Formatter && ) = delete;
-
-    auto operator=( Output_Formatter const & ) = delete;
+    /**
+     * \brief Assignment operator.
+     *
+     * \param[in] expression The expression to be assigned.
+     *
+     * \return The assigned to object.
+     */
+    constexpr auto operator=( Output_Formatter && expression ) noexcept -> Output_Formatter & = default;
 
     /**
-     * \brief Parse the format specification for the character to be formatted.
+     * \brief Assignment operator.
      *
-     * \param[in] format The format specification for the character to be formatted.
+     * \param[in] expression The expression to be assigned.
      *
-     * \return format
+     * \return The assigned to object.
      */
-    constexpr auto parse( char const * format ) noexcept -> char const *
-    {
-        return format;
-    }
+    constexpr auto operator   =( Output_Formatter const & expression ) noexcept
+        -> Output_Formatter & = default;
 
     /**
      * \brief Write the formatted character to the stream.
@@ -903,7 +888,7 @@ class Output_Formatter<char> {
      * \return The number of characters written to the stream if the write succeeded.
      * \return An error code if the write failed.
      */
-    auto print( Output_Stream & stream, char character ) noexcept -> Result<std::size_t, Error_Code>
+    auto print( Output_Stream & stream, char character ) const noexcept -> Result<std::size_t, Error_Code>
     {
         auto result = stream.put( character );
         if ( result.is_error() ) {
@@ -916,8 +901,6 @@ class Output_Formatter<char> {
 
 /**
  * \brief Null-terminated string output formatter.
- *
- * Null-terminated strings only support the default format specification ("{}").
  */
 template<>
 class Output_Formatter<char const *> {
@@ -927,32 +910,43 @@ class Output_Formatter<char const *> {
      */
     constexpr Output_Formatter() noexcept = default;
 
-    Output_Formatter( Output_Formatter && ) = delete;
+    /**
+     * \brief Constructor.
+     *
+     * \param[in] source The source of the move.
+     */
+    constexpr Output_Formatter( Output_Formatter && source ) = default;
 
-    Output_Formatter( Output_Formatter const & ) = delete;
+    /**
+     * \brief Constructor.
+     *
+     * \param[in] original The original to copy.
+     */
+    constexpr Output_Formatter( Output_Formatter const & original ) = default;
 
     /**
      * \brief Destructor.
      */
     ~Output_Formatter() noexcept = default;
 
-    auto operator=( Output_Formatter && ) = delete;
-
-    auto operator=( Output_Formatter const & ) = delete;
+    /**
+     * \brief Assignment operator.
+     *
+     * \param[in] expression The expression to be assigned.
+     *
+     * \return The assigned to object.
+     */
+    constexpr auto operator=( Output_Formatter && expression ) noexcept -> Output_Formatter & = default;
 
     /**
-     * \brief Parse the format specification for the null-terminated string to be
-     *        formatted.
+     * \brief Assignment operator.
      *
-     * \param[in] format The format specification for the null-terminated string to be
-     *            formatted.
+     * \param[in] expression The expression to be assigned.
      *
-     * \return format
+     * \return The assigned to object.
      */
-    constexpr auto parse( char const * format ) noexcept -> char const *
-    {
-        return format;
-    }
+    constexpr auto operator   =( Output_Formatter const & expression ) noexcept
+        -> Output_Formatter & = default;
 
     /**
      * \brief Write the formatted null-terminated string to the stream.
@@ -963,7 +957,8 @@ class Output_Formatter<char const *> {
      * \return The number of characters written to the stream if the write succeeded.
      * \return An error code if the write failed.
      */
-    auto print( Output_Stream & stream, char const * string ) noexcept -> Result<std::size_t, Error_Code>
+    auto print( Output_Stream & stream, char const * string ) const noexcept
+        -> Result<std::size_t, Error_Code>
     {
         auto result = stream.put( string );
         if ( result.is_error() ) {
@@ -976,8 +971,6 @@ class Output_Formatter<char const *> {
 
 /**
  * \brief picolibrary::Void output formatter.
- *
- * picolibrary::Void only supports the default format specification ("{}").
  */
 template<>
 class Output_Formatter<Void> {
@@ -987,38 +980,50 @@ class Output_Formatter<Void> {
      */
     constexpr Output_Formatter() noexcept = default;
 
-    Output_Formatter( Output_Formatter && ) = delete;
+    /**
+     * \brief Constructor.
+     *
+     * \param[in] source The source of the move.
+     */
+    constexpr Output_Formatter( Output_Formatter && source ) = default;
 
-    Output_Formatter( Output_Formatter const & ) = delete;
+    /**
+     * \brief Constructor.
+     *
+     * \param[in] original The original to copy.
+     */
+    constexpr Output_Formatter( Output_Formatter const & original ) = default;
 
     /**
      * \brief Destructor.
      */
     ~Output_Formatter() noexcept = default;
 
-    auto operator=( Output_Formatter && ) = delete;
-
-    auto operator=( Output_Formatter const & ) = delete;
+    /**
+     * \brief Assignment operator.
+     *
+     * \param[in] expression The expression to be assigned.
+     *
+     * \return The assigned to object.
+     */
+    constexpr auto operator=( Output_Formatter && expression ) noexcept -> Output_Formatter & = default;
 
     /**
-     * \brief Parse the format specification for the picolibrary::Void to be formatted.
+     * \brief Assignment operator.
      *
-     * \param[in] format The format specification for the picolibrary::Void to be
-     *            formatted.
+     * \param[in] expression The expression to be assigned.
      *
-     * \return format
+     * \return The assigned to object.
      */
-    constexpr auto parse( char const * format ) noexcept -> char const *
-    {
-        return format;
-    }
+    constexpr auto operator   =( Output_Formatter const & expression ) noexcept
+        -> Output_Formatter & = default;
 
     /**
      * \brief Write nothing to the stream.
      *
      * \return 0
      */
-    constexpr auto print( Output_Stream &, Void ) noexcept -> Result<std::size_t, Void>
+    constexpr auto print( Output_Stream &, Void ) const noexcept -> Result<std::size_t, Void>
     {
         return std::size_t{ 0 };
     }
@@ -1026,8 +1031,6 @@ class Output_Formatter<Void> {
 
 /**
  * \brief picolibrary::Error_Code output formatter.
- *
- * picolibrary::Error_Code only support the default format specification ("{}").
  */
 template<>
 class Output_Formatter<Error_Code> {
@@ -1037,32 +1040,43 @@ class Output_Formatter<Error_Code> {
      */
     constexpr Output_Formatter() noexcept = default;
 
-    Output_Formatter( Output_Formatter && ) = delete;
+    /**
+     * \brief Constructor.
+     *
+     * \param[in] source The source of the move.
+     */
+    constexpr Output_Formatter( Output_Formatter && source ) = default;
 
-    Output_Formatter( Output_Formatter const & ) = delete;
+    /**
+     * \brief Constructor.
+     *
+     * \param[in] original The original to copy.
+     */
+    constexpr Output_Formatter( Output_Formatter const & original ) = default;
 
     /**
      * \brief Destructor.
      */
     ~Output_Formatter() noexcept = default;
 
-    auto operator=( Output_Formatter && ) = delete;
-
-    auto operator=( Output_Formatter const & ) = delete;
+    /**
+     * \brief Assignment operator.
+     *
+     * \param[in] expression The expression to be assigned.
+     *
+     * \return The assigned to object.
+     */
+    constexpr auto operator=( Output_Formatter && expression ) noexcept -> Output_Formatter & = default;
 
     /**
-     * \brief Parse the format specification for the picolibrary::Error_Code to be
-     *        formatted.
+     * \brief Assignment operator.
      *
-     * \param[in] format The format specification for the picolibrary::Error_Code to be
-     *            formatted.
+     * \param[in] expression The expression to be assigned.
      *
-     * \return format
+     * \return The assigned to object.
      */
-    constexpr auto parse( char const * format ) noexcept -> char const *
-    {
-        return format;
-    }
+    constexpr auto operator   =( Output_Formatter const & expression ) noexcept
+        -> Output_Formatter & = default;
 
     /**
      * \brief Write the formatted picolibrary::Error_Code to the stream.
@@ -1073,10 +1087,10 @@ class Output_Formatter<Error_Code> {
      * \return The number of characters written to the stream if the write succeeded.
      * \return An error code if the write failed.
      */
-    auto print( Output_Stream & stream, Error_Code const & error ) noexcept
+    auto print( Output_Stream & stream, Error_Code const & error ) const noexcept
         -> Result<std::size_t, Error_Code>
     {
-        return stream.print( "{}::{}", error.category().name(), error.description() );
+        return stream.print( error.category().name(), "::", error.description() );
     }
 };
 

--- a/include/picolibrary/stream.h
+++ b/include/picolibrary/stream.h
@@ -795,7 +795,7 @@ class Output_Stream : public Stream {
     auto print_implementation( std::size_t n, Type && value, Output_Formatter<std::decay_t<Type>> formatter, Types &&... values ) noexcept
         -> Result<std::size_t, Error_Code>
     {
-        auto result = formatter.print( *this, std::forward<Type>( value ) );
+        auto result = formatter.print( *this, value );
         if ( result.is_error() ) {
             report_fatal_error();
 

--- a/include/picolibrary/stream.h
+++ b/include/picolibrary/stream.h
@@ -795,6 +795,7 @@ class Output_Stream : public Stream {
     auto print_implementation( std::size_t n, Type && value, Output_Formatter<std::decay_t<Type>> formatter, Types &&... values ) noexcept
         -> Result<std::size_t, Error_Code>
     {
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
         auto result = formatter.print( *this, value );
         if ( result.is_error() ) {
             report_fatal_error();

--- a/include/picolibrary/stream.h
+++ b/include/picolibrary/stream.h
@@ -451,14 +451,14 @@ class Output_Formatter {
      *
      * \param[in] source The source of the move.
      */
-    Output_Formatter( Output_Formatter && source ) = default;
+    Output_Formatter( Output_Formatter && source ) noexcept = default;
 
     /**
      * \brief Constructor.
      *
      * \param[in] original The original to copy.
      */
-    Output_Formatter( Output_Formatter const & original ) = default;
+    Output_Formatter( Output_Formatter const & original ) noexcept = default;
 
     /**
      * \brief Destructor.
@@ -846,14 +846,14 @@ class Output_Formatter<char> {
      *
      * \param[in] source The source of the move.
      */
-    constexpr Output_Formatter( Output_Formatter && source ) = default;
+    constexpr Output_Formatter( Output_Formatter && source ) noexcept = default;
 
     /**
      * \brief Constructor.
      *
      * \param[in] original The original to copy.
      */
-    constexpr Output_Formatter( Output_Formatter const & original ) = default;
+    constexpr Output_Formatter( Output_Formatter const & original ) noexcept = default;
 
     /**
      * \brief Destructor.
@@ -915,14 +915,14 @@ class Output_Formatter<char const *> {
      *
      * \param[in] source The source of the move.
      */
-    constexpr Output_Formatter( Output_Formatter && source ) = default;
+    constexpr Output_Formatter( Output_Formatter && source ) noexcept = default;
 
     /**
      * \brief Constructor.
      *
      * \param[in] original The original to copy.
      */
-    constexpr Output_Formatter( Output_Formatter const & original ) = default;
+    constexpr Output_Formatter( Output_Formatter const & original ) noexcept = default;
 
     /**
      * \brief Destructor.
@@ -985,14 +985,14 @@ class Output_Formatter<Void> {
      *
      * \param[in] source The source of the move.
      */
-    constexpr Output_Formatter( Output_Formatter && source ) = default;
+    constexpr Output_Formatter( Output_Formatter && source ) noexcept = default;
 
     /**
      * \brief Constructor.
      *
      * \param[in] original The original to copy.
      */
-    constexpr Output_Formatter( Output_Formatter const & original ) = default;
+    constexpr Output_Formatter( Output_Formatter const & original ) noexcept = default;
 
     /**
      * \brief Destructor.
@@ -1045,14 +1045,14 @@ class Output_Formatter<Error_Code> {
      *
      * \param[in] source The source of the move.
      */
-    constexpr Output_Formatter( Output_Formatter && source ) = default;
+    constexpr Output_Formatter( Output_Formatter && source ) noexcept = default;
 
     /**
      * \brief Constructor.
      *
      * \param[in] original The original to copy.
      */
-    constexpr Output_Formatter( Output_Formatter const & original ) = default;
+    constexpr Output_Formatter( Output_Formatter const & original ) noexcept = default;
 
     /**
      * \brief Destructor.

--- a/include/picolibrary/stream.h
+++ b/include/picolibrary/stream.h
@@ -795,7 +795,7 @@ class Output_Stream : public Stream {
     auto print_implementation( std::size_t n, Type && value, Output_Formatter<std::decay_t<Type>> formatter, Types &&... values ) noexcept
         -> Result<std::size_t, Error_Code>
     {
-        auto result = formatter.print( *this, value );
+        auto result = formatter.print( *this, std::forward<Type>( value ) );
         if ( result.is_error() ) {
             report_fatal_error();
 

--- a/include/picolibrary/testing/automated/stream.h
+++ b/include/picolibrary/testing/automated/stream.h
@@ -23,7 +23,6 @@
 #ifndef PICOLIBRARY_TESTING_AUTOMATED_STREAM_H
 #define PICOLIBRARY_TESTING_AUTOMATED_STREAM_H
 
-#include <cstddef>
 #include <cstdint>
 #include <string>
 #include <vector>
@@ -32,7 +31,6 @@
 #include "picolibrary/error.h"
 #include "picolibrary/result.h"
 #include "picolibrary/stream.h"
-#include "picolibrary/testing/automated/random.h"
 #include "picolibrary/void.h"
 
 namespace picolibrary::Testing::Automated {
@@ -87,19 +85,6 @@ class Mock_Stream_Buffer : public Stream_Buffer {
 
     MOCK_METHOD( (Result<Void, Error_Code>), flush, (), ( noexcept, override ) );
 };
-
-/**
- * \brief Generate a std::string of the specified size populated with pseudo-randomly
- *        generated characters in the range [' ','z'].
- *
- * \param[in] size The desired std::string size.
- *
- * \return The generated std::string.
- */
-inline auto random_format_string( std::size_t size = random<std::size_t>( 0, 15 ) ) -> std::string
-{
-    return random_container<std::string>( size, []() { return random<char>( ' ', 'z' ); } );
-}
 
 /**
  * \brief Mock output stream.

--- a/include/picolibrary/testing/interactive/adc.h
+++ b/include/picolibrary/testing/interactive/adc.h
@@ -57,9 +57,11 @@ void sample_blocking_single_sample_converter( Output_Stream & stream, Blocking_S
 
     {
         auto result = stream.print(
-            "ADC sample range: [{},{}]\n",
+            "ADC sample range: [",
             Format::Decimal{ Blocking_Single_Sample_Converter::Sample::min().as_unsigned_integer() },
-            Format::Decimal{ Blocking_Single_Sample_Converter::Sample::max().as_unsigned_integer() } );
+            ',',
+            Format::Decimal{ Blocking_Single_Sample_Converter::Sample::max().as_unsigned_integer() },
+            "]\n" );
         expect( not result.is_error(), result.error() );
     }
 
@@ -67,8 +69,7 @@ void sample_blocking_single_sample_converter( Output_Stream & stream, Blocking_S
         delay();
 
         {
-            auto result = stream.print(
-                "{}\n", Format::Decimal{ adc.sample().as_unsigned_integer() } );
+            auto result = stream.print( Format::Decimal{ adc.sample().as_unsigned_integer() } );
             expect( not result.is_error(), result.error() );
         }
 

--- a/include/picolibrary/testing/interactive/adc.h
+++ b/include/picolibrary/testing/interactive/adc.h
@@ -69,7 +69,7 @@ void sample_blocking_single_sample_converter( Output_Stream & stream, Blocking_S
         delay();
 
         {
-            auto result = stream.print( Format::Decimal{ adc.sample().as_unsigned_integer() } );
+            auto result = stream.print( Format::Decimal{ adc.sample().as_unsigned_integer() }, '\n' );
             expect( not result.is_error(), result.error() );
         }
 

--- a/include/picolibrary/testing/interactive/i2c.h
+++ b/include/picolibrary/testing/interactive/i2c.h
@@ -63,9 +63,11 @@ void scan( Output_Stream & stream, Controller controller ) noexcept
                 devices_found = true;
 
                 auto result = stream.print(
-                    "device found: {} ({})\n",
+                    "device found: ",
                     Format::Hexadecimal{ static_cast<std::uint8_t>( address.as_unsigned_integer() ) },
-                    operation == ::picolibrary::I2C::Operation::READ ? 'R' : 'W' );
+                    " (",
+                    operation == ::picolibrary::I2C::Operation::READ ? 'R' : 'W',
+                    ")\n" );
                 expect( not result.is_error(), result.error() );
             } // if
         } );

--- a/include/picolibrary/testing/interactive/spi.h
+++ b/include/picolibrary/testing/interactive/spi.h
@@ -63,7 +63,7 @@ void echo( Output_Stream & stream, Controller controller, typename Controller::C
         {
             auto const rx     = controller.exchange( tx );
             auto       result = stream.print(
-                "exchange( {} ) -> {}\n", Format::Hexadecimal{ tx }, Format::Hexadecimal{ rx } );
+                "exchange( ", Format::Hexadecimal{ tx }, " ) -> ", Format::Hexadecimal{ rx }, '\n' );
             expect( not result.is_error(), result.error() );
             expect( rx == tx, Generic_Error::RUNTIME_ERROR );
         }

--- a/test/automated/picolibrary/event/main.cc
+++ b/test/automated/picolibrary/event/main.cc
@@ -112,7 +112,7 @@ TEST( outputFormatterEvent, putError )
     EXPECT_CALL( stream.buffer(), put( A<std::string>() ) ).WillOnce( Return( error ) );
     EXPECT_CALL( event, print_details( _ ) ).Times( 0 );
 
-    auto const result = stream.print( "{}", static_cast<::picolibrary::Event const &>( event ) );
+    auto const result = stream.print( static_cast<::picolibrary::Event const &>( event ) );
 
     EXPECT_TRUE( result.is_error() );
     EXPECT_EQ( result.error(), error );
@@ -143,7 +143,7 @@ TEST( outputFormatterEvent, detailsPrintError )
     EXPECT_CALL( category, event_description( _ ) ).WillOnce( Return( event_description.c_str() ) );
     EXPECT_CALL( event, print_details( _ ) ).WillOnce( Return( error ) );
 
-    auto const result = stream.print( "{}", static_cast<::picolibrary::Event const &>( event ) );
+    auto const result = stream.print( static_cast<::picolibrary::Event const &>( event ) );
 
     EXPECT_TRUE( result.is_error() );
     EXPECT_EQ( result.error(), error );
@@ -173,7 +173,7 @@ TEST( outputFormatterEvent, worksProperly )
     EXPECT_CALL( category, event_description( id ) ).WillOnce( Return( event_description.c_str() ) );
     EXPECT_CALL( event, print_details( Ref( stream ) ) ).WillOnce( Return( event_details_size ) );
 
-    auto const result = stream.print( "{}", static_cast<::picolibrary::Event const &>( event ) );
+    auto const result = stream.print( static_cast<::picolibrary::Event const &>( event ) );
 
     EXPECT_TRUE( result.is_value() );
     EXPECT_EQ( result.value(), stream.string().size() + event_details_size );

--- a/test/automated/picolibrary/format/binary/main.cc
+++ b/test/automated/picolibrary/format/binary/main.cc
@@ -43,7 +43,6 @@ using ::picolibrary::Testing::Automated::Mock_Error;
 using ::picolibrary::Testing::Automated::Mock_Output_Stream;
 using ::picolibrary::Testing::Automated::Output_String_Stream;
 using ::picolibrary::Testing::Automated::random;
-using ::picolibrary::Testing::Automated::random_format_string;
 using ::testing::A;
 using ::testing::Return;
 
@@ -103,7 +102,7 @@ TYPED_TEST( outputFormatterBinary, putError )
 
     EXPECT_CALL( stream.buffer(), put( A<std::string>() ) ).WillOnce( Return( error ) );
 
-    auto const result = stream.print( "{}", Binary{ random<Integer>() } );
+    auto const result = stream.print( Binary{ random<Integer>() } );
 
     ASSERT_TRUE( result.is_error() );
     EXPECT_EQ( result.error(), error );
@@ -125,7 +124,7 @@ TYPED_TEST( outputFormatterBinary, worksProperly )
 
     auto const value = random<Integer>();
 
-    auto const result = stream.print( "{}", Binary{ value } );
+    auto const result = stream.print( Binary{ value } );
 
     ASSERT_TRUE( result.is_value() );
     EXPECT_EQ( result.value(), stream.string().size() );

--- a/test/automated/picolibrary/format/decimal/main.cc
+++ b/test/automated/picolibrary/format/decimal/main.cc
@@ -40,7 +40,6 @@ using ::picolibrary::Testing::Automated::Mock_Error;
 using ::picolibrary::Testing::Automated::Mock_Output_Stream;
 using ::picolibrary::Testing::Automated::Output_String_Stream;
 using ::picolibrary::Testing::Automated::random;
-using ::picolibrary::Testing::Automated::random_format_string;
 using ::testing::A;
 using ::testing::Return;
 
@@ -93,7 +92,7 @@ TYPED_TEST( outputFormatterDecimal, putError )
 
     EXPECT_CALL( stream.buffer(), put( A<std::string>() ) ).WillOnce( Return( error ) );
 
-    auto const result = stream.print( "{}", Decimal{ random<Integer>() } );
+    auto const result = stream.print( Decimal{ random<Integer>() } );
 
     ASSERT_TRUE( result.is_error() );
     EXPECT_EQ( result.error(), error );
@@ -115,7 +114,7 @@ TYPED_TEST( outputFormatterDecimal, worksProperly )
 
     auto const value = random<Integer>();
 
-    auto const result = stream.print( "{}", Decimal{ value } );
+    auto const result = stream.print( Decimal{ value } );
 
     ASSERT_TRUE( result.is_value() );
     EXPECT_EQ( result.value(), stream.string().size() );

--- a/test/automated/picolibrary/format/hexadecimal/main.cc
+++ b/test/automated/picolibrary/format/hexadecimal/main.cc
@@ -44,7 +44,6 @@ using ::picolibrary::Testing::Automated::Mock_Error;
 using ::picolibrary::Testing::Automated::Mock_Output_Stream;
 using ::picolibrary::Testing::Automated::Output_String_Stream;
 using ::picolibrary::Testing::Automated::random;
-using ::picolibrary::Testing::Automated::random_format_string;
 using ::testing::A;
 using ::testing::Return;
 
@@ -107,7 +106,7 @@ TYPED_TEST( outputFormatterHexadecimal, putError )
 
     EXPECT_CALL( stream.buffer(), put( A<std::string>() ) ).WillOnce( Return( error ) );
 
-    auto const result = stream.print( "{}", Hexadecimal{ random<Integer>() } );
+    auto const result = stream.print( Hexadecimal{ random<Integer>() } );
 
     ASSERT_TRUE( result.is_error() );
     EXPECT_EQ( result.error(), error );
@@ -129,7 +128,7 @@ TYPED_TEST( outputFormatterHexadecimal, worksProperly )
 
     auto const value = random<Integer>();
 
-    auto const result = stream.print( "{}", Hexadecimal{ value } );
+    auto const result = stream.print( Hexadecimal{ value } );
 
     ASSERT_TRUE( result.is_value() );
     EXPECT_EQ( result.value(), stream.string().size() );

--- a/test/automated/picolibrary/ipv4/address/main.cc
+++ b/test/automated/picolibrary/ipv4/address/main.cc
@@ -381,7 +381,7 @@ TEST( outputFormatterIPv4Address, printError )
 
     EXPECT_CALL( stream.buffer(), put( A<std::string>() ) ).WillOnce( Return( error ) );
 
-    auto const result = stream.print( "{}", Address{ random<Address::Unsigned_Integer>() } );
+    auto const result = stream.print( Address{ random<Address::Unsigned_Integer>() } );
 
     ASSERT_TRUE( result.is_error() );
     EXPECT_EQ( result.error(), error );
@@ -402,7 +402,7 @@ TEST( outputFormatterIPv4Address, worksProperly )
 
     auto const address = Address{ byte_array };
 
-    auto const result = stream.print( "{}", address );
+    auto const result = stream.print( address );
 
     ASSERT_TRUE( result.is_value() );
     EXPECT_EQ( result.value(), stream.string().size() );

--- a/test/automated/picolibrary/mac_address/main.cc
+++ b/test/automated/picolibrary/mac_address/main.cc
@@ -373,7 +373,7 @@ TEST( outputFormatterMACAddress, putError )
 
     EXPECT_CALL( stream.buffer(), put( A<std::string>() ) ).WillOnce( Return( error ) );
 
-    auto const result = stream.print( "{}", MAC_Address{ random_array<std::uint8_t, 6>() } );
+    auto const result = stream.print( MAC_Address{ random_array<std::uint8_t, 6>() } );
 
     ASSERT_TRUE( result.is_error() );
     EXPECT_EQ( result.error(), error );
@@ -394,7 +394,7 @@ TEST( outputFormatterMACAddress, worksProperly )
 
     auto const address = MAC_Address{ byte_array };
 
-    auto const result = stream.print( "{}", address );
+    auto const result = stream.print( address );
 
     ASSERT_TRUE( result.is_value() );
     EXPECT_EQ( result.value(), stream.string().size() );

--- a/test/automated/picolibrary/output_stream/main.cc
+++ b/test/automated/picolibrary/output_stream/main.cc
@@ -83,7 +83,7 @@ class Mock_Output_Formatter {
 template<>
 class picolibrary::Output_Formatter<::Foo> {
   public:
-    Output_Formatter() noexcept = default;
+    Output_Formatter() = delete;
 
     Output_Formatter( ::Mock_Output_Formatter const & mock_output_formatter ) noexcept :
         m_mock_output_formatter{ &mock_output_formatter }

--- a/test/automated/picolibrary/output_stream/main.cc
+++ b/test/automated/picolibrary/output_stream/main.cc
@@ -22,7 +22,6 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <stdexcept>
 #include <string>
 #include <type_traits>
 #include <vector>
@@ -41,8 +40,7 @@
 namespace {
 
 using ::picolibrary::Error_Code;
-using ::picolibrary::Error_ID;
-using ::picolibrary::Generic_Error;
+using ::picolibrary::Output_Formatter;
 using ::picolibrary::Output_Stream;
 using ::picolibrary::Result;
 using ::picolibrary::to_underlying;
@@ -53,7 +51,6 @@ using ::picolibrary::Testing::Automated::Mock_Output_Stream;
 using ::picolibrary::Testing::Automated::Output_String_Stream;
 using ::picolibrary::Testing::Automated::random;
 using ::picolibrary::Testing::Automated::random_container;
-using ::picolibrary::Testing::Automated::random_format_string;
 using ::testing::_;
 using ::testing::A;
 using ::testing::Eq;
@@ -66,44 +63,19 @@ enum class Foo {};
 
 class Mock_Output_Formatter {
   public:
-    static auto instance() -> Mock_Output_Formatter &
-    {
-        if ( not INSTANCE ) {
-            throw std::logic_error{
-                "::Mock_Output_Formatter::instance(): no active instance"
-            };
-        } // if
-
-        return *INSTANCE;
-    }
-
-    Mock_Output_Formatter()
-    {
-        if ( INSTANCE ) {
-            throw std::logic_error{
-                "::Mock_Output_Formatter::Mock_Output_Formatter(): only one instance may "
-                "be active at a time"
-            };
-        } // if
-
-        INSTANCE = this;
-    }
-
-    ~Mock_Output_Formatter() noexcept
-    {
-        INSTANCE = nullptr;
-    }
+    Mock_Output_Formatter() = default;
 
     Mock_Output_Formatter( Mock_Output_Formatter && ) = delete;
 
     Mock_Output_Formatter( Mock_Output_Formatter const & ) = delete;
 
-    MOCK_METHOD( char const *, parse, ( std::string ) );
+    ~Mock_Output_Formatter() noexcept = default;
 
-    MOCK_METHOD( (Result<std::size_t, Error_Code>), print, (Output_Stream &, Foo const &));
+    auto operator=( Mock_Output_Formatter && ) = delete;
 
-  private:
-    inline static auto INSTANCE = static_cast<Mock_Output_Formatter *>( nullptr );
+    auto operator=( Mock_Output_Formatter const & ) = delete;
+
+    MOCK_METHOD( (Result<std::size_t, Error_Code>), print, (Output_Stream &, Foo const &), ( const ) );
 };
 
 } // namespace
@@ -111,27 +83,31 @@ class Mock_Output_Formatter {
 template<>
 class picolibrary::Output_Formatter<::Foo> {
   public:
-    constexpr Output_Formatter() noexcept = default;
+    Output_Formatter() noexcept = default;
 
-    Output_Formatter( Output_Formatter && ) = delete;
+    Output_Formatter( ::Mock_Output_Formatter const & mock_output_formatter ) noexcept :
+        m_mock_output_formatter{ &mock_output_formatter }
+    {
+    }
 
-    Output_Formatter( Output_Formatter const & ) = delete;
+    Output_Formatter( Output_Formatter && source ) noexcept = default;
+
+    Output_Formatter( Output_Formatter const & original ) noexcept = default;
 
     ~Output_Formatter() noexcept = default;
 
-    auto operator=( Output_Formatter && ) = delete;
+    auto operator=( Output_Formatter && expression ) noexcept -> Output_Formatter & = default;
 
-    auto operator=( Output_Formatter const & ) = delete;
+    auto operator=( Output_Formatter const & expression ) noexcept -> Output_Formatter & = default;
 
-    auto parse( char const * format ) noexcept -> char const *
+    auto print( Output_Stream & stream, ::Foo const & foo ) const noexcept
+        -> Result<std::size_t, Error_Code>
     {
-        return ::Mock_Output_Formatter::instance().parse( format );
+        return m_mock_output_formatter->print( stream, foo );
     }
 
-    auto print( Output_Stream & stream, ::Foo const & foo ) noexcept -> Result<std::size_t, Error_Code>
-    {
-        return ::Mock_Output_Formatter::instance().print( stream, foo );
-    }
+  private:
+    ::Mock_Output_Formatter const * m_mock_output_formatter{};
 };
 
 template<>
@@ -416,68 +392,20 @@ TEST( putSignedByteBlock, worksProperly )
 }
 
 /**
- * \brief Verify picolibrary::Output_Stream::print() properly handles a put error.
- */
-TEST( print, putError )
-{
-    {
-        auto stream = Mock_Output_Stream{};
-
-        auto const error = random<Mock_Error>();
-
-        EXPECT_CALL( stream.buffer(), put( A<char>() ) ).WillOnce( Return( error ) );
-
-        auto const result = stream.print(
-            random_format_string( random<std::size_t>( 1, 15 ) ).c_str() );
-
-        ASSERT_TRUE( result.is_error() );
-        EXPECT_EQ( result.error(), error );
-
-        EXPECT_FALSE( stream.end_of_file_reached() );
-        EXPECT_FALSE( stream.io_error_present() );
-        EXPECT_TRUE( stream.fatal_error_present() );
-    }
-
-    {
-        auto stream = Mock_Output_Stream{};
-
-        auto const error = random<Mock_Error>();
-
-        EXPECT_CALL( stream.buffer(), put( A<char>() ) ).WillOnce( Return( error ) );
-
-        auto const result = stream.print(
-            ( random_format_string( random<std::size_t>( 1, 15 ) ) + "{}" + random_format_string() )
-                .c_str(),
-            random<Foo>() );
-
-        ASSERT_TRUE( result.is_error() );
-        EXPECT_EQ( result.error(), error );
-
-        EXPECT_FALSE( stream.end_of_file_reached() );
-        EXPECT_FALSE( stream.io_error_present() );
-        EXPECT_TRUE( stream.fatal_error_present() );
-    }
-}
-
-/**
  * \brief Verify picolibrary::Output_Stream::print() properly handles a
  *        picolibrary::Output_Formatter::print() error.
  */
 TEST( print, outputFormatterPrintError )
 {
-    auto stream = Output_String_Stream{};
+    auto stream = Mock_Output_Stream{};
 
-    auto formatter = Mock_Output_Formatter{};
+    auto const formatter = Mock_Output_Formatter{};
 
     auto const error = random<Mock_Error>();
 
-    EXPECT_CALL( formatter, parse( _ ) ).WillOnce( Return( "}" ) );
     EXPECT_CALL( formatter, print( _, _ ) ).WillOnce( Return( error ) );
 
-    auto const result = stream.print(
-        ( random_format_string() + '{' + random_format_string() + '}' + random_format_string() )
-            .c_str(),
-        random<Foo>() );
+    auto const result = stream.print( random<Foo>(), Output_Formatter<Foo>{ formatter } );
 
     ASSERT_TRUE( result.is_error() );
     EXPECT_EQ( result.error(), error );
@@ -493,52 +421,44 @@ TEST( print, outputFormatterPrintError )
 TEST( print, worksProperly )
 {
     {
-        auto stream = Output_String_Stream{};
+        auto stream = Mock_Output_Stream{};
 
-        auto const a = random_format_string();
-        auto const b = random_format_string();
-        auto const c = random_format_string();
+        auto const foo           = random<Foo>();
+        auto const foo_formatter = Mock_Output_Formatter{};
+        auto const foo_size      = random<std::size_t>();
 
-        auto const result = stream.print( ( a + "{{" + b + "}}" + c ).c_str() );
+        EXPECT_CALL( foo_formatter, print( Ref( stream ), Ref( foo ) ) ).WillOnce( Return( foo_size ) );
+
+        auto const result = stream.print( foo, Output_Formatter<Foo>{ foo_formatter } );
 
         ASSERT_TRUE( result.is_value() );
-        EXPECT_EQ( result.value(), stream.string().size() );
+        EXPECT_EQ( result.value(), foo_size );
 
         EXPECT_TRUE( stream.is_nominal() );
-        EXPECT_EQ( stream.string(), a + '{' + b + '}' + c );
     }
 
     {
         auto const in_sequence = InSequence{};
 
-        auto stream = Output_String_Stream{};
+        auto stream = Mock_Output_Stream{};
 
-        auto formatter = Mock_Output_Formatter{};
+        auto const foo_a           = random<Foo>();
+        auto const foo_a_formatter = Mock_Output_Formatter{};
+        auto const foo_a_size      = random<std::size_t>();
+        auto const foo_b           = random<Foo>();
+        auto const foo_b_formatter = Mock_Output_Formatter{};
+        auto const foo_b_size      = random<std::size_t>();
 
-        auto const a = random_format_string();
-        auto const b = random_format_string();
-        auto const c = random_format_string();
-        auto const d = random_format_string();
-        auto const e = random_format_string();
-
-        auto const format_specification_begin = d + '}' + e;
-        auto const format_specification_end   = std::string{ '}' } + e;
-
-        auto const foo      = random<Foo>();
-        auto const foo_size = random<std::size_t>();
-
-        EXPECT_CALL( formatter, parse( format_specification_begin ) )
-            .WillOnce( Return( format_specification_end.c_str() ) );
-        EXPECT_CALL( formatter, print( Ref( stream ), Ref( foo ) ) ).WillOnce( Return( foo_size ) );
+        EXPECT_CALL( foo_a_formatter, print( Ref( stream ), Ref( foo_a ) ) ).WillOnce( Return( foo_a_size ) );
+        EXPECT_CALL( foo_b_formatter, print( Ref( stream ), Ref( foo_b ) ) ).WillOnce( Return( foo_b_size ) );
 
         auto const result = stream.print(
-            ( a + "{{" + b + "}}" + c + '{' + d + '}' + e ).c_str(), foo );
+            foo_a, Output_Formatter<Foo>{ foo_a_formatter }, foo_b, Output_Formatter<Foo>{ foo_b_formatter } );
 
         ASSERT_TRUE( result.is_value() );
-        EXPECT_EQ( result.value(), stream.string().size() + foo_size );
+        EXPECT_EQ( result.value(), foo_a_size + foo_b_size );
 
         EXPECT_TRUE( stream.is_nominal() );
-        EXPECT_EQ( stream.string(), a + '{' + b + '}' + c + e );
     }
 }
 
@@ -588,7 +508,7 @@ TEST( outputFormatterChar, putError )
 
     EXPECT_CALL( stream.buffer(), put( A<char>() ) ).WillOnce( Return( error ) );
 
-    auto const result = stream.print( "{}", random<char>() );
+    auto const result = stream.print( random<char>() );
 
     ASSERT_TRUE( result.is_error() );
     EXPECT_EQ( result.error(), error );
@@ -607,7 +527,7 @@ TEST( outputFormatterChar, worksProperly )
 
     auto const character = random<char>();
 
-    auto const result = stream.print( "{}", character );
+    auto const result = stream.print( character );
 
     ASSERT_TRUE( result.is_value() );
     EXPECT_EQ( result.value(), stream.string().size() );
@@ -627,7 +547,7 @@ TEST( outputFormatterNullTerminatedString, putError )
 
     EXPECT_CALL( stream.buffer(), put( A<std::string>() ) ).WillOnce( Return( error ) );
 
-    auto const result = stream.print( "{}", random_container<std::string>().c_str() );
+    auto const result = stream.print( random_container<std::string>().c_str() );
 
     ASSERT_TRUE( result.is_error() );
     EXPECT_EQ( result.error(), error );
@@ -646,7 +566,7 @@ TEST( outputFormatterNullTerminatedString, worksProperly )
 
     auto const string = random_container<std::string>();
 
-    auto const result = stream.print( "{}", string.c_str() );
+    auto const result = stream.print( string.c_str() );
 
     ASSERT_TRUE( result.is_value() );
     EXPECT_EQ( result.value(), stream.string().size() );
@@ -662,7 +582,7 @@ TEST( outputFormatterVoid, worksProperly )
 {
     auto stream = Output_String_Stream{};
 
-    auto const result = stream.print( "{}", Void{} );
+    auto const result = stream.print( Void{} );
 
     ASSERT_TRUE( result.is_value() );
     EXPECT_EQ( result.value(), stream.string().size() );
@@ -690,7 +610,7 @@ TEST( outputFormatterErrorCode, putError )
         .WillOnce( Return( error_description.c_str() ) );
     EXPECT_CALL( stream.buffer(), put( A<std::string>() ) ).WillOnce( Return( error ) );
 
-    auto const result = stream.print( "{}", Error_Code{ random<Mock_Error>() } );
+    auto const result = stream.print( Error_Code{ random<Mock_Error>() } );
 
     ASSERT_TRUE( result.is_error() );
     EXPECT_EQ( result.error(), error );
@@ -716,7 +636,7 @@ TEST( outputFormatterErrorCode, worksProperly )
     EXPECT_CALL( Mock_Error_Category::instance(), error_description( to_underlying( error ) ) )
         .WillOnce( Return( error_description.c_str() ) );
 
-    auto const result = stream.print( "{}", Error_Code{ error } );
+    auto const result = stream.print( Error_Code{ error } );
 
     ASSERT_TRUE( result.is_value() );
     EXPECT_EQ( result.value(), stream.string().size() );
@@ -745,7 +665,7 @@ TEST( outputFormatterErrorCodeEnum, putError )
         .WillOnce( Return( error_description.c_str() ) );
     EXPECT_CALL( stream.buffer(), put( A<std::string>() ) ).WillOnce( Return( error ) );
 
-    auto const result = stream.print( "{}", random<Mock_Error>() );
+    auto const result = stream.print( random<Mock_Error>() );
 
     ASSERT_TRUE( result.is_error() );
     EXPECT_EQ( result.error(), error );
@@ -772,7 +692,7 @@ TEST( outputFormatterErrorCodeEnum, worksProperly )
     EXPECT_CALL( Mock_Error_Category::instance(), error_description( to_underlying( error ) ) )
         .WillOnce( Return( error_description.c_str() ) );
 
-    auto const result = stream.print( "{}", error );
+    auto const result = stream.print( error );
 
     ASSERT_TRUE( result.is_value() );
     EXPECT_EQ( result.value(), stream.string().size() );


### PR DESCRIPTION
Resolves #1509 (Replace formatted output format strings with directly
constructed output formatters).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
