### PR TITLE
Add output stream flushing to TCP over IP socket echo interactive test helper

### DIFF
--- a/include/picolibrary/testing/interactive/ip/tcp.h
+++ b/include/picolibrary/testing/interactive/ip/tcp.h
@@ -168,6 +168,7 @@ void echo( Reliable_Output_Stream & stream, Socket socket ) noexcept
         }
 
         stream.print( "echoing:\n", Format::Hex_Dump{ buffer.cbegin(), end } );
+        stream.flush();
 
         {
             auto result = transmit_all( socket, buffer.cbegin(), end );
@@ -178,6 +179,7 @@ void echo( Reliable_Output_Stream & stream, Socket socket ) noexcept
     } // for
 
     stream.put( "connection lost, attempting graceful shutdown\n" );
+    stream.flush();
 
     shutdown_gracefully( socket );
 }


### PR DESCRIPTION
Resolves #1745 (Add output stream flushing to TCP over IP socket echo interactive test helper).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
