### PR TITLE
Disable clang-tidy bugprone-suspicious-enum-usage check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -20,6 +20,7 @@ Checks: >
     -abseil*,
     -android*,
     -boost*,
+    -bugprone-suspicious-enum-usage,
     -cppcoreguidelines-avoid-c-arrays,
     -cppcoreguidelines-avoid-magic-numbers,
     -cppcoreguidelines-pro-bounds-pointer-arithmetic,
@@ -105,9 +106,6 @@ CheckOptions:
     - key:   bugprone-string-constructor.LargeLengthThreshold
       value: '8388608'
     - key:   bugprone-string-constructor.WarnOnLargeLength
-      value: '1'
-
-    - key:   bugprone-suspicious-enum-usage.StrictMode
       value: '1'
 
     - key:   bugprone-suspicious-missing-comma.MaxConcatenatedTokens


### PR DESCRIPTION
Resolves #1611 (Disable clang-tidy bugprone-suspicious-enum-usage
check).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
