### PR TITLE
Add output stream flushing to TCP over IP client socket echo interactive test helper

### DIFF
--- a/include/picolibrary/testing/interactive/ip/tcp.h
+++ b/include/picolibrary/testing/interactive/ip/tcp.h
@@ -248,11 +248,14 @@ void echo_client(
 
         stream.print(
             "attempting to connect to ", remote_endpoint, " from ", client.local_endpoint(), '\n' );
+        stream.flush();
         auto result = connect( client, remote_endpoint );
         if ( result.is_error() ) {
             stream.put( "connection failed\n" );
+            stream.flush();
         } else {
             stream.put( "connection established\n" );
+            stream.flush();
 
             echo( stream, std::move( client ) );
         } // else


### PR DESCRIPTION
Resolves #1746 (Add output stream flushing to TCP over IP client socket echo interactive test helper).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
