### PR TITLE
Add WIZnet W5500 TCP over IP interactive testing facilities namespace

### DIFF
--- a/include/picolibrary/testing/interactive/wiznet/w5500/ip/tcp.h
+++ b/include/picolibrary/testing/interactive/wiznet/w5500/ip/tcp.h
@@ -1,0 +1,33 @@
+/**
+ * picolibrary
+ *
+ * Copyright 2020-2022, Andrew Countryman <apcountryman@gmail.com> and the picolibrary
+ * contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/**
+ * \file
+ * \brief picolibrary::Testing::Interactive::WIZnet::W5500::IP::TCP interface.
+ */
+
+#ifndef PICOLIBRARY_TESTING_INTERACTIVE_WIZNET_W5500_IP_TCP_H
+#define PICOLIBRARY_TESTING_INTERACTIVE_WIZNET_W5500_IP_TCP_H
+
+/**
+ * \brief WIZnet W5500 Transmission Control Protocol (TCP) over IP interactive testing
+ *        facilities.
+ */
+namespace picolibrary::Testing::Interactive::WIZnet::W5500::IP::TCP {
+} // namespace picolibrary::Testing::Interactive::WIZnet::W5500::IP::TCP
+
+#endif // PICOLIBRARY_TESTING_INTERACTIVE_WIZNET_W5500_IP_TCP_H

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -136,6 +136,7 @@ if( ${PICOLIBRARY_ENABLE_INTERACTIVE_TESTING} )
         "picolibrary/testing/interactive/wiznet/w5500.cc"
         "picolibrary/testing/interactive/wiznet/w5500/ip.cc"
         "picolibrary/testing/interactive/wiznet/w5500/ip/network_stack.cc"
+        "picolibrary/testing/interactive/wiznet/w5500/ip/tcp.cc"
     )
 endif( ${PICOLIBRARY_ENABLE_INTERACTIVE_TESTING} )
 

--- a/source/picolibrary/testing/interactive/wiznet/w5500/ip/tcp.cc
+++ b/source/picolibrary/testing/interactive/wiznet/w5500/ip/tcp.cc
@@ -1,0 +1,23 @@
+/**
+ * picolibrary
+ *
+ * Copyright 2020-2022, Andrew Countryman <apcountryman@gmail.com> and the picolibrary
+ * contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/**
+ * \file
+ * \brief picolibrary::Testing::Interactive::WIZnet::W5500::IP::TCP implementation.
+ */
+
+#include "picolibrary/testing/interactive/wiznet/w5500/ip/tcp.h"


### PR DESCRIPTION
Resolves #1709 (Add WIZnet W5500 TCP over IP interactive testing facilities namespace).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
