### PR TITLE
Generalize hex dump output format specifier to use iterators instead of pointers

### DIFF
--- a/include/picolibrary/format.h
+++ b/include/picolibrary/format.h
@@ -1063,7 +1063,7 @@ class Output_Formatter<Format::Hex_Dump<Iterator>> {
      */
     static void format_hex( std::uintptr_t memory_offset, typename Row::Iterator location ) noexcept
     {
-        auto i = Row::Reverse_Iterator{ location + MEMORY_OFFSET_NIBBLES };
+        auto i = typename Row::Reverse_Iterator{ location + MEMORY_OFFSET_NIBBLES };
         for ( auto nibble = std::uint_fast8_t{ 0 }; nibble < MEMORY_OFFSET_NIBBLES; ++nibble ) {
             auto const n = memory_offset & NIBBLE_MASK;
 
@@ -1080,9 +1080,9 @@ class Output_Formatter<Format::Hex_Dump<Iterator>> {
      * \param[in] byte The byte to format.
      * \param[out] location The location to write the formatted byte to.
      */
-    static void format_hex( std::uint8_t byte, Row::Iterator location ) noexcept
+    static void format_hex( std::uint8_t byte, typename Row::Iterator location ) noexcept
     {
-        auto i = Row::Reverse_Iterator{ location + BYTE_NIBBLES };
+        auto i = typename Row::Reverse_Iterator{ location + BYTE_NIBBLES };
         for ( auto nibble = std::uint_fast8_t{ 0 }; nibble < BYTE_NIBBLES; ++nibble ) {
             auto const n = byte & NIBBLE_MASK;
 
@@ -1099,7 +1099,7 @@ class Output_Formatter<Format::Hex_Dump<Iterator>> {
      * \param[in] byte The byte to format.
      * \param[out] location The location to write the formatted byte to.
      */
-    static void format_ascii( std::uint8_t byte, Row::Iterator location ) noexcept
+    static void format_ascii( std::uint8_t byte, typename Row::Iterator location ) noexcept
     {
         *location = std::isprint( byte ) ? static_cast<char>( byte ) : '.';
     }
@@ -1127,11 +1127,11 @@ class Output_Formatter<Format::Hex_Dump<Iterator>> {
 
         auto byte = std::uint_fast8_t{ 0 };
         for ( ; begin != end and byte < ROW_BYTES; ++begin, ++byte ) {
-            auto const data = static_cast<std::uint8_t>( *begin );
+            format_hex(
+                static_cast<std::uint8_t>( *begin ),
+                row.begin() + DATA_HEX_OFFSET + ( ( BYTE_NIBBLES + 1 ) * byte ) );
 
-            format_hex( data, row.begin() + DATA_HEX_OFFSET + ( ( BYTE_NIBBLES + 1 ) * byte ) );
-
-            format_ascii( data, row.begin() + DATA_ASCII_OFFSET + byte );
+            format_ascii( static_cast<std::uint8_t>( *begin ), row.begin() + DATA_ASCII_OFFSET + byte );
         } // for
         *( row.begin() + DATA_ASCII_OFFSET + byte ) = '|';
 

--- a/include/picolibrary/format.h
+++ b/include/picolibrary/format.h
@@ -1061,7 +1061,7 @@ class Output_Formatter<Format::Hex_Dump<Iterator>> {
      * \param[in] memory_offset The memory offset to format.
      * \param[out] location The location to write the formatted memory offset to.
      */
-    static void format_hex( std::uintptr_t memory_offset, Row::Iterator location ) noexcept
+    static void format_hex( std::uintptr_t memory_offset, typename Row::Iterator location ) noexcept
     {
         auto i = Row::Reverse_Iterator{ location + MEMORY_OFFSET_NIBBLES };
         for ( auto nibble = std::uint_fast8_t{ 0 }; nibble < MEMORY_OFFSET_NIBBLES; ++nibble ) {

--- a/test/automated/picolibrary/format/hex_dump/main.cc
+++ b/test/automated/picolibrary/format/hex_dump/main.cc
@@ -58,7 +58,7 @@ TEST( outputFormatterHexDump, putError )
     EXPECT_CALL( stream.buffer(), put( A<std::string>() ) ).WillOnce( Return( error ) );
 
     auto const data   = random_container<std::string>( random<std::uint_fast8_t>( 1 ) );
-    auto const result = stream.print( Hex_Dump{ &*data.begin(), &*data.end() } );
+    auto const result = stream.print( Hex_Dump{ data.begin(), data.end() } );
 
     ASSERT_TRUE( result.is_error() );
     EXPECT_EQ( result.error(), error );
@@ -117,7 +117,7 @@ TEST( outputFormatterHexDump, worksProperly )
             auto stream = Output_String_Stream{};
 
             auto const result = stream.print(
-                Hex_Dump{ &*test_case.data.begin(), &*test_case.data.end() } );
+                Hex_Dump{ test_case.data.begin(), test_case.data.end() } );
 
             ASSERT_TRUE( result.is_value() );
             EXPECT_EQ( result.value(), stream.string().size() );
@@ -129,8 +129,7 @@ TEST( outputFormatterHexDump, worksProperly )
         {
             auto stream = Reliable_Output_String_Stream{};
 
-            auto const n = stream.print(
-                Hex_Dump{ &*test_case.data.begin(), &*test_case.data.end() } );
+            auto const n = stream.print( Hex_Dump{ test_case.data.begin(), test_case.data.end() } );
 
             EXPECT_EQ( n, stream.string().size() );
 


### PR DESCRIPTION
Resolves #1700 (Generalize hex dump output format specifier to use iterators instead of pointers).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
