### PR TITLE
Remove interactive test helper output stream overloads

### DIFF
--- a/include/picolibrary/testing/interactive/adc.h
+++ b/include/picolibrary/testing/interactive/adc.h
@@ -24,61 +24,12 @@
 #define PICOLIBRARY_TESTING_INTERACTIVE_ADC_H
 
 #include "picolibrary/format.h"
-#include "picolibrary/precondition.h"
 #include "picolibrary/stream.h"
 
 /**
  * \brief Analog-to-Digital Converter (ADC) interactive testing facilities.
  */
 namespace picolibrary::Testing::Interactive::ADC {
-
-/**
- * \brief Blocking, single sample ADC sample interactive test helper.
- *
- * \tparam Blocking_Single_Sample_Converter The type of blocking, single sample ADC to use
- *         to get the samples.
- * \tparam Delayer A nullary functor called to introduce a delay each time a sample is
- *         gotten.
- *
- * \param[in] stream The output stream to write the samples to.
- * \param[in] adc The ADC to use to get the samples.
- * \param[in] delay The nullary functor to call to introduce a delay each time a sample is
- *            gotten.
- *
- * \pre writing to the stream succeeds
- */
-template<typename Blocking_Single_Sample_Converter, typename Delayer>
-// NOLINTNEXTLINE(readability-function-size)
-void sample_blocking_single_sample_converter( Output_Stream & stream, Blocking_Single_Sample_Converter adc, Delayer delay ) noexcept
-{
-    // #lizard forgives the length
-
-    adc.initialize();
-
-    {
-        auto result = stream.print(
-            "ADC sample range: [",
-            Format::Decimal{ Blocking_Single_Sample_Converter::Sample::min().as_unsigned_integer() },
-            ',',
-            Format::Decimal{ Blocking_Single_Sample_Converter::Sample::max().as_unsigned_integer() },
-            "]\n" );
-        expect( not result.is_error(), result.error() );
-    }
-
-    for ( ;; ) {
-        delay();
-
-        {
-            auto result = stream.print( Format::Decimal{ adc.sample().as_unsigned_integer() }, '\n' );
-            expect( not result.is_error(), result.error() );
-        }
-
-        {
-            auto result = stream.flush();
-            expect( not result.is_error(), result.error() );
-        }
-    } // for
-}
 
 /**
  * \brief Blocking, single sample ADC sample interactive test helper.

--- a/include/picolibrary/testing/interactive/gpio.h
+++ b/include/picolibrary/testing/interactive/gpio.h
@@ -23,47 +23,12 @@
 #ifndef PICOLIBRARY_TESTING_INTERACTIVE_GPIO_H
 #define PICOLIBRARY_TESTING_INTERACTIVE_GPIO_H
 
-#include "picolibrary/precondition.h"
 #include "picolibrary/stream.h"
 
 /**
  * \brief General Purpose Input/Output (GPIO) interactive testing facilities.
  */
 namespace picolibrary::Testing::Interactive::GPIO {
-
-/**
- * \brief GPIO input pin state interactive test helper.
- *
- * \tparam Input_Pin The type of input pin to get the state of.
- * \tparam Delayer A nullary functor called to introduce a delay each time the pin's state
- *         is gotten.
- *
- * \param[in] stream The output stream to write the pin state to.
- * \param[in] pin The pin to get the state of.
- * \param[in] delay The nullary functor to call to introduce a delay each time the pin's
- *            state is gotten.
- *
- * \pre writing to the stream succeeds
- */
-template<typename Input_Pin, typename Delayer>
-void state( Output_Stream & stream, Input_Pin pin, Delayer delay ) noexcept
-{
-    pin.initialize();
-
-    for ( ;; ) {
-        delay();
-
-        {
-            auto result = stream.put( pin.is_high() ? "high\n" : "low\n" );
-            expect( not result.is_error(), result.error() );
-        }
-
-        {
-            auto result = stream.flush();
-            expect( not result.is_error(), result.error() );
-        }
-    } // for
-}
 
 /**
  * \brief GPIO input pin state interactive test helper.

--- a/include/picolibrary/testing/interactive/i2c.h
+++ b/include/picolibrary/testing/interactive/i2c.h
@@ -27,59 +27,12 @@
 
 #include "picolibrary/format.h"
 #include "picolibrary/i2c.h"
-#include "picolibrary/precondition.h"
 #include "picolibrary/stream.h"
 
 /**
  * \brief Inter-Integrated Circuit (I2C) interactive testing facilities.
  */
 namespace picolibrary::Testing::Interactive::I2C {
-
-/**
- * \brief Controller bus scan interactive test helper.
- *
- * \tparam Controller The type of controller used to communicate with devices on the bus.
- *
- * \param[in] stream The output stream to write the scan results to.
- * \param[in] controller The controller used to communicate with devices on the bus.
- *
- * \pre writing to the stream succeeds
- */
-template<typename Controller>
-// NOLINTNEXTLINE(readability-function-size)
-void scan( Output_Stream & stream, Controller controller ) noexcept
-{
-    // #lizard forgives the length
-
-    controller.initialize();
-
-    auto devices_found = false;
-
-    ::picolibrary::I2C::scan(
-        controller,
-        [ &stream, &devices_found ](
-            ::picolibrary::I2C::Address_Numeric address, auto operation, auto response ) noexcept {
-            if ( response == ::picolibrary::I2C::Response::ACK ) {
-                devices_found = true;
-
-                auto result = stream.print(
-                    "device found: ",
-                    Format::Hexadecimal{ static_cast<std::uint8_t>( address.as_unsigned_integer() ) },
-                    " (",
-                    operation == ::picolibrary::I2C::Operation::READ ? 'R' : 'W',
-                    ")\n" );
-                expect( not result.is_error(), result.error() );
-            } // if
-        } );
-
-    if ( not devices_found ) {
-        auto result = stream.put( "no devices found\n" );
-        expect( not result.is_error(), result.error() );
-    } // if
-
-    auto result = stream.flush();
-    expect( not result.is_error(), result.error() );
-}
 
 /**
  * \brief Controller bus scan interactive test helper.

--- a/include/picolibrary/testing/interactive/microchip/mcp23008.h
+++ b/include/picolibrary/testing/interactive/microchip/mcp23008.h
@@ -29,6 +29,7 @@
 #include "picolibrary/error.h"
 #include "picolibrary/i2c.h"
 #include "picolibrary/microchip/mcp23008.h"
+#include "picolibrary/stream.h"
 #include "picolibrary/testing/interactive/gpio.h"
 
 /**
@@ -39,7 +40,6 @@ namespace picolibrary::Testing::Interactive::Microchip::MCP23008 {
 /**
  * \brief Internally pulled-up input pin state interactive test helper.
  *
- * \tparam Output_Stream The type of output stream to use.
  * \tparam Controller The type of controller used to communicate with the MCP23008.
  * \tparam Delayer A nullary functor called to introduce a delay each time the pin's state
  *         is gotten.
@@ -50,12 +50,10 @@ namespace picolibrary::Testing::Interactive::Microchip::MCP23008 {
  * \param[in] mask The mask identifying the pin.
  * \param[in] delay The nullary functor to call to introduce a delay each time the pin's
  *            state is gotten.
- *
- * \pre writing to the stream succeeds
  */
-template<typename Output_Stream, typename Controller, typename Delayer>
+template<typename Controller, typename Delayer>
 void state(
-    Output_Stream &                                         stream,
+    Reliable_Output_Stream &                                stream,
     Controller                                              controller,
     ::picolibrary::Microchip::MCP23008::Address_Transmitted address,
     std::uint8_t                                            mask,

--- a/include/picolibrary/testing/interactive/microchip/mcp23s08.h
+++ b/include/picolibrary/testing/interactive/microchip/mcp23s08.h
@@ -27,6 +27,7 @@
 #include <utility>
 
 #include "picolibrary/microchip/mcp23s08.h"
+#include "picolibrary/stream.h"
 #include "picolibrary/testing/interactive/gpio.h"
 
 /**
@@ -37,7 +38,6 @@ namespace picolibrary::Testing::Interactive::Microchip::MCP23S08 {
 /**
  * \brief Internally pulled-up input pin state interactive test helper.
  *
- * \tparam Output_Stream The type of output stream to use.
  * \tparam Controller The type of controller used to communicate with the MCP23S08.
  * \tparam Device_Selector The type of device selector used to select and deselect the
  *         MCP23S08.
@@ -54,13 +54,11 @@ namespace picolibrary::Testing::Interactive::Microchip::MCP23S08 {
  * \param[in] mask The mask identifying the pin.
  * \param[in] delay The nullary functor to call to introduce a delay each time the pin's
  *            state is gotten.
- *
- * \pre writing to the stream succeeds
  */
-template<typename Output_Stream, typename Controller, typename Device_Selector, typename Delayer>
+template<typename Controller, typename Device_Selector, typename Delayer>
 // NOLINTNEXTLINE(readability-function-size)
 void state(
-    Output_Stream &                                         stream,
+    Reliable_Output_Stream &                                stream,
     Controller                                              controller,
     typename Controller::Configuration                      configuration,
     Device_Selector                                         device_selector,

--- a/include/picolibrary/testing/interactive/microchip/mcp3008.h
+++ b/include/picolibrary/testing/interactive/microchip/mcp3008.h
@@ -26,6 +26,7 @@
 #include <utility>
 
 #include "picolibrary/microchip/mcp3008.h"
+#include "picolibrary/stream.h"
 #include "picolibrary/testing/interactive/adc.h"
 
 /**
@@ -36,7 +37,6 @@ namespace picolibrary::Testing::Interactive::Microchip::MCP3008 {
 /**
  * \brief Blocking, single sample ADC sample interactive test helper.
  *
- * \tparam Output_Stream The type of output stream to use.
  * \tparam Controller The type of controller used to communicate with the MCP3008.
  * \tparam Device_Selector The type of device selector used to select and deselect the
  *         MCP3008.
@@ -51,13 +51,11 @@ namespace picolibrary::Testing::Interactive::Microchip::MCP3008 {
  * \param[in] input The input to sample.
  * \param[in] delay The nullary functor to call to introduce a delay each time a sample is
  *            gotten.
- *
- * \pre writing to the stream succeeds
  */
-template<typename Output_Stream, typename Controller, typename Device_Selector, typename Delayer>
+template<typename Controller, typename Device_Selector, typename Delayer>
 // NOLINTNEXTLINE(readability-function-size)
 void sample(
-    Output_Stream &                          stream,
+    Reliable_Output_Stream &                 stream,
     Controller                               controller,
     typename Controller::Configuration       configuration,
     Device_Selector                          device_selector,

--- a/include/picolibrary/testing/interactive/spi.h
+++ b/include/picolibrary/testing/interactive/spi.h
@@ -48,46 +48,6 @@ namespace picolibrary::Testing::Interactive::SPI {
  *            the test.
  * \param[in] delay The nullary functor to call to introduce a delay each time data is
  *            exchanged.
- *
- * \pre writing to the stream succeeds
- */
-template<typename Controller, typename Delayer>
-void echo( Output_Stream & stream, Controller controller, typename Controller::Configuration const & configuration, Delayer delay ) noexcept
-{
-    controller.initialize();
-    controller.configure( configuration );
-
-    for ( auto tx = std::uint8_t{};; ++tx ) {
-        delay();
-
-        {
-            auto const rx     = controller.exchange( tx );
-            auto       result = stream.print(
-                "exchange( ", Format::Hexadecimal{ tx }, " ) -> ", Format::Hexadecimal{ rx }, '\n' );
-            expect( not result.is_error(), result.error() );
-            expect( rx == tx, Generic_Error::RUNTIME_ERROR );
-        }
-
-        {
-            auto result = stream.flush();
-            expect( not result.is_error(), result.error() );
-        }
-    } // for
-}
-
-/**
- * \brief Controller echo interactive test helper.
- *
- * \tparam Controller The type of controller to test.
- * \tparam Delayer A nullary functor called to introduce a delay each time data is
- *         exchanged.
- *
- * \param[in] stream The output stream to write test output to.
- * \param[in] controller The controller to test.
- * \param[in] configuration The clock and data exchange bit order configuration to use for
- *            the test.
- * \param[in] delay The nullary functor to call to introduce a delay each time data is
- *            exchanged.
  */
 template<typename Controller, typename Delayer>
 void echo(

--- a/include/picolibrary/testing/interactive/stream.h
+++ b/include/picolibrary/testing/interactive/stream.h
@@ -23,30 +23,9 @@
 #ifndef PICOLIBRARY_TESTING_INTERACTIVE_STREAM_H
 #define PICOLIBRARY_TESTING_INTERACTIVE_STREAM_H
 
-#include "picolibrary/precondition.h"
 #include "picolibrary/stream.h"
 
 namespace picolibrary::Testing::Interactive {
-
-/**
- * \brief Output stream hello world interactive test helper.
- *
- * \param[in] stream The output stream to write "Hello, world!\n" to.
- *
- * \pre writing to the stream succeeds
- */
-inline void hello_world( Output_Stream & stream ) noexcept
-{
-    {
-        auto result = stream.put( "Hello, world!\n" );
-        expect( not result.is_error(), result.error() );
-    }
-
-    {
-        auto result = stream.flush();
-        expect( not result.is_error(), result.error() );
-    }
-}
 
 /**
  * \brief Output stream hello world interactive test helper.


### PR DESCRIPTION
Resolves #1632 (Remove interactive test helper output stream overloads).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
