### PR TITLE
Add WIZnet W5500 IP network stack ping interactive test helper

### DIFF
--- a/include/picolibrary/testing/interactive/wiznet/w5500/ip/network_stack.h
+++ b/include/picolibrary/testing/interactive/wiznet/w5500/ip/network_stack.h
@@ -1,0 +1,131 @@
+/**
+ * picolibrary
+ *
+ * Copyright 2020-2022, Andrew Countryman <apcountryman@gmail.com> and the picolibrary
+ * contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/**
+ * \file
+ * \brief picolibrary::Testing::Interactive::WIZnet::W5500::IP::Network_Stack interface.
+ */
+
+#ifndef PICOLIBRARY_TESTING_INTERACTIVE_WIZNET_W5500_IP_NETWORK_STACK_H
+#define PICOLIBRARY_TESTING_INTERACTIVE_WIZNET_W5500_IP_NETWORK_STACK_H
+
+#include <cstdint>
+#include <utility>
+
+#include "picolibrary/error.h"
+#include "picolibrary/ipv4.h"
+#include "picolibrary/mac_address.h"
+#include "picolibrary/precondition.h"
+#include "picolibrary/stream.h"
+#include "picolibrary/wiznet/w5500.h"
+#include "picolibrary/wiznet/w5500/ip.h"
+#include "picolibrary/wiznet/w5500/ip/network_stack.h"
+
+namespace picolibrary::Testing::Interactive::WIZnet::W5500::IP::Network_Stack {
+
+/**
+ * \brief Network stack ping interactive test helper.
+ *
+ * \tparam Controller The type of controller used to communicate with the W5500.
+ * \tparam Device_Selector The type of device selector used to select and deselect the
+ *         W5500.
+ *
+ * \param[in] stream The output stream to write information to.
+ * \param[in] controller The controller used to communicate with the W5500.
+ * \param[in] configuration The controller clock and data exchange bit order configuration
+ *            that meets the W5500's communication requirements.
+ * \param[in] device_selector The device_selector used to select and deselect the W5500.
+ * \param[in] phy_mode The desired W5500 PHY mode.
+ * \param[in] arp_forcing_configuration The desired W5500 ARP forcing configuration.
+ * \param[in] retransmission_retry_time The desired W5500 retransmission retry time (RTR
+ *            register value).
+ * \param[in] retransmission_retry_count The desired W5500 retransmission retry count (RCR
+ *            register value).
+ * \param[in] mac_address The desired W5500 MAC address.
+ * \param[in] ipv4_address The desired W5500 IPv4 address.
+ * \param[in] gateway_ipv4_address The desired W5500 gateway IPv4 address.
+ * \param[in] ipv4_subnet_mask The desired W5500 IPv4 subnet mask.
+ */
+template<typename Controller, typename Device_Selector>
+void ping(
+    Reliable_Output_Stream &                  stream,
+    Controller                                controller,
+    typename Controller::Configuration        configuration,
+    Device_Selector                           device_selector,
+    ::picolibrary::WIZnet::W5500::PHY_Mode    phy_mode,
+    ::picolibrary::WIZnet::W5500::ARP_Forcing arp_forcing_configuration,
+    std::uint16_t                             retransmission_retry_time,
+    std::uint8_t                              retransmission_retry_count,
+    MAC_Address                               mac_address,
+    IPv4::Address                             ipv4_address,
+    IPv4::Address                             gateway_ipv4_address,
+    IPv4::Address                             ipv4_subnet_mask ) noexcept
+{
+    controller.initialize();
+
+    auto w5500 = ::picolibrary::WIZnet::W5500::Driver{ controller, configuration, std::move( device_selector ) };
+
+    w5500.initialize();
+
+    auto network_stack = ::picolibrary::WIZnet::W5500::IP::Network_Stack{
+        w5500, Generic_Error::NONRESPONSIVE_DEVICE, ::picolibrary::WIZnet::W5500::IP::Unsupported_Protocol_Port_Allocator{}
+    };
+
+    expect( network_stack.w5500_is_responsive(), network_stack.nonresponsive_device_error() );
+
+    network_stack.configure_phy( phy_mode );
+
+    network_stack.configure_ping_blocking( ::picolibrary::WIZnet::W5500::Ping_Blocking::DISABLED );
+
+    network_stack.configure_arp_forcing( arp_forcing_configuration );
+    network_stack.configure_retransmission( retransmission_retry_time, retransmission_retry_count );
+
+    network_stack.configure_mac_address( mac_address );
+
+    network_stack.configure_ipv4_address( ipv4_address );
+    network_stack.configure_gateway_ipv4_address( gateway_ipv4_address );
+    network_stack.configure_ipv4_subnet_mask( ipv4_subnet_mask );
+
+    stream.put( "waiting for link to be established\n" );
+
+    while ( network_stack.link_status() != ::picolibrary::WIZnet::W5500::Link_Status::UP ) {} // while
+
+    auto const link_speed = network_stack.link_speed();
+    auto const link_mode  = network_stack.link_mode();
+
+    // clang-format off
+    stream.print(
+        "link established:\n"
+        "    speed: ", link_speed == ::picolibrary::WIZnet::W5500::Link_Speed::_10_MbPs  ? "10 Mb/s"
+                     : link_speed == ::picolibrary::WIZnet::W5500::Link_Speed::_100_MbPs ? "100 Mb/s"
+                                                                                         : "unknown", "\n"
+        "    mode: ", link_mode == ::picolibrary::WIZnet::W5500::Link_Mode::HALF_DUPLEX ? "half duplex"
+                    : link_mode == ::picolibrary::WIZnet::W5500::Link_Mode::FULL_DUPLEX ? "full duplex"
+                                                                                        : "unknown", "\n"
+        "MAC address: ", mac_address, "\n"
+        "IPv4 address: ", ipv4_address, "\n"
+        "gateway IPv4 address: ", gateway_ipv4_address, "\n"
+        "IPv4 subnet mask: ", ipv4_subnet_mask, "\n"
+    );
+    // clang-format on
+
+    for ( ;; ) {} // for
+}
+
+} // namespace picolibrary::Testing::Interactive::WIZnet::W5500::IP::Network_Stack
+
+#endif // PICOLIBRARY_TESTING_INTERACTIVE_WIZNET_W5500_IP_NETWORK_STACK_H

