### PR TITLE
Add postcondition check helper overload for execution paths that always fail

### DIFF
--- a/include/picolibrary/postcondition.h
+++ b/include/picolibrary/postcondition.h
@@ -43,6 +43,19 @@ constexpr void ensure( bool guarantee, Error error ) noexcept
     } // if
 }
 
+/**
+ * \brief Check a postcondition's guarantee.
+ *
+ * \tparam Error A type that can be implicitly converted to picolibrary::Error_Code.
+ *
+ * \param[in] error The fatal error that occurs.
+ */
+template<typename Error>
+[[noreturn]] void ensure( Error error ) noexcept
+{
+    trap_fatal_error( error );
+}
+
 } // namespace picolibrary
 
 #endif // PICOLIBRARY_POSTCONDITION_H


### PR DESCRIPTION
Resolves #1691 (Add postcondition check helper overload for execution paths that always fail).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
