### PR TITLE
Add WIZnet W5500 TCP/UDP over IP port allocator without ephemeral port allocation support

### DIFF
--- a/include/picolibrary/wiznet/w5500/ip.h
+++ b/include/picolibrary/wiznet/w5500/ip.h
@@ -209,6 +209,8 @@ class Port_Allocator_Without_Ephemeral_Port_Allocation {
     template<typename Driver>
     auto port_is_in_use( Driver const & driver, ::picolibrary::IP::Port port ) noexcept -> bool
     {
+        // #lizard forgives the length
+
         Socket_ID const socket_ids[]{
             // clang-format off
 

--- a/include/picolibrary/wiznet/w5500/ip.h
+++ b/include/picolibrary/wiznet/w5500/ip.h
@@ -205,6 +205,10 @@ class Port_Allocator_Without_Ephemeral_Port_Allocation {
      * \tparam Driver The type of driver used to interact with the W5500.
      *
      * \param[in] driver The driver used to interact with the W5500.
+     * \param[in] port The port to check.
+     *
+     * \return true if port is in use.
+     * \return false if port is not in use.
      */
     template<typename Driver>
     // NOLINTNEXTLINE(readability-function-size)

--- a/include/picolibrary/wiznet/w5500/ip.h
+++ b/include/picolibrary/wiznet/w5500/ip.h
@@ -206,6 +206,7 @@ class Port_Allocator_Without_Ephemeral_Port_Allocation {
      *
      * \param[in] driver The driver used to interact with the W5500.
      */
+    // NOLINTNEXTLINE(readability-function-size)
     template<typename Driver>
     auto port_is_in_use( Driver const & driver, ::picolibrary::IP::Port port ) noexcept -> bool
     {

--- a/include/picolibrary/wiznet/w5500/ip.h
+++ b/include/picolibrary/wiznet/w5500/ip.h
@@ -23,7 +23,10 @@
 #ifndef PICOLIBRARY_WIZNET_W5500_IP_H
 #define PICOLIBRARY_WIZNET_W5500_IP_H
 
+#include "picolibrary/error.h"
 #include "picolibrary/ip.h"
+#include "picolibrary/precondition.h"
+#include "picolibrary/wiznet/w5500.h"
 
 /**
  * \brief WIZnet W5500 Internet Protocol (IP) facilities.
@@ -88,6 +91,148 @@ class Port_Allocator_Concept {
      * \param[in] port The previously allocated port to deallocate.
      */
     void deallocate( ::picolibrary::IP::Port port ) noexcept;
+};
+
+/**
+ * \brief TCP/UDP over IP port allocator without ephemeral port allocation support.
+ */
+class Port_Allocator_Without_Ephemeral_Port_Allocation {
+  public:
+    /**
+     * \brief Constructor.
+     */
+    constexpr Port_Allocator_Without_Ephemeral_Port_Allocation() noexcept = default;
+
+    /**
+     * \brief Constructor.
+     *
+     * \param[in] socket_protocol The socket protocol the port allocator will support.
+     *
+     * \pre socket_protocol == picolibrary::WIZnet::W5500::Socket_Protocol::TCP or
+     *      socket_protocol == picolibrary::WIZnet::W5500::Socket_Protocol::UDP
+     */
+    constexpr Port_Allocator_Without_Ephemeral_Port_Allocation( Socket_Protocol socket_protocol ) noexcept :
+        m_socket_protocol{ socket_protocol }
+    {
+        expect(
+            socket_protocol == Socket_Protocol::TCP or socket_protocol == Socket_Protocol::UDP,
+            Generic_Error::INVALID_ARGUMENT );
+    }
+
+    /**
+     * \brief Constructor.
+     *
+     * \param[in] source The source of the move.
+     */
+    constexpr Port_Allocator_Without_Ephemeral_Port_Allocation(
+        Port_Allocator_Without_Ephemeral_Port_Allocation && source ) noexcept = default;
+
+    /**
+     * \brief Constructor.
+     *
+     * \param[in] original The original to copy.
+     */
+    constexpr Port_Allocator_Without_Ephemeral_Port_Allocation(
+        Port_Allocator_Without_Ephemeral_Port_Allocation const & original ) noexcept = default;
+
+    /**
+     * \brief Destructor.
+     */
+    ~Port_Allocator_Without_Ephemeral_Port_Allocation() noexcept = default;
+
+    /**
+     * \brief Assignment operator.
+     *
+     * \param[in] expression The expression to be assigned.
+     *
+     * \return The assigned to object.
+     */
+    constexpr auto operator=( Port_Allocator_Without_Ephemeral_Port_Allocation && expression ) noexcept
+        -> Port_Allocator_Without_Ephemeral_Port_Allocation & = default;
+
+    /**
+     * \brief Assignment operator.
+     *
+     * \param[in] expression The expression to be assigned.
+     *
+     * \return The assigned to object.
+     */
+    constexpr auto operator=( Port_Allocator_Without_Ephemeral_Port_Allocation const & expression ) noexcept
+        -> Port_Allocator_Without_Ephemeral_Port_Allocation & = default;
+
+    /**
+     * \brief Allocate a port.
+     *
+     * \tparam Driver The type of driver used to interact with the W5500.
+     *
+     * \param[in] driver The driver used to interact with the W5500.
+     * \param[in] port The port to allocate.
+     *
+     * \pre not port.is_any()
+     * \pre port is not already in use
+     *
+     * \return port
+     */
+    template<typename Driver>
+    auto allocate( Driver const & driver, ::picolibrary::IP::Port port ) noexcept
+        -> ::picolibrary::IP::Port
+    {
+        expect( not port.is_any(), Generic_Error::LOGIC_ERROR );
+        expect( not port_is_in_use( driver, port ), Generic_Error::LOGIC_ERROR );
+
+        return port;
+    }
+
+    /**
+     * \brief Deallocate a previously allocated port.
+     *
+     * \param[in] port The previously allocated port to deallocate.
+     */
+    constexpr void deallocate( ::picolibrary::IP::Port port ) noexcept
+    {
+        static_cast<void>( port );
+    }
+
+  private:
+    /**
+     * \brief The socket protocol the port allocator supports.
+     */
+    Socket_Protocol m_socket_protocol{};
+
+    /**
+     * \brief Check if a port is in use.
+     *
+     * \tparam Driver The type of driver used to interact with the W5500.
+     *
+     * \param[in] driver The driver used to interact with the W5500.
+     */
+    template<typename Driver>
+    auto port_is_in_use( Driver const & driver, ::picolibrary::IP::Port port ) noexcept -> bool
+    {
+        Socket_ID const socket_ids[]{
+            // clang-format off
+
+            Socket_ID::_0,
+            Socket_ID::_1,
+            Socket_ID::_2,
+            Socket_ID::_3,
+            Socket_ID::_4,
+            Socket_ID::_5,
+            Socket_ID::_6,
+            Socket_ID::_7,
+
+            // clang-format on
+        };
+
+        for ( auto const socket_id : socket_ids ) {
+            if ( static_cast<Socket_Protocol>( driver.read_sn_mr( socket_id ) & SN_MR::Mask::P ) == m_socket_protocol
+                 and driver.read_sn_port( socket_id ) == port ) {
+                return true;
+            } // if
+        }     // for
+
+        return false;
+    }
 };
 
 } // namespace picolibrary::WIZnet::W5500::IP

--- a/include/picolibrary/wiznet/w5500/ip.h
+++ b/include/picolibrary/wiznet/w5500/ip.h
@@ -206,8 +206,8 @@ class Port_Allocator_Without_Ephemeral_Port_Allocation {
      *
      * \param[in] driver The driver used to interact with the W5500.
      */
-    // NOLINTNEXTLINE(readability-function-size)
     template<typename Driver>
+    // NOLINTNEXTLINE(readability-function-size)
     auto port_is_in_use( Driver const & driver, ::picolibrary::IP::Port port ) noexcept -> bool
     {
         // #lizard forgives the length


### PR DESCRIPTION
Resolves #1585 (Add WIZnet W5500 TCP/UDP over IP port allocator without
ephemeral port allocation support).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
