### PR TITLE
Fix WIZnet W5500 IP network stack ping interactive test helper placement

### DIFF
--- a/include/picolibrary/testing/interactive/wiznet/w5500/ip/network_stack.h
+++ b/include/picolibrary/testing/interactive/wiznet/w5500/ip/network_stack.h
@@ -35,7 +35,7 @@
 #include "picolibrary/wiznet/w5500/ip.h"
 #include "picolibrary/wiznet/w5500/ip/network_stack.h"
 
-namespace picolibrary::Testing::Interactive::WIZnet::W5500::IP::Network_Stack {
+namespace picolibrary::Testing::Interactive::WIZnet::W5500::IP {
 
 /**
  * \brief Network stack ping interactive test helper.
@@ -130,6 +130,6 @@ void ping(
     for ( ;; ) {} // for
 }
 
-} // namespace picolibrary::Testing::Interactive::WIZnet::W5500::IP::Network_Stack
+} // namespace picolibrary::Testing::Interactive::WIZnet::W5500::IP
 
 #endif // PICOLIBRARY_TESTING_INTERACTIVE_WIZNET_W5500_IP_NETWORK_STACK_H


### PR DESCRIPTION
Resolves #1644 (Fix WIZnet W5500 IP network stack ping interactive test
helper placement).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
