### PR TITLE
Add output stream flushing to WIZnet W5500 IP network stack ping interactive test helper

### DIFF
--- a/include/picolibrary/testing/interactive/wiznet/w5500/ip/network_stack.h
+++ b/include/picolibrary/testing/interactive/wiznet/w5500/ip/network_stack.h
@@ -105,6 +105,7 @@ void ping(
     network_stack.configure_ipv4_subnet_mask( ipv4_subnet_mask );
 
     stream.put( "waiting for link to be established\n" );
+    stream.flush();
 
     while ( network_stack.link_status() != ::picolibrary::WIZnet::W5500::Link_Status::UP ) {} // while
 
@@ -126,6 +127,7 @@ void ping(
         "IPv4 subnet mask: ", ipv4_subnet_mask, "\n"
     );
     // clang-format on
+    stream.flush();
 
     for ( ;; ) {} // for
 }


### PR DESCRIPTION
Resolves #1747 (Add output stream flushing to WIZnet W5500 IP network stack ping interactive test helper).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
