### PR TITLE
Fix WIZnet W5500 SN_SR register status enumerator typo

### DIFF
--- a/include/picolibrary/wiznet/w5500.h
+++ b/include/picolibrary/wiznet/w5500.h
@@ -1285,7 +1285,7 @@ struct SN_SR {
      */
     enum STATUS : Type {
         STATUS_SOCK_CLOSED = 0x00, ///< Closed.
-        STATUS_SOCK_INT    = 0x13, ///< Opened (TCP).
+        STATUS_SOCK_INIT   = 0x13, ///< Opened (TCP).
         STATUS_SOCK_LISTEN = 0x14, ///< Waiting for connection request from remote endpoint.
         STATUS_SOCK_ESTABLISHED = 0x17, ///< Established.
         STATUS_SOCK_CLOSE_WAIT = 0x1C, ///< Waiting for connection termination request from local user.


### PR DESCRIPTION
Resolves #1688 (Fix WIZnet W5500 SN_SR register status enumerator typo).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
