### PR TITLE
Add WIZnet W5500 no delayed ACK usage configuration

### DIFF
--- a/include/picolibrary/wiznet/w5500.h
+++ b/include/picolibrary/wiznet/w5500.h
@@ -3027,6 +3027,14 @@ enum class Socket_Protocol : SN_MR::Type {
 };
 
 /**
+ * \brief No delayed ACK usage configuration.
+ */
+enum class No_Delayed_ACK_Usage : SN_MR::Type {
+    DISABLED = 0b0 << SN_MR::Bit::ND, ///< Disabled.
+    ENABLED  = 0b1 << SN_MR::Bit::ND, ///< Enabled.
+};
+
+/**
  * \brief Socket buffer size.
  */
 enum class Socket_Buffer_Size : SN_RXBUF_SIZE::Type {


### PR DESCRIPTION
Resolves #1679 (Add WIZnet W5500 no delayed ACK usage configuration).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
