### PR TITLE
Add output stream flushing to WIZnet W5500 TCP over IP client socket echo interactive test helper

### DIFF
--- a/include/picolibrary/testing/interactive/wiznet/w5500/ip/tcp.h
+++ b/include/picolibrary/testing/interactive/wiznet/w5500/ip/tcp.h
@@ -135,6 +135,7 @@ void echo_client(
     network_stack.configure_ipv4_subnet_mask( ipv4_subnet_mask );
 
     stream.put( "waiting for link to be established\n" );
+    stream.flush();
 
     while ( network_stack.link_status() != ::picolibrary::WIZnet::W5500::Link_Status::UP ) {} // while
 
@@ -156,6 +157,7 @@ void echo_client(
         "IPv4 subnet mask: ", ipv4_subnet_mask, "\n"
     );
     // clang-format on
+    stream.flush();
 
     ::picolibrary::Testing::Interactive::IP::TCP::echo_client(
         stream,


### PR DESCRIPTION
Resolves #1748 (Add output stream flushing to WIZnet W5500 TCP over IP client socket echo interactive test helper).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
