### PR TITLE
Fix WIZnet W5500 TCP over IP client socket compilation errors

### DIFF
--- a/include/picolibrary/wiznet/w5500/ip/tcp.h
+++ b/include/picolibrary/wiznet/w5500/ip/tcp.h
@@ -604,7 +604,7 @@ class Client {
             return Generic_Error::WOULD_BLOCK;
         } // if
 
-        if ( end - begin > sn_tx_fsr ) {
+        if ( static_cast<std::uintptr_t>( end - begin ) > sn_tx_fsr ) {
             end = begin + sn_tx_fsr;
         } // if
 
@@ -741,7 +741,7 @@ class Client {
             return end;
         } // if
 
-        if ( end - begin > sn_rx_rsr ) {
+        if ( static_cast<std::uintptr_t>( end - begin ) > sn_rx_rsr ) {
             end = begin + sn_rx_rsr;
         } // if
 


### PR DESCRIPTION
Resolves #1732 (Fix WIZnet W5500 TCP over IP client socket compilation errors).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
