### PR TITLE
Fix WIZnet W5500 TCP over IP client socket SN_SR register value handling

### DIFF
--- a/include/picolibrary/wiznet/w5500.h
+++ b/include/picolibrary/wiznet/w5500.h
@@ -1282,6 +1282,12 @@ struct SN_SR {
 
     /**
      * \brief Status.
+     *
+     * \warning This enum does not cover all valid register values since there are
+     *          register values that are not documented, and these register values will
+     *          not be disclosed due to WIZnet company policy (see
+     *          https://forum.wiznet.io/t/topic/5020/2 and
+     *          https://forum.wiznet.io/t/topic/8883/2).
      */
     enum STATUS : Type {
         STATUS_SOCK_CLOSED = 0x00, ///< Closed.

--- a/include/picolibrary/wiznet/w5500.h
+++ b/include/picolibrary/wiznet/w5500.h
@@ -1284,8 +1284,8 @@ struct SN_SR {
      * \brief Status.
      *
      * \warning This enum does not cover all valid register values since there are
-     *          register values that are not documented, and these register values will
-     *          not be disclosed due to WIZnet company policy (see
+     *          register values that are not documented in the datasheet, and these
+     *          register values will not be disclosed due to WIZnet company policy (see
      *          https://forum.wiznet.io/t/topic/5020/2 and
      *          https://forum.wiznet.io/t/topic/8883/2).
      */

--- a/include/picolibrary/wiznet/w5500/ip/tcp.h
+++ b/include/picolibrary/wiznet/w5500/ip/tcp.h
@@ -362,8 +362,11 @@ class Client {
      * \pre endpoint is not already in use
      * \pre if an ephemeral port is requested, an ephemeral port is available
      */
+    // NOLINTNEXTLINE(readability-function-size)
     void bind( ::picolibrary::IP::TCP::Endpoint const & endpoint = ::picolibrary::IP::TCP::Endpoint{} ) noexcept
     {
+        // #lizard forgives the length
+
         expect( m_state == State::INITIALIZED, Generic_Error::LOGIC_ERROR );
 
         expect(
@@ -408,8 +411,11 @@ class Client {
      * \return picolibrary::Generic_Error::OPERATION_TIMEOUT if connecting to the remote
      *         endpoint timed out.
      */
+    // NOLINTNEXTLINE(readability-function-size)
     auto connect( ::picolibrary::IP::TCP::Endpoint const & endpoint ) noexcept -> Result<Void, Error_Code>
     {
+        // #lizard forgives the length
+
         if ( m_state == State::BOUND ) {
             expect(
                 endpoint.address().is_ipv4() and not endpoint.address().is_any()
@@ -518,9 +524,12 @@ class Client {
      * \return picolibrary::Generic_Error::WOULD_BLOCK if no data could be written to the
      *         socket's transmit buffer without blocking.
      */
+    // NOLINTNEXTLINE(readability-function-size)
     auto transmit( std::uint8_t const * begin, std::uint8_t const * end ) noexcept
         -> Result<std::uint8_t const *, Error_Code>
     {
+        // #lizard forgives the length
+
         expect( m_state == State::CONNECTED, Generic_Error::LOGIC_ERROR );
 
         if ( m_driver->read_sn_sr( m_socket_id ) != SN_SR::STATUS_SOCK_ESTABLISHED ) {
@@ -627,9 +636,12 @@ class Client {
      * \return picolibrary::Generic_Error::WOULD_BLOCK if no data could be read from the
      *         socket's receive buffer without blocking.
      */
+    // NOLINTNEXTLINE(readability-function-size)
     auto receive( std::uint8_t * begin, std::uint8_t * end ) noexcept
         -> Result<std::uint8_t *, Error_Code>
     {
+        // #lizard forgives the length
+
         expect( m_state == State::CONNECTED, Generic_Error::LOGIC_ERROR );
 
         auto close_wait = false;
@@ -689,8 +701,11 @@ class Client {
     /**
      * \brief Close the socket.
      */
+    // NOLINTNEXTLINE(readability-function-size)
     constexpr void close() noexcept
     {
+        // #lizard forgives the length
+
         if ( m_state == State::UNINITIALIZED ) {
             return;
         } // if


### PR DESCRIPTION
Resolves #1735 (Fix WIZnet W5500 TCP over IP client socket SN_SR register value handling).

According to WIZnet forum posts (https://forum.wiznet.io/t/topic/5020/2 and https://forum.wiznet.io/t/topic/8883/2), there are SN_SR register values that are not documented in the datasheet, and these register values will not be disclosed due to WIZnet company policy.

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
