### PR TITLE
Add precondition check helper overload for execution paths that always fail

### DIFF
--- a/include/picolibrary/hsm.h
+++ b/include/picolibrary/hsm.h
@@ -477,7 +477,7 @@ class HSM {
                     state = m_superstate;
                     break;
                 case Event_Handling_Result::EVENT_IGNORED: return;
-                default: expect( false, Generic_Error::UNEXPECTED_EVENT_HANDLING_RESULT );
+                default: expect( Generic_Error::UNEXPECTED_EVENT_HANDLING_RESULT );
             } // switch
         }     // for
     }
@@ -740,7 +740,7 @@ class HSM {
         switch ( ( state )( *this, ENTRY ) ) {
             case Event_Handling_Result::EVENT_HANDLED: [[fallthrough]];
             case Event_Handling_Result::EVENT_HANDLING_DEFERRED_TO_SUPERSTATE: return;
-            default: expect( false, Generic_Error::UNEXPECTED_EVENT_HANDLING_RESULT );
+            default: expect( Generic_Error::UNEXPECTED_EVENT_HANDLING_RESULT );
         } // switch
     }
 
@@ -772,7 +772,7 @@ class HSM {
         switch ( ( state )( *this, EXIT ) ) {
             case Event_Handling_Result::EVENT_HANDLED: [[fallthrough]];
             case Event_Handling_Result::EVENT_HANDLING_DEFERRED_TO_SUPERSTATE: return;
-            default: expect( false, Generic_Error::UNEXPECTED_EVENT_HANDLING_RESULT );
+            default: expect( Generic_Error::UNEXPECTED_EVENT_HANDLING_RESULT );
         } // switch
     }
 
@@ -849,7 +849,7 @@ class HSM {
                     target_state = m_target_state;
                     break;
                 case Event_Handling_Result::EVENT_HANDLING_DEFERRED_TO_SUPERSTATE: return;
-                default: expect( false, Generic_Error::UNEXPECTED_EVENT_HANDLING_RESULT );
+                default: expect( Generic_Error::UNEXPECTED_EVENT_HANDLING_RESULT );
             } // switch
         }     // for
     }

--- a/include/picolibrary/precondition.h
+++ b/include/picolibrary/precondition.h
@@ -44,6 +44,19 @@ constexpr void expect( bool expectation, Error error ) noexcept
 }
 
 /**
+ * \brief Check a precondition's expectation.
+ *
+ * \tparam Error A type that can be implicitly converted to picolibrary::Error_Code.
+ *
+ * \param[in] error The fatal error that occurs.
+ */
+template<typename Error>
+[[noreturn]] void expect( Error error ) noexcept
+{
+    trap_fatal_error( error );
+}
+
+/**
  * \brief Bypass precondition expectation checks tag.
  */
 struct Bypass_Precondition_Expectation_Checks {

--- a/include/picolibrary/state_machine.h
+++ b/include/picolibrary/state_machine.h
@@ -363,7 +363,7 @@ class State_Machine {
                 enter( *m_target_state );
                 m_current_state = m_target_state;
                 return;
-            default: expect( false, Generic_Error::UNEXPECTED_EVENT_HANDLING_RESULT );
+            default: expect( Generic_Error::UNEXPECTED_EVENT_HANDLING_RESULT );
         } // switch
     }
 

--- a/include/picolibrary/wiznet/w5500/ip/network_stack.h
+++ b/include/picolibrary/wiznet/w5500/ip/network_stack.h
@@ -301,7 +301,7 @@ class Network_Stack {
 
                 // clang-format on
 
-            default: expect( false, Generic_Error::INVALID_ARGUMENT );
+            default: expect( Generic_Error::INVALID_ARGUMENT );
         } // switch
 
         for ( auto socket = std::uint_fast8_t{ 0 }; socket < sockets; ++socket ) {
@@ -589,7 +589,7 @@ class Network_Stack {
             } // if
         }     // for
 
-        expect( false, Generic_Error::NO_SOCKETS_AVAILABLE );
+        expect( Generic_Error::NO_SOCKETS_AVAILABLE );
     }
 
     /**


### PR DESCRIPTION
Resolves #1690 (Add precondition check helper overload for execution paths that always fail).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
