### PR TITLE
Add hex dump output format specifier

### DIFF
--- a/include/picolibrary/format.h
+++ b/include/picolibrary/format.h
@@ -945,17 +945,17 @@ class Output_Formatter<Format::Hex_Dump> {
     auto print( Output_Stream & stream, Format::Hex_Dump const & hex_dump ) const noexcept
         -> Result<std::size_t, Error_Code>
     {
-        Row_Buffer row_buffer;
+        Row row;
 
         auto begin = static_cast<std::uint8_t const *>( hex_dump.begin() );
         auto end   = static_cast<std::uint8_t const *>( hex_dump.end() );
         auto n     = std::size_t{ 0 };
 
-        for ( auto offset = std::uintptr_t{ 0 }; begin != end;
-              offset += 16, n += row_buffer.size() ) {
-            begin = generate_row( offset, begin, end, row_buffer );
+        for ( auto memory_offset = std::uintptr_t{ 0 }; begin != end;
+              memory_offset += ROW_BYTES, n += row.size() ) {
+            begin = generate_row( memory_offset, begin, end, row );
 
-            auto result = stream.put( row_buffer.begin(), row_buffer.end() );
+            auto result = stream.put( row.begin(), row.end() );
             if ( result.is_error() ) {
                 return result.error();
             } // if
@@ -976,17 +976,17 @@ class Output_Formatter<Format::Hex_Dump> {
     auto print( Reliable_Output_Stream & stream, Format::Hex_Dump const & hex_dump ) const noexcept
         -> std::size_t
     {
-        Row_Buffer row_buffer;
+        Row row;
 
         auto begin = static_cast<std::uint8_t const *>( hex_dump.begin() );
         auto end   = static_cast<std::uint8_t const *>( hex_dump.end() );
         auto n     = std::size_t{ 0 };
 
-        for ( auto offset = std::uintptr_t{ 0 }; begin != end;
-              offset += 16, n += row_buffer.size() ) {
-            begin = generate_row( offset, begin, end, row_buffer );
+        for ( auto memory_offset = std::uintptr_t{ 0 }; begin != end;
+              memory_offset += ROW_BYTES, n += row.size() ) {
+            begin = generate_row( memory_offset, begin, end, row );
 
-            stream.put( row_buffer.begin(), row_buffer.end() );
+            stream.put( row.begin(), row.end() );
         } // for
 
         return n;
@@ -1004,10 +1004,11 @@ class Output_Formatter<Format::Hex_Dump> {
     static constexpr auto NIBBLE_MASK = mask<std::uint_fast8_t>( NIBBLE_DIGITS, 0 );
 
     /**
-     * \brief The number of nibbles in an offset.
+     * \brief The number of nibbles in a memory offset.
      */
-    static constexpr auto OFFSET_NIBBLES = std::uint_fast8_t{ std::numeric_limits<std::uintptr_t>::digits
-                                                              / NIBBLE_DIGITS };
+    static constexpr auto MEMORY_OFFSET_NIBBLES = std::uint_fast8_t{
+        std::numeric_limits<std::uintptr_t>::digits / NIBBLE_DIGITS
+    };
 
     /**
      * \brief The number of nibbles in a byte.
@@ -1026,57 +1027,57 @@ class Output_Formatter<Format::Hex_Dump> {
     static constexpr auto ROW_BYTES = std::uint_fast8_t{ 16 };
 
     /**
-     * \brief Row buffer offset (hex) index.
+     * \brief Row buffer offset (hex) offset.
      */
-    static constexpr auto OFFSET_HEX_INDEX = std::uint_fast8_t{ 0 };
+    static constexpr auto MEMORY_OFFSET_HEX_OFFSET = std::uint_fast8_t{ 0 };
 
     /**
-     * \brief Row buffer data (hex) index.
+     * \brief Row buffer data (hex) offset.
      */
-    static constexpr auto DATA_HEX_INDEX = std::uint_fast8_t{ OFFSET_HEX_INDEX + OFFSET_NIBBLES
-                                                              + GROUP_SEPARATION };
+    static constexpr auto DATA_HEX_OFFSET = std::uint_fast8_t{ MEMORY_OFFSET_HEX_OFFSET + MEMORY_OFFSET_NIBBLES
+                                                               + GROUP_SEPARATION };
 
     /**
-     * \brief Row buffer data (ASCII) index.
+     * \brief Row buffer data (ASCII) offset.
      */
-    static constexpr auto DATA_ASCII_INDEX = std::uint_fast8_t{
-        DATA_HEX_INDEX + ( ( ( BYTE_NIBBLES + 1 ) * ROW_BYTES ) - 1 ) + GROUP_SEPARATION + 1
+    static constexpr auto DATA_ASCII_OFFSET = std::uint_fast8_t{
+        DATA_HEX_OFFSET + ( ( ( BYTE_NIBBLES + 1 ) * ROW_BYTES ) - 1 ) + GROUP_SEPARATION + 1
     };
 
     /**
      * \brief Row buffer.
      */
-    using Row_Buffer =
-        Array<char, OFFSET_NIBBLES + GROUP_SEPARATION + ( ( ( BYTE_NIBBLES + 1 ) * ROW_BYTES ) - 1 ) + GROUP_SEPARATION + 1 + ROW_BYTES + 1 + 1>;
+    using Row =
+        Array<char, MEMORY_OFFSET_NIBBLES + GROUP_SEPARATION + ( ( ( BYTE_NIBBLES + 1 ) * ROW_BYTES ) - 1 ) + GROUP_SEPARATION + 1 + ROW_BYTES + 1 + 1>;
 
     /**
-     * \brief Format an offset (hex).
+     * \brief Format a memory offset (hex).
      *
-     * \param[in] offset The offset to format.
-     * \param[out] row_buffer The row buffer location to write the formatted offset to.
+     * \param[in] memory_offset The memory offset to format.
+     * \param[out] location The location to write the formatted memory offset to.
      */
-    static void format_hex( std::uintptr_t offset, char * row_buffer ) noexcept
+    static void format_hex( std::uintptr_t memory_offset, Row::Iterator location ) noexcept
     {
-        auto i = Row_Buffer::Reverse_Iterator{ row_buffer + OFFSET_NIBBLES };
-        for ( auto nibble = std::uint_fast8_t{ 0 }; nibble < OFFSET_NIBBLES; ++nibble ) {
-            auto const n = offset & NIBBLE_MASK;
+        auto i = Row::Reverse_Iterator{ location + MEMORY_OFFSET_NIBBLES };
+        for ( auto nibble = std::uint_fast8_t{ 0 }; nibble < MEMORY_OFFSET_NIBBLES; ++nibble ) {
+            auto const n = memory_offset & NIBBLE_MASK;
 
             *i = n < 0xA ? '0' + n : 'A' + ( n - 0xA );
 
             ++i;
-            offset >>= NIBBLE_DIGITS;
+            memory_offset >>= NIBBLE_DIGITS;
         } // for
     }
 
     /**
      * \brief Format a byte (hex).
      *
-     * \param[in] byte The byte of data to format.
-     * \param[out] row_buffer The row buffer location to write the formatted byte to.
+     * \param[in] byte The byte to format.
+     * \param[out] location The location to write the formatted byte to.
      */
-    static void format_hex( std::uint8_t byte, char * row_buffer ) noexcept
+    static void format_hex( std::uint8_t byte, Row::Iterator location ) noexcept
     {
-        auto i = Row_Buffer::Reverse_Iterator{ row_buffer + BYTE_NIBBLES };
+        auto i = Row::Reverse_Iterator{ location + BYTE_NIBBLES };
         for ( auto nibble = std::uint_fast8_t{ 0 }; nibble < BYTE_NIBBLES; ++nibble ) {
             auto const n = byte & NIBBLE_MASK;
 
@@ -1090,42 +1091,45 @@ class Output_Formatter<Format::Hex_Dump> {
     /**
      * \brief Format a byte (ASCII).
      *
-     * \param[in] byte The byte of data to format.
-     * \param[out] row_buffer The row buffer location to write the formatted byte to.
+     * \param[in] byte The byte to format.
+     * \param[out] location The location to write the formatted byte to.
      */
-    static void format_ascii( std::uint8_t byte, char * row_buffer ) noexcept
+    static void format_ascii( std::uint8_t byte, Row::Iterator location ) noexcept
     {
-        *row_buffer = std::isprint( byte ) ? static_cast<char>( byte ) : '.';
+        *location = std::isprint( byte ) ? static_cast<char>( byte ) : '.';
     }
 
     /**
      * \brief Generate a row.
      *
-     * \param[in] offset The row's offset.
+     * \param[in] memory_offset The row's memory offset.
      * \param[in] begin The beginning of the block of memory.
      * \param[in] end The end of the block of memory.
-     * \param[out] row_buffer The row buffer to write the generated row to.
+     * \param[out] row The row buffer to write the generated row to.
      *
      * \return The beginning of the remaining block of memory.
      */
-    static auto generate_row( std::uintptr_t offset, std::uint8_t const * begin, std::uint8_t const * end, Row_Buffer & row_buffer ) noexcept
-        -> std::uint8_t const *
+    static auto generate_row(
+        std::uintptr_t       memory_offset,
+        std::uint8_t const * begin,
+        std::uint8_t const * end,
+        Row &                row ) noexcept -> std::uint8_t const *
     {
-        fill( row_buffer.begin() + OFFSET_NIBBLES, row_buffer.end() - 1, ' ' );
+        fill( row.begin() + MEMORY_OFFSET_NIBBLES, row.end() - 1, ' ' );
 
-        row_buffer.back() = '\n';
+        row.back() = '\n';
 
-        row_buffer[ DATA_ASCII_INDEX - 1 ] = '|';
+        *( row.begin() + DATA_ASCII_OFFSET - 1 ) = '|';
 
-        format_hex( offset, &row_buffer[ OFFSET_HEX_INDEX ] );
+        format_hex( memory_offset, row.begin() + MEMORY_OFFSET_HEX_OFFSET );
 
         auto byte = std::uint_fast8_t{ 0 };
         for ( ; begin != end and byte < ROW_BYTES; ++begin, ++byte ) {
-            format_hex( *begin, &row_buffer[ DATA_HEX_INDEX + ( ( BYTE_NIBBLES + 1 ) * byte ) ] );
+            format_hex( *begin, row.begin() + DATA_HEX_OFFSET + ( ( BYTE_NIBBLES + 1 ) * byte ) );
 
-            format_ascii( *begin, &row_buffer[ DATA_ASCII_INDEX + byte ] );
+            format_ascii( *begin, row.begin() + DATA_ASCII_OFFSET + byte );
         } // for
-        row_buffer[ DATA_ASCII_INDEX + byte ] = '|';
+        *( row.begin() + DATA_ASCII_OFFSET + byte ) = '|';
 
         return begin;
     }

--- a/include/picolibrary/format.h
+++ b/include/picolibrary/format.h
@@ -1027,7 +1027,7 @@ class Output_Formatter<Format::Hex_Dump> {
     static constexpr auto ROW_BYTES = std::uint_fast8_t{ 16 };
 
     /**
-     * \brief Row buffer offset (hex) offset.
+     * \brief Row buffer memory offset (hex) offset.
      */
     static constexpr auto MEMORY_OFFSET_HEX_OFFSET = std::uint_fast8_t{ 0 };
 

--- a/include/picolibrary/format.h
+++ b/include/picolibrary/format.h
@@ -941,6 +941,7 @@ class Output_Formatter<Format::Hex_Dump> {
      * \return The number of characters written to the stream if the write succeeded.
      * \return An error code if the write failed.
      */
+    // NOLINTNEXTLINE(readability-function-size)
     auto print( Output_Stream & stream, Format::Hex_Dump const & hex_dump ) const noexcept
         -> Result<std::size_t, Error_Code>
     {
@@ -1107,7 +1108,6 @@ class Output_Formatter<Format::Hex_Dump> {
      *
      * \return The beginning of the remaining block of memory.
      */
-    // NOLINTNEXTLINE(readability-function-size)
     static auto generate_row( std::uintptr_t offset, std::uint8_t const * begin, std::uint8_t const * end, Row_Buffer & row_buffer ) noexcept
         -> std::uint8_t const *
     {

--- a/include/picolibrary/format.h
+++ b/include/picolibrary/format.h
@@ -1054,7 +1054,7 @@ class Output_Formatter<Format::Hex_Dump> {
      * \param[in] offset The offset to format.
      * \param[out] row_buffer The row buffer location to write the formatted offset to.
      */
-    static constexpr void format_hex( std::uintptr_t offset, char * row_buffer ) noexcept
+    static void format_hex( std::uintptr_t offset, char * row_buffer ) noexcept
     {
         auto i = Row_Buffer::Reverse_Iterator{ row_buffer + OFFSET_NIBBLES };
         for ( auto nibble = std::uint_fast8_t{ 0 }; nibble < OFFSET_NIBBLES; ++nibble ) {
@@ -1073,7 +1073,7 @@ class Output_Formatter<Format::Hex_Dump> {
      * \param[in] byte The byte of data to format.
      * \param[out] row_buffer The row buffer location to write the formatted byte to.
      */
-    static constexpr void format_hex( std::uint8_t byte, char * row_buffer ) noexcept
+    static void format_hex( std::uint8_t byte, char * row_buffer ) noexcept
     {
         auto i = Row_Buffer::Reverse_Iterator{ row_buffer + BYTE_NIBBLES };
         for ( auto nibble = std::uint_fast8_t{ 0 }; nibble < BYTE_NIBBLES; ++nibble ) {
@@ -1092,9 +1092,9 @@ class Output_Formatter<Format::Hex_Dump> {
      * \param[in] byte The byte of data to format.
      * \param[out] row_buffer The row buffer location to write the formatted byte to.
      */
-    static constexpr void format_ascii( std::uint8_t byte, char * row_buffer ) noexcept
+    static void format_ascii( std::uint8_t byte, char * row_buffer ) noexcept
     {
-        *row_buffer = std::isprint( byte ) ? byte : '.';
+        *row_buffer = std::isprint( byte ) ? static_cast<char>( byte ) : '.';
     }
 
     /**
@@ -1107,8 +1107,8 @@ class Output_Formatter<Format::Hex_Dump> {
      *
      * \return The beginning of the remaining block of memory.
      */
-    static constexpr auto
-    generate_row( std::uintptr_t offset, std::uint8_t const * begin, std::uint8_t const * end, Row_Buffer & row_buffer ) noexcept
+    // NOLINTNEXTLINE(readability-function-size)
+    static auto generate_row( std::uintptr_t offset, std::uint8_t const * begin, std::uint8_t const * end, Row_Buffer & row_buffer ) noexcept
         -> std::uint8_t const *
     {
         fill( row_buffer.begin() + OFFSET_NIBBLES, row_buffer.end() - 1, ' ' );

--- a/test/automated/picolibrary/format/hex_dump/CMakeLists.txt
+++ b/test/automated/picolibrary/format/hex_dump/CMakeLists.txt
@@ -13,16 +13,21 @@
 # KIND, either express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-# Description: picolibrary::Format automated tests CMake rules.
-
-# build the picolibrary::Format::Bin automated tests
-add_subdirectory( bin )
-
-# build the picolibrary::Format::Dec automated tests
-add_subdirectory( dec )
-
-# build the picolibrary::Format::Hex automated tests
-add_subdirectory( hex )
+# Description: picolibrary::Format::Hex_Dump automated tests CMake rules.
 
 # build the picolibrary::Format::Hex_Dump automated tests
-add_subdirectory( hex_dump )
+if( ${PICOLIBRARY_ENABLE_AUTOMATED_TESTING} )
+    add_executable(
+        test-automated-picolibrary-format-hex_dump
+        main.cc
+    )
+    target_link_libraries(
+        test-automated-picolibrary-format-hex_dump
+        picolibrary
+        picolibrary-testing-automated-fatal_error
+    )
+    add_test(
+        NAME    test-automated-picolibrary-format-hex_dump
+        COMMAND test-automated-picolibrary-format-hex_dump --gtest_color=yes
+    )
+endif( ${PICOLIBRARY_ENABLE_AUTOMATED_TESTING} )

--- a/test/automated/picolibrary/format/hex_dump/main.cc
+++ b/test/automated/picolibrary/format/hex_dump/main.cc
@@ -1,0 +1,155 @@
+/**
+ * picolibrary
+ *
+ * Copyright 2020-2022, Andrew Countryman <apcountryman@gmail.com> and the picolibrary
+ * contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/**
+ * \file
+ * \brief picolibrary::Format::Hex_Dump automated test program.
+ */
+
+#include <cstdint>
+#include <limits>
+#include <string>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "picolibrary/format.h"
+#include "picolibrary/testing/automated/error.h"
+#include "picolibrary/testing/automated/stream.h"
+
+namespace {
+
+using ::picolibrary::Format::Hex_Dump;
+using ::picolibrary::Testing::Automated::Mock_Error;
+using ::picolibrary::Testing::Automated::Mock_Output_Stream;
+using ::picolibrary::Testing::Automated::Output_String_Stream;
+using ::picolibrary::Testing::Automated::random;
+using ::picolibrary::Testing::Automated::random_container;
+using ::picolibrary::Testing::Automated::Reliable_Output_String_Stream;
+using ::testing::A;
+using ::testing::Return;
+
+} // namespace
+
+/**
+ * \brief Verify picolibrary::Output_Formatter<picolibrary::Format::Hex_Dump> properly
+ *        handles a put error.
+ */
+TEST( outputFormatterHexDump, putError )
+{
+    auto stream = Mock_Output_Stream{};
+
+    auto const error = random<Mock_Error>();
+
+    EXPECT_CALL( stream.buffer(), put( A<std::string>() ) ).WillOnce( Return( error ) );
+
+    auto const data   = random_container<std::string>( random<std::uint_fast8_t>( 1 ) );
+    auto const result = stream.print( Hex_Dump{ &*data.begin(), &*data.end() } );
+
+    ASSERT_TRUE( result.is_error() );
+    EXPECT_EQ( result.error(), error );
+
+    EXPECT_FALSE( stream.end_of_file_reached() );
+    EXPECT_FALSE( stream.io_error_present() );
+    EXPECT_TRUE( stream.fatal_error_present() );
+}
+
+/**
+ * \brief Verify picolibrary::Output_Formatter<picolibrary::Format::Hex_Dump> works
+ *        properly.
+ */
+TEST( outputFormatterHexDump, worksProperly )
+{
+    static_assert( std::numeric_limits<std::uintptr_t>::digits == 64 );
+
+    struct {
+        std::string data;
+        std::string hex_dump;
+    } const test_cases[]{
+        // clang-format off
+
+        {
+            "",
+            "",
+        },
+
+        {
+            "(Y !d5vz\t^2",
+            "0000000000000000  28 59 20 21 64 35 76 7A 09 5E 32                 |(Y !d5vz.^2|     \n"
+        },
+
+        {
+            ":X;27N8u]hde[e&+",
+            "0000000000000000  3A 58 3B 32 37 4E 38 75 5D 68 64 65 5B 65 26 2B  |:X;27N8u]hde[e&+|\n"
+        },
+
+        {
+            "{yZZk7V!/{>fm[lxV!$e|:",
+            "0000000000000000  7B 79 5A 5A 6B 37 56 21 2F 7B 3E 66 6D 5B 6C 78  |{yZZk7V!/{>fm[lx|\n"
+            "0000000000000010  56 21 24 65 7C 3A                                |V!$e|:|          \n"
+        },
+
+        {
+            "/B>wiGoUZ|6cjO(_`T.8jV:RxSUssq!L",
+            "0000000000000000  2F 42 3E 77 69 47 6F 55 5A 7C 36 63 6A 4F 28 5F  |/B>wiGoUZ|6cjO(_|\n"
+            "0000000000000010  60 54 2E 38 6A 56 3A 52 78 53 55 73 73 71 21 4C  |`T.8jV:RxSUssq!L|\n"
+        },
+
+        // clang-format on
+    };
+
+    for ( auto const test_case : test_cases ) {
+        {
+            auto stream = Output_String_Stream{};
+
+            auto const result = stream.print(
+                Hex_Dump{ &*test_case.data.begin(), &*test_case.data.end() } );
+
+            ASSERT_TRUE( result.is_value() );
+            EXPECT_EQ( result.value(), stream.string().size() );
+
+            EXPECT_TRUE( stream.is_nominal() );
+            EXPECT_EQ( stream.string(), test_case.hex_dump );
+        }
+
+        {
+            auto stream = Reliable_Output_String_Stream{};
+
+            auto const n = stream.print(
+                Hex_Dump{ &*test_case.data.begin(), &*test_case.data.end() } );
+
+            EXPECT_EQ( n, stream.string().size() );
+
+            EXPECT_TRUE( stream.is_nominal() );
+            EXPECT_EQ( stream.string(), test_case.hex_dump );
+        }
+    } // for
+}
+
+/**
+ * \brief Execute the picolibrary::Format::Hex_Dump automated tests.
+ *
+ * \param[in] argc The number of arguments to pass to testing::InitGoogleMock().
+ * \param[in] argc The array of arguments to pass to testing::InitGoogleMock().
+ *
+ * \return See Google Test's RUN_ALL_TESTS().
+ */
+int main( int argc, char * argv[] )
+{
+    ::testing::InitGoogleMock( &argc, argv );
+
+    return RUN_ALL_TESTS();
+}

--- a/test/automated/picolibrary/format/hex_dump/main.cc
+++ b/test/automated/picolibrary/format/hex_dump/main.cc
@@ -28,6 +28,7 @@
 #include "gtest/gtest.h"
 #include "picolibrary/format.h"
 #include "picolibrary/testing/automated/error.h"
+#include "picolibrary/testing/automated/random.h"
 #include "picolibrary/testing/automated/stream.h"
 
 namespace {


### PR DESCRIPTION
Resolves #1696 (Add hex dump output format specifier).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