--- a/include/picolibrary/testing/interactive/wiznet/w5500/ip/network_stack.h
+++ b/include/picolibrary/testing/interactive/wiznet/w5500/ip/network_stack.h
@@ -48,7 +48,7 @@ namespace picolibrary::Testing::Interactive::WIZnet::W5500::IP::Network_Stack {
  * \param[in] controller The controller used to communicate with the W5500.
  * \param[in] configuration The controller clock and data exchange bit order configuration
  *            that meets the W5500's communication requirements.
- * \param[in] device_selector The device_selector used to select and deselect the W5500.
+ * \param[in] device_selector The device selector used to select and deselect the W5500.
  * \param[in] phy_mode The desired W5500 PHY mode.
  * \param[in] arp_forcing_configuration The desired W5500 ARP forcing configuration.
  * \param[in] retransmission_retry_time The desired W5500 retransmission retry time (RTR

--- a/include/picolibrary/testing/interactive/wiznet/w5500/ip/network_stack.h
+++ b/include/picolibrary/testing/interactive/wiznet/w5500/ip/network_stack.h
@@ -61,6 +61,7 @@ namespace picolibrary::Testing::Interactive::WIZnet::W5500::IP::Network_Stack {
  * \param[in] ipv4_subnet_mask The desired W5500 IPv4 subnet mask.
  */
 template<typename Controller, typename Device_Selector>
+// NOLINTNEXTLINE(readability-function-size)
 void ping(
     Reliable_Output_Stream &                  stream,
     Controller                                controller,
@@ -75,6 +76,9 @@ void ping(
     IPv4::Address                             gateway_ipv4_address,
     IPv4::Address                             ipv4_subnet_mask ) noexcept
 {
+    // #lizard forgives the length
+    // #lizard forgives the parameter count
+
     controller.initialize();
 
     auto w5500 = ::picolibrary::WIZnet::W5500::Driver{ controller, configuration, std::move( device_selector ) };

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -131,6 +131,7 @@ if( ${PICOLIBRARY_ENABLE_INTERACTIVE_TESTING} )
         "picolibrary/testing/interactive/wiznet.cc"
         "picolibrary/testing/interactive/wiznet/w5500.cc"
         "picolibrary/testing/interactive/wiznet/w5500/ip.cc"
+        "picolibrary/testing/interactive/wiznet/w5500/ip/network_stack.cc"
     )
 endif( ${PICOLIBRARY_ENABLE_INTERACTIVE_TESTING} )
 

--- a/source/picolibrary/testing/interactive/wiznet/w5500/ip/network_stack.cc
+++ b/source/picolibrary/testing/interactive/wiznet/w5500/ip/network_stack.cc
@@ -1,0 +1,24 @@
+/**
+ * picolibrary
+ *
+ * Copyright 2020-2022, Andrew Countryman <apcountryman@gmail.com> and the picolibrary
+ * contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/**
+ * \file
+ * \brief picolibrary::Testing::Interactive::WIZnet::W5500::IP::Network_Stack
+ *        implementation.
+ */
+
+#include "picolibrary/testing/interactive/wiznet/w5500/ip/network_stack.h"


### PR DESCRIPTION
Resolves #1639 (Add WIZnet W5500 IP network stack ping interactive test
helper).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
