### PR TITLE
Rename integer output format specifiers

### DIFF
--- a/include/picolibrary/format.h
+++ b/include/picolibrary/format.h
@@ -45,18 +45,18 @@ namespace picolibrary::Format {
  * \tparam Integer The integer type to format.
  */
 template<typename Integer>
-class Binary {
+class Bin {
   public:
     static_assert( std::is_integral_v<Integer> );
 
-    Binary() = delete;
+    Bin() = delete;
 
     /**
      * \brief Constructor.
      *
      * \param[in] value The integer to be formatted.
      */
-    constexpr Binary( Integer value ) noexcept : m_value{ value }
+    constexpr Bin( Integer value ) noexcept : m_value{ value }
     {
     }
 
@@ -65,19 +65,19 @@ class Binary {
      *
      * \param[in] source The source of the move.
      */
-    constexpr Binary( Binary && source ) noexcept = default;
+    constexpr Bin( Bin && source ) noexcept = default;
 
     /**
      * \brief Constructor.
      *
      * \param[in] original The original to copy.
      */
-    constexpr Binary( Binary const & original ) noexcept = default;
+    constexpr Bin( Bin const & original ) noexcept = default;
 
     /**
      * \brief Destructor.
      */
-    ~Binary() noexcept = default;
+    ~Bin() noexcept = default;
 
     /**
      * \brief Assignment operator.
@@ -86,7 +86,7 @@ class Binary {
      *
      * \return The assigned to object.
      */
-    constexpr auto operator=( Binary && expression ) noexcept -> Binary & = default;
+    constexpr auto operator=( Bin && expression ) noexcept -> Bin & = default;
 
     /**
      * \brief Assignment operator.
@@ -95,7 +95,7 @@ class Binary {
      *
      * \return The assigned to object.
      */
-    constexpr auto operator=( Binary const & expression ) noexcept -> Binary & = default;
+    constexpr auto operator=( Bin const & expression ) noexcept -> Bin & = default;
 
     /**
      * \brief Get the integer to be formatted.
@@ -120,18 +120,18 @@ class Binary {
  * \tparam Integer The integer type to format.
  */
 template<typename Integer>
-class Decimal {
+class Dec {
   public:
     static_assert( std::is_integral_v<Integer> );
 
-    Decimal() = delete;
+    Dec() = delete;
 
     /**
      * \brief Constructor.
      *
      * \param[in] value The integer to be formatted.
      */
-    constexpr Decimal( Integer value ) noexcept : m_value{ value }
+    constexpr Dec( Integer value ) noexcept : m_value{ value }
     {
     }
 
@@ -140,19 +140,19 @@ class Decimal {
      *
      * \param[in] source The source of the move.
      */
-    constexpr Decimal( Decimal && source ) noexcept = default;
+    constexpr Dec( Dec && source ) noexcept = default;
 
     /**
      * \brief Constructor.
      *
      * \param[in] original The original to copy.
      */
-    constexpr Decimal( Decimal const & original ) noexcept = default;
+    constexpr Dec( Dec const & original ) noexcept = default;
 
     /**
      * \brief Destructor.
      */
-    ~Decimal() noexcept = default;
+    ~Dec() noexcept = default;
 
     /**
      * \brief Assignment operator.
@@ -161,7 +161,7 @@ class Decimal {
      *
      * \return The assigned to object.
      */
-    constexpr auto operator=( Decimal && expression ) noexcept -> Decimal & = default;
+    constexpr auto operator=( Dec && expression ) noexcept -> Dec & = default;
 
     /**
      * \brief Assignment operator.
@@ -170,7 +170,7 @@ class Decimal {
      *
      * \return The assigned to object.
      */
-    constexpr auto operator=( Decimal const & expression ) noexcept -> Decimal & = default;
+    constexpr auto operator=( Dec const & expression ) noexcept -> Dec & = default;
 
     /**
      * \brief Get the integer to be formatted.
@@ -195,18 +195,18 @@ class Decimal {
  * \tparam Integer The integer type to format.
  */
 template<typename Integer>
-class Hexadecimal {
+class Hex {
   public:
     static_assert( std::is_integral_v<Integer> );
 
-    Hexadecimal() = delete;
+    Hex() = delete;
 
     /**
      * \brief Constructor.
      *
      * \param[in] value The integer to be formatted.
      */
-    constexpr Hexadecimal( Integer value ) noexcept : m_value{ value }
+    constexpr Hex( Integer value ) noexcept : m_value{ value }
     {
     }
 
@@ -215,19 +215,19 @@ class Hexadecimal {
      *
      * \param[in] source The source of the move.
      */
-    constexpr Hexadecimal( Hexadecimal && source ) noexcept = default;
+    constexpr Hex( Hex && source ) noexcept = default;
 
     /**
      * \brief Constructor.
      *
      * \param[in] original The original to copy.
      */
-    constexpr Hexadecimal( Hexadecimal const & original ) noexcept = default;
+    constexpr Hex( Hex const & original ) noexcept = default;
 
     /**
      * \brief Destructor.
      */
-    ~Hexadecimal() noexcept = default;
+    ~Hex() noexcept = default;
 
     /**
      * \brief Assignment operator.
@@ -236,7 +236,7 @@ class Hexadecimal {
      *
      * \return The assigned to object.
      */
-    constexpr auto operator=( Hexadecimal && expression ) noexcept -> Hexadecimal & = default;
+    constexpr auto operator=( Hex && expression ) noexcept -> Hex & = default;
 
     /**
      * \brief Assignment operator.
@@ -245,7 +245,7 @@ class Hexadecimal {
      *
      * \return The assigned to object.
      */
-    constexpr auto operator=( Hexadecimal const & expression ) noexcept -> Hexadecimal & = default;
+    constexpr auto operator=( Hex const & expression ) noexcept -> Hex & = default;
 
     /**
      * \brief Get the integer to be formatted.
@@ -269,12 +269,12 @@ class Hexadecimal {
 namespace picolibrary {
 
 /**
- * \brief picolibrary::Format::Binary output formatter.
+ * \brief picolibrary::Format::Bin output formatter.
  *
  * \tparam Integer The type of integer to print.
  */
 template<typename Integer>
-class Output_Formatter<Format::Binary<Integer>> {
+class Output_Formatter<Format::Bin<Integer>> {
   public:
     /**
      * \brief Constructor.
@@ -320,9 +320,9 @@ class Output_Formatter<Format::Binary<Integer>> {
         -> Output_Formatter & = default;
 
     /**
-     * \brief Write the formatted picolibrary::Format::Binary to the stream.
+     * \brief Write the formatted picolibrary::Format::Bin to the stream.
      *
-     * \param[in] stream The stream to write the formatted picolibrary::Format::Binary to.
+     * \param[in] stream The stream to write the formatted picolibrary::Format::Bin to.
      * \param[in] integer The integer to format.
      *
      * \return The number of characters written to the stream if the write succeeded.
@@ -342,9 +342,9 @@ class Output_Formatter<Format::Binary<Integer>> {
     }
 
     /**
-     * \brief Write the formatted picolibrary::Format::Binary to the stream.
+     * \brief Write the formatted picolibrary::Format::Bin to the stream.
      *
-     * \param[in] stream The stream to write the formatted picolibrary::Format::Binary to.
+     * \param[in] stream The stream to write the formatted picolibrary::Format::Bin to.
      * \param[in] integer The integer to format.
      *
      * \return The number of characters written to the stream.
@@ -398,12 +398,12 @@ class Output_Formatter<Format::Binary<Integer>> {
 };
 
 /**
- * \brief picolibrary::Format::Decimal output formatter.
+ * \brief picolibrary::Format::Dec output formatter.
  *
  * \tparam Integer The type of integer to print.
  */
 template<typename Integer>
-class Output_Formatter<Format::Decimal<Integer>, std::enable_if_t<std::is_signed_v<Integer>>> {
+class Output_Formatter<Format::Dec<Integer>, std::enable_if_t<std::is_signed_v<Integer>>> {
   public:
     /**
      * \brief Constructor.
@@ -449,10 +449,9 @@ class Output_Formatter<Format::Decimal<Integer>, std::enable_if_t<std::is_signed
         -> Output_Formatter & = default;
 
     /**
-     * \brief Write the formatted picolibrary::Format::Decimal to the stream.
+     * \brief Write the formatted picolibrary::Format::Dec to the stream.
      *
-     * \param[in] stream The stream to write the formatted picolibrary::Format::Decimal
-     *            to.
+     * \param[in] stream The stream to write the formatted picolibrary::Format::Dec to.
      * \param[in] integer The integer to format.
      *
      * \return The number of characters written to the stream if the write succeeded.
@@ -474,10 +473,9 @@ class Output_Formatter<Format::Decimal<Integer>, std::enable_if_t<std::is_signed
     }
 
     /**
-     * \brief Write the formatted picolibrary::Format::Decimal to the stream.
+     * \brief Write the formatted picolibrary::Format::Dec to the stream.
      *
-     * \param[in] stream The stream to write the formatted picolibrary::Format::Decimal
-     *            to.
+     * \param[in] stream The stream to write the formatted picolibrary::Format::Dec to.
      * \param[in] integer The integer to format.
      *
      * \return The number of characters written to the stream.
@@ -531,12 +529,12 @@ class Output_Formatter<Format::Decimal<Integer>, std::enable_if_t<std::is_signed
 };
 
 /**
- * \brief picolibrary::Format::Decimal output formatter.
+ * \brief picolibrary::Format::Dec output formatter.
  *
  * \tparam Integer The type of integer to print.
  */
 template<typename Integer>
-class Output_Formatter<Format::Decimal<Integer>, std::enable_if_t<std::is_unsigned_v<Integer>>> {
+class Output_Formatter<Format::Dec<Integer>, std::enable_if_t<std::is_unsigned_v<Integer>>> {
   public:
     /**
      * \brief Constructor.
@@ -582,10 +580,9 @@ class Output_Formatter<Format::Decimal<Integer>, std::enable_if_t<std::is_unsign
         -> Output_Formatter & = default;
 
     /**
-     * \brief Write the formatted picolibrary::Format::Decimal to the stream.
+     * \brief Write the formatted picolibrary::Format::Dec to the stream.
      *
-     * \param[in] stream The stream to write the formatted picolibrary::Format::Decimal
-     *            to.
+     * \param[in] stream The stream to write the formatted picolibrary::Format::Dec to.
      * \param[in] integer The integer to format.
      *
      * \return The number of characters written to the stream if the write succeeded.
@@ -607,10 +604,9 @@ class Output_Formatter<Format::Decimal<Integer>, std::enable_if_t<std::is_unsign
     }
 
     /**
-     * \brief Write the formatted picolibrary::Format::Decimal to the stream.
+     * \brief Write the formatted picolibrary::Format::Dec to the stream.
      *
-     * \param[in] stream The stream to write the formatted picolibrary::Format::Decimal
-     *            to.
+     * \param[in] stream The stream to write the formatted picolibrary::Format::Dec to.
      * \param[in] integer The integer to format.
      *
      * \return The number of characters written to the stream.
@@ -654,12 +650,12 @@ class Output_Formatter<Format::Decimal<Integer>, std::enable_if_t<std::is_unsign
 };
 
 /**
- * \brief picolibrary::Format::Hexadecimal output formatter.
+ * \brief picolibrary::Format::Hex output formatter.
  *
  * \tparam Integer The type of integer to print.
  */
 template<typename Integer>
-class Output_Formatter<Format::Hexadecimal<Integer>> {
+class Output_Formatter<Format::Hex<Integer>> {
   public:
     /**
      * \brief Constructor.
@@ -705,10 +701,9 @@ class Output_Formatter<Format::Hexadecimal<Integer>> {
         -> Output_Formatter & = default;
 
     /**
-     * \brief Write the formatted picolibrary::Format::Hexadecimal to the stream.
+     * \brief Write the formatted picolibrary::Format::Hex to the stream.
      *
-     * \param[in] stream The stream to write the formatted
-     *            picolibrary::Format::Hexadecimal to.
+     * \param[in] stream The stream to write the formatted picolibrary::Format::Hex to.
      * \param[in] integer The integer to format.
      *
      * \return The number of characters written to the stream if the write succeeded.
@@ -728,10 +723,9 @@ class Output_Formatter<Format::Hexadecimal<Integer>> {
     }
 
     /**
-     * \brief Write the formatted picolibrary::Format::Hexadecimal to the stream.
+     * \brief Write the formatted picolibrary::Format::Hex to the stream.
      *
-     * \param[in] stream The stream to write the formatted
-     *            picolibrary::Format::Hexadecimal to.
+     * \param[in] stream The stream to write the formatted picolibrary::Format::Hex to.
      * \param[in] integer The integer to format.
      *
      * \return The number of characters written to the stream.

--- a/include/picolibrary/ip.h
+++ b/include/picolibrary/ip.h
@@ -962,7 +962,7 @@ class Output_Formatter<IP::Port> {
      */
     auto print( Output_Stream & stream, IP::Port port ) const noexcept -> Result<std::size_t, Error_Code>
     {
-        return stream.print( Format::Decimal{ port.as_unsigned_integer() } );
+        return stream.print( Format::Dec{ port.as_unsigned_integer() } );
     }
 
     /**
@@ -975,7 +975,7 @@ class Output_Formatter<IP::Port> {
      */
     auto print( Reliable_Output_Stream & stream, IP::Port port ) const noexcept -> std::size_t
     {
-        return stream.print( Format::Decimal{ port.as_unsigned_integer() } );
+        return stream.print( Format::Dec{ port.as_unsigned_integer() } );
     }
 };
 

--- a/include/picolibrary/ipv4.h
+++ b/include/picolibrary/ipv4.h
@@ -413,13 +413,13 @@ class Output_Formatter<IPv4::Address> {
         -> Result<std::size_t, Error_Code>
     {
         return stream.print(
-            Format::Decimal{ address.as_byte_array()[ 0 ] },
+            Format::Dec{ address.as_byte_array()[ 0 ] },
             '.',
-            Format::Decimal{ address.as_byte_array()[ 1 ] },
+            Format::Dec{ address.as_byte_array()[ 1 ] },
             '.',
-            Format::Decimal{ address.as_byte_array()[ 2 ] },
+            Format::Dec{ address.as_byte_array()[ 2 ] },
             '.',
-            Format::Decimal{ address.as_byte_array()[ 3 ] } );
+            Format::Dec{ address.as_byte_array()[ 3 ] } );
     }
 
     /**
@@ -434,13 +434,13 @@ class Output_Formatter<IPv4::Address> {
         -> std::size_t
     {
         return stream.print(
-            Format::Decimal{ address.as_byte_array()[ 0 ] },
+            Format::Dec{ address.as_byte_array()[ 0 ] },
             '.',
-            Format::Decimal{ address.as_byte_array()[ 1 ] },
+            Format::Dec{ address.as_byte_array()[ 1 ] },
             '.',
-            Format::Decimal{ address.as_byte_array()[ 2 ] },
+            Format::Dec{ address.as_byte_array()[ 2 ] },
             '.',
-            Format::Decimal{ address.as_byte_array()[ 3 ] } );
+            Format::Dec{ address.as_byte_array()[ 3 ] } );
     }
 };
 

--- a/include/picolibrary/testing/interactive/adc.h
+++ b/include/picolibrary/testing/interactive/adc.h
@@ -51,15 +51,15 @@ void sample_blocking_single_sample_converter( Reliable_Output_Stream & stream, B
 
     stream.print(
         "ADC sample range: [",
-        Format::Decimal{ Blocking_Single_Sample_Converter::Sample::min().as_unsigned_integer() },
+        Format::Dec{ Blocking_Single_Sample_Converter::Sample::min().as_unsigned_integer() },
         ',',
-        Format::Decimal{ Blocking_Single_Sample_Converter::Sample::max().as_unsigned_integer() },
+        Format::Dec{ Blocking_Single_Sample_Converter::Sample::max().as_unsigned_integer() },
         "]\n" );
 
     for ( ;; ) {
         delay();
 
-        stream.print( Format::Decimal{ adc.sample().as_unsigned_integer() }, '\n' );
+        stream.print( Format::Dec{ adc.sample().as_unsigned_integer() }, '\n' );
 
         stream.flush();
     } // for

--- a/include/picolibrary/testing/interactive/i2c.h
+++ b/include/picolibrary/testing/interactive/i2c.h
@@ -61,7 +61,7 @@ void scan( Reliable_Output_Stream & stream, Controller controller ) noexcept
 
                 stream.print(
                     "device found: ",
-                    Format::Hexadecimal{ static_cast<std::uint8_t>( address.as_unsigned_integer() ) },
+                    Format::Hex{ static_cast<std::uint8_t>( address.as_unsigned_integer() ) },
                     " (",
                     operation == ::picolibrary::I2C::Operation::READ ? 'R' : 'W',
                     ")\n" );

--- a/include/picolibrary/testing/interactive/spi.h
+++ b/include/picolibrary/testing/interactive/spi.h
@@ -63,8 +63,7 @@ void echo(
         delay();
 
         auto const rx = controller.exchange( tx );
-        stream.print(
-            "exchange( ", Format::Hexadecimal{ tx }, " ) -> ", Format::Hexadecimal{ rx }, '\n' );
+        stream.print( "exchange( ", Format::Hex{ tx }, " ) -> ", Format::Hex{ rx }, '\n' );
         expect( rx == tx, Generic_Error::RUNTIME_ERROR );
 
         stream.flush();

--- a/test/automated/picolibrary/format/CMakeLists.txt
+++ b/test/automated/picolibrary/format/CMakeLists.txt
@@ -15,11 +15,11 @@
 
 # Description: picolibrary::Format automated tests CMake rules.
 
-# build the picolibrary::Format::Binary automated tests
-add_subdirectory( binary )
+# build the picolibrary::Format::Bin automated tests
+add_subdirectory( bin )
 
-# build the picolibrary::Format::Decimal automated tests
-add_subdirectory( decimal )
+# build the picolibrary::Format::Dec automated tests
+add_subdirectory( dec )
 
-# build the picolibrary::Format::Hexadecimal automated tests
-add_subdirectory( hexadecimal )
+# build the picolibrary::Format::Hex automated tests
+add_subdirectory( hex )

--- a/test/automated/picolibrary/format/bin/CMakeLists.txt
+++ b/test/automated/picolibrary/format/bin/CMakeLists.txt
@@ -13,21 +13,21 @@
 # KIND, either express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-# Description: picolibrary::Format::Decimal automated tests CMake rules.
+# Description: picolibrary::Format::Bin automated tests CMake rules.
 
-# build the picolibrary::Format::Decimal automated tests
+# build the picolibrary::Format::Bin automated tests
 if( ${PICOLIBRARY_ENABLE_AUTOMATED_TESTING} )
     add_executable(
-        test-automated-picolibrary-format-decimal
+        test-automated-picolibrary-format-bin
         main.cc
     )
     target_link_libraries(
-        test-automated-picolibrary-format-decimal
+        test-automated-picolibrary-format-bin
         picolibrary
         picolibrary-testing-automated-fatal_error
     )
     add_test(
-        NAME    test-automated-picolibrary-format-decimal
-        COMMAND test-automated-picolibrary-format-decimal --gtest_color=yes
+        NAME    test-automated-picolibrary-format-bin
+        COMMAND test-automated-picolibrary-format-bin --gtest_color=yes
     )
 endif( ${PICOLIBRARY_ENABLE_AUTOMATED_TESTING} )

--- a/test/automated/picolibrary/format/bin/main.cc
+++ b/test/automated/picolibrary/format/bin/main.cc
@@ -17,7 +17,7 @@
 
 /**
  * \file
- * \brief picolibrary::Format::Binary automated test program.
+ * \brief picolibrary::Format::Bin automated test program.
  */
 
 #include <bitset>
@@ -39,7 +39,7 @@
 namespace {
 
 using ::picolibrary::to_unsigned;
-using ::picolibrary::Format::Binary;
+using ::picolibrary::Format::Bin;
 using ::picolibrary::Testing::Automated::Mock_Error;
 using ::picolibrary::Testing::Automated::Mock_Output_Stream;
 using ::picolibrary::Testing::Automated::Output_String_Stream;
@@ -49,7 +49,7 @@ using ::testing::A;
 using ::testing::Return;
 
 template<typename Integer>
-auto binary( Integer value ) -> std::string
+auto bin( Integer value ) -> std::string
 {
     using U = std::make_unsigned_t<Integer>;
 
@@ -65,30 +65,30 @@ auto binary( Integer value ) -> std::string
 } // namespace
 
 /**
- * \brief picolibrary::Output_Formatter<picolibrary::Binary> automated test fixture.
+ * \brief picolibrary::Output_Formatter<picolibrary::Bin> automated test fixture.
  *
  * \tparam Integer The type of integer to print.
  */
 template<typename Integer>
-class outputFormatterBinary : public ::testing::Test {
+class outputFormatterBin : public ::testing::Test {
 };
 
 /**
- * \brief picolibrary::Output_Formatter<picolibrary::Binary> automated test integer types.
+ * \brief picolibrary::Output_Formatter<picolibrary::Bin> automated test integer types.
  */
 using Integers =
     ::testing::Types<std::int8_t, std::uint8_t, std::int16_t, std::uint16_t, std::int32_t, std::uint32_t, std::int64_t, std::uint64_t>;
 
 /**
- * \brief picolibrary::Output_Formatter<picolibrary::Binary> automated test fixture.
+ * \brief picolibrary::Output_Formatter<picolibrary::Bin> automated test fixture.
  */
-TYPED_TEST_SUITE( outputFormatterBinary, Integers );
+TYPED_TEST_SUITE( outputFormatterBin, Integers );
 
 /**
- * \brief Verify picolibrary::Output_Formatter<picolibrary::Format::Binary> properly
- *        handles a put error.
+ * \brief Verify picolibrary::Output_Formatter<picolibrary::Format::Bin> properly handles
+ *        a put error.
  */
-TYPED_TEST( outputFormatterBinary, putError )
+TYPED_TEST( outputFormatterBin, putError )
 {
     using Integer = TypeParam;
 
@@ -98,7 +98,7 @@ TYPED_TEST( outputFormatterBinary, putError )
 
     EXPECT_CALL( stream.buffer(), put( A<std::string>() ) ).WillOnce( Return( error ) );
 
-    auto const result = stream.print( Binary{ random<Integer>() } );
+    auto const result = stream.print( Bin{ random<Integer>() } );
 
     ASSERT_TRUE( result.is_error() );
     EXPECT_EQ( result.error(), error );
@@ -109,10 +109,9 @@ TYPED_TEST( outputFormatterBinary, putError )
 }
 
 /**
- * \brief Verify picolibrary::Output_Formatter<picolibrary::Format::Binary> works
- *        properly.
+ * \brief Verify picolibrary::Output_Formatter<picolibrary::Format::Bin> works properly.
  */
-TYPED_TEST( outputFormatterBinary, worksProperly )
+TYPED_TEST( outputFormatterBin, worksProperly )
 {
     using Integer = TypeParam;
 
@@ -121,13 +120,13 @@ TYPED_TEST( outputFormatterBinary, worksProperly )
 
         auto const value = random<Integer>();
 
-        auto const result = stream.print( Binary{ value } );
+        auto const result = stream.print( Bin{ value } );
 
         ASSERT_TRUE( result.is_value() );
         EXPECT_EQ( result.value(), stream.string().size() );
 
         EXPECT_TRUE( stream.is_nominal() );
-        EXPECT_EQ( stream.string(), binary( value ) );
+        EXPECT_EQ( stream.string(), bin( value ) );
     }
 
     {
@@ -135,17 +134,17 @@ TYPED_TEST( outputFormatterBinary, worksProperly )
 
         auto const value = random<Integer>();
 
-        auto const n = stream.print( Binary{ value } );
+        auto const n = stream.print( Bin{ value } );
 
         EXPECT_EQ( n, stream.string().size() );
 
         EXPECT_TRUE( stream.is_nominal() );
-        EXPECT_EQ( stream.string(), binary( value ) );
+        EXPECT_EQ( stream.string(), bin( value ) );
     }
 }
 
 /**
- * \brief Execute the picolibrary::Format::Binary automated tests.
+ * \brief Execute the picolibrary::Format::Bin automated tests.
  *
  * \param[in] argc The number of arguments to pass to testing::InitGoogleMock().
  * \param[in] argc The array of arguments to pass to testing::InitGoogleMock().

--- a/test/automated/picolibrary/format/dec/CMakeLists.txt
+++ b/test/automated/picolibrary/format/dec/CMakeLists.txt
@@ -13,21 +13,21 @@
 # KIND, either express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-# Description: picolibrary::Format::Hexadecimal automated tests CMake rules.
+# Description: picolibrary::Format::Dec automated tests CMake rules.
 
-# build the picolibrary::Format::Hexadecimal automated tests
+# build the picolibrary::Format::Dec automated tests
 if( ${PICOLIBRARY_ENABLE_AUTOMATED_TESTING} )
     add_executable(
-        test-automated-picolibrary-format-hexadecimal
+        test-automated-picolibrary-format-dec
         main.cc
     )
     target_link_libraries(
-        test-automated-picolibrary-format-hexadecimal
+        test-automated-picolibrary-format-dec
         picolibrary
         picolibrary-testing-automated-fatal_error
     )
     add_test(
-        NAME    test-automated-picolibrary-format-hexadecimal
-        COMMAND test-automated-picolibrary-format-hexadecimal --gtest_color=yes
+        NAME    test-automated-picolibrary-format-dec
+        COMMAND test-automated-picolibrary-format-dec --gtest_color=yes
     )
 endif( ${PICOLIBRARY_ENABLE_AUTOMATED_TESTING} )

--- a/test/automated/picolibrary/format/dec/main.cc
+++ b/test/automated/picolibrary/format/dec/main.cc
@@ -17,7 +17,7 @@
 
 /**
  * \file
- * \brief picolibrary::Format::Decimal automated test program.
+ * \brief picolibrary::Format::Dec automated test program.
  */
 
 #include <cstddef>
@@ -35,7 +35,7 @@
 
 namespace {
 
-using ::picolibrary::Format::Decimal;
+using ::picolibrary::Format::Dec;
 using ::picolibrary::Testing::Automated::Mock_Error;
 using ::picolibrary::Testing::Automated::Mock_Output_Stream;
 using ::picolibrary::Testing::Automated::Output_String_Stream;
@@ -45,7 +45,7 @@ using ::testing::A;
 using ::testing::Return;
 
 template<typename Integer>
-auto decimal( Integer value ) -> std::string
+auto dec( Integer value ) -> std::string
 {
     auto stream = std::ostringstream{};
 
@@ -59,31 +59,30 @@ auto decimal( Integer value ) -> std::string
 } // namespace
 
 /**
- * \brief picolibrary::Output_Formatter<picolibrary::Decimal> automated test fixture.
+ * \brief picolibrary::Output_Formatter<picolibrary::Dec> automated test fixture.
  *
  * \tparam Integer The type of integer to print.
  */
 template<typename Integer>
-class outputFormatterDecimal : public ::testing::Test {
+class outputFormatterDec : public ::testing::Test {
 };
 
 /**
- * \brief picolibrary::Output_Formatter<picolibrary::Decimal> automated test integer
- *        types.
+ * \brief picolibrary::Output_Formatter<picolibrary::Dec> automated test integer types.
  */
 using Integers =
     ::testing::Types<std::int8_t, std::uint8_t, std::int16_t, std::uint16_t, std::int32_t, std::uint32_t, std::int64_t, std::uint64_t>;
 
 /**
- * \brief picolibrary::Output_Formatter<picolibrary::Decimal> automated test fixture.
+ * \brief picolibrary::Output_Formatter<picolibrary::Dec> automated test fixture.
  */
-TYPED_TEST_SUITE( outputFormatterDecimal, Integers );
+TYPED_TEST_SUITE( outputFormatterDec, Integers );
 
 /**
- * \brief Verify picolibrary::Output_Formatter<picolibrary::Format::Decimal> properly
- *        handles a put error.
+ * \brief Verify picolibrary::Output_Formatter<picolibrary::Format::Dec> properly handles
+ *        a put error.
  */
-TYPED_TEST( outputFormatterDecimal, putError )
+TYPED_TEST( outputFormatterDec, putError )
 {
     using Integer = TypeParam;
 
@@ -93,7 +92,7 @@ TYPED_TEST( outputFormatterDecimal, putError )
 
     EXPECT_CALL( stream.buffer(), put( A<std::string>() ) ).WillOnce( Return( error ) );
 
-    auto const result = stream.print( Decimal{ random<Integer>() } );
+    auto const result = stream.print( Dec{ random<Integer>() } );
 
     ASSERT_TRUE( result.is_error() );
     EXPECT_EQ( result.error(), error );
@@ -104,10 +103,9 @@ TYPED_TEST( outputFormatterDecimal, putError )
 }
 
 /**
- * \brief Verify picolibrary::Output_Formatter<picolibrary::Format::Decimal> works
- *        properly.
+ * \brief Verify picolibrary::Output_Formatter<picolibrary::Format::Dec> works properly.
  */
-TYPED_TEST( outputFormatterDecimal, worksProperly )
+TYPED_TEST( outputFormatterDec, worksProperly )
 {
     using Integer = TypeParam;
 
@@ -116,13 +114,13 @@ TYPED_TEST( outputFormatterDecimal, worksProperly )
 
         auto const value = random<Integer>();
 
-        auto const result = stream.print( Decimal{ value } );
+        auto const result = stream.print( Dec{ value } );
 
         ASSERT_TRUE( result.is_value() );
         EXPECT_EQ( result.value(), stream.string().size() );
 
         EXPECT_TRUE( stream.is_nominal() );
-        EXPECT_EQ( stream.string(), decimal( value ) );
+        EXPECT_EQ( stream.string(), dec( value ) );
     }
 
     {
@@ -130,17 +128,17 @@ TYPED_TEST( outputFormatterDecimal, worksProperly )
 
         auto const value = random<Integer>();
 
-        auto const n = stream.print( Decimal{ value } );
+        auto const n = stream.print( Dec{ value } );
 
         EXPECT_EQ( n, stream.string().size() );
 
         EXPECT_TRUE( stream.is_nominal() );
-        EXPECT_EQ( stream.string(), decimal( value ) );
+        EXPECT_EQ( stream.string(), dec( value ) );
     }
 }
 
 /**
- * \brief Execute the picolibrary::Format::Decimal automated tests.
+ * \brief Execute the picolibrary::Format::Dec automated tests.
  *
  * \param[in] argc The number of arguments to pass to testing::InitGoogleMock().
  * \param[in] argc The array of arguments to pass to testing::InitGoogleMock().

--- a/test/automated/picolibrary/format/hex/CMakeLists.txt
+++ b/test/automated/picolibrary/format/hex/CMakeLists.txt
@@ -13,21 +13,21 @@
 # KIND, either express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-# Description: picolibrary::Format::Binary automated tests CMake rules.
+# Description: picolibrary::Format::Hex automated tests CMake rules.
 
-# build the picolibrary::Format::Binary automated tests
+# build the picolibrary::Format::Hex automated tests
 if( ${PICOLIBRARY_ENABLE_AUTOMATED_TESTING} )
     add_executable(
-        test-automated-picolibrary-format-binary
+        test-automated-picolibrary-format-hex
         main.cc
     )
     target_link_libraries(
-        test-automated-picolibrary-format-binary
+        test-automated-picolibrary-format-hex
         picolibrary
         picolibrary-testing-automated-fatal_error
     )
     add_test(
-        NAME    test-automated-picolibrary-format-binary
-        COMMAND test-automated-picolibrary-format-binary --gtest_color=yes
+        NAME    test-automated-picolibrary-format-hex
+        COMMAND test-automated-picolibrary-format-hex --gtest_color=yes
     )
 endif( ${PICOLIBRARY_ENABLE_AUTOMATED_TESTING} )

--- a/test/automated/picolibrary/format/hex/main.cc
+++ b/test/automated/picolibrary/format/hex/main.cc
@@ -17,7 +17,7 @@
 
 /**
  * \file
- * \brief picolibrary::Format::Hexadecimal automated test program.
+ * \brief picolibrary::Format::Hex automated test program.
  */
 
 #include <cstddef>
@@ -40,7 +40,7 @@
 namespace {
 
 using ::picolibrary::to_unsigned;
-using ::picolibrary::Format::Hexadecimal;
+using ::picolibrary::Format::Hex;
 using ::picolibrary::Testing::Automated::Mock_Error;
 using ::picolibrary::Testing::Automated::Mock_Output_Stream;
 using ::picolibrary::Testing::Automated::Output_String_Stream;
@@ -50,7 +50,7 @@ using ::testing::A;
 using ::testing::Return;
 
 template<typename Integer>
-auto hexadecimal( Integer value ) -> std::string
+auto hex( Integer value ) -> std::string
 {
     using U = std::make_unsigned_t<Integer>;
 
@@ -68,31 +68,30 @@ auto hexadecimal( Integer value ) -> std::string
 } // namespace
 
 /**
- * \brief picolibrary::Output_Formatter<picolibrary::Hexadecimal> automated test fixture.
+ * \brief picolibrary::Output_Formatter<picolibrary::Hex> automated test fixture.
  *
  * \tparam Integer The type of integer to print.
  */
 template<typename Integer>
-class outputFormatterHexadecimal : public ::testing::Test {
+class outputFormatterHex : public ::testing::Test {
 };
 
 /**
- * \brief picolibrary::Output_Formatter<picolibrary::Hexadecimal> automated test integer
- *        types.
+ * \brief picolibrary::Output_Formatter<picolibrary::Hex> automated test integer types.
  */
 using Integers =
     ::testing::Types<std::int8_t, std::uint8_t, std::int16_t, std::uint16_t, std::int32_t, std::uint32_t, std::int64_t, std::uint64_t>;
 
 /**
- * \brief picolibrary::Output_Formatter<picolibrary::Hexadecimal> automated test fixture.
+ * \brief picolibrary::Output_Formatter<picolibrary::Hex> automated test fixture.
  */
-TYPED_TEST_SUITE( outputFormatterHexadecimal, Integers );
+TYPED_TEST_SUITE( outputFormatterHex, Integers );
 
 /**
- * \brief Verify picolibrary::Output_Formatter<picolibrary::Format::Hexadecimal> properly
- *        handles a put error.
+ * \brief Verify picolibrary::Output_Formatter<picolibrary::Format::Hex> properly handles
+ *        a put error.
  */
-TYPED_TEST( outputFormatterHexadecimal, putError )
+TYPED_TEST( outputFormatterHex, putError )
 {
     using Integer = TypeParam;
 
@@ -102,7 +101,7 @@ TYPED_TEST( outputFormatterHexadecimal, putError )
 
     EXPECT_CALL( stream.buffer(), put( A<std::string>() ) ).WillOnce( Return( error ) );
 
-    auto const result = stream.print( Hexadecimal{ random<Integer>() } );
+    auto const result = stream.print( Hex{ random<Integer>() } );
 
     ASSERT_TRUE( result.is_error() );
     EXPECT_EQ( result.error(), error );
@@ -113,10 +112,9 @@ TYPED_TEST( outputFormatterHexadecimal, putError )
 }
 
 /**
- * \brief Verify picolibrary::Output_Formatter<picolibrary::Format::Hexadecimal> works
- *        properly.
+ * \brief Verify picolibrary::Output_Formatter<picolibrary::Format::Hex> works properly.
  */
-TYPED_TEST( outputFormatterHexadecimal, worksProperly )
+TYPED_TEST( outputFormatterHex, worksProperly )
 {
     using Integer = TypeParam;
 
@@ -125,13 +123,13 @@ TYPED_TEST( outputFormatterHexadecimal, worksProperly )
 
         auto const value = random<Integer>();
 
-        auto const result = stream.print( Hexadecimal{ value } );
+        auto const result = stream.print( Hex{ value } );
 
         ASSERT_TRUE( result.is_value() );
         EXPECT_EQ( result.value(), stream.string().size() );
 
         EXPECT_TRUE( stream.is_nominal() );
-        EXPECT_EQ( stream.string(), hexadecimal( value ) );
+        EXPECT_EQ( stream.string(), hex( value ) );
     }
 
     {
@@ -139,17 +137,17 @@ TYPED_TEST( outputFormatterHexadecimal, worksProperly )
 
         auto const value = random<Integer>();
 
-        auto const n = stream.print( Hexadecimal{ value } );
+        auto const n = stream.print( Hex{ value } );
 
         EXPECT_EQ( n, stream.string().size() );
 
         EXPECT_TRUE( stream.is_nominal() );
-        EXPECT_EQ( stream.string(), hexadecimal( value ) );
+        EXPECT_EQ( stream.string(), hex( value ) );
     }
 }
 
 /**
- * \brief Execute the picolibrary::Format::Hexadecimal automated tests.
+ * \brief Execute the picolibrary::Format::Hex automated tests.
  *
  * \param[in] argc The number of arguments to pass to testing::InitGoogleMock().
  * \param[in] argc The array of arguments to pass to testing::InitGoogleMock().

--- a/test/automated/picolibrary/ip/port/main.cc
+++ b/test/automated/picolibrary/ip/port/main.cc
@@ -42,7 +42,7 @@ using ::picolibrary::Testing::Automated::Reliable_Output_String_Stream;
 using ::testing::A;
 using ::testing::Return;
 
-auto decimal( Port::Unsigned_Integer unsigned_integer ) -> std::string
+auto dec( Port::Unsigned_Integer unsigned_integer ) -> std::string
 {
     auto stream = std::ostringstream{};
 
@@ -253,7 +253,7 @@ TEST( outputFormatterIPPort, worksProperly )
         EXPECT_EQ( result.value(), stream.string().size() );
 
         EXPECT_TRUE( stream.is_nominal() );
-        EXPECT_EQ( stream.string(), decimal( unsigned_integer ) );
+        EXPECT_EQ( stream.string(), dec( unsigned_integer ) );
     }
 
     {
@@ -268,7 +268,7 @@ TEST( outputFormatterIPPort, worksProperly )
         EXPECT_EQ( n, stream.string().size() );
 
         EXPECT_TRUE( stream.is_nominal() );
-        EXPECT_EQ( stream.string(), decimal( unsigned_integer ) );
+        EXPECT_EQ( stream.string(), dec( unsigned_integer ) );
     }
 }
 

--- a/test/automated/picolibrary/mac_address/main.cc
+++ b/test/automated/picolibrary/mac_address/main.cc
@@ -80,7 +80,7 @@ auto random_unique_unsigned_integer_pair()
     };
 }
 
-auto hyphen_separated_hexadecimal_digit_pairs( MAC_Address::Byte_Array const & byte_array ) -> std::string
+auto hyphen_separated_hex_digit_pairs( MAC_Address::Byte_Array const & byte_array ) -> std::string
 {
     auto stream = std::ostringstream{};
 
@@ -402,7 +402,7 @@ TEST( outputFormatterMACAddress, worksProperly )
         EXPECT_EQ( result.value(), stream.string().size() );
 
         EXPECT_TRUE( stream.is_nominal() );
-        EXPECT_EQ( stream.string(), hyphen_separated_hexadecimal_digit_pairs( byte_array ) );
+        EXPECT_EQ( stream.string(), hyphen_separated_hex_digit_pairs( byte_array ) );
     }
 
     {
@@ -417,7 +417,7 @@ TEST( outputFormatterMACAddress, worksProperly )
         EXPECT_EQ( n, stream.string().size() );
 
         EXPECT_TRUE( stream.is_nominal() );
-        EXPECT_EQ( stream.string(), hyphen_separated_hexadecimal_digit_pairs( byte_array ) );
+        EXPECT_EQ( stream.string(), hyphen_separated_hex_digit_pairs( byte_array ) );
     }
 }
 


### PR DESCRIPTION
Resolves #1694 (Rename integer output format specifiers).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
