### PR TITLE
Add [[noreturn]] attribute to interactive test helpers that do not return

### DIFF
--- a/include/picolibrary/testing/interactive/adc.h
+++ b/include/picolibrary/testing/interactive/adc.h
@@ -45,7 +45,10 @@ namespace picolibrary::Testing::Interactive::ADC {
  *            gotten.
  */
 template<typename Blocking_Single_Sample_Converter, typename Delayer>
-void sample_blocking_single_sample_converter( Reliable_Output_Stream & stream, Blocking_Single_Sample_Converter adc, Delayer delay ) noexcept
+[[noreturn]] void sample_blocking_single_sample_converter(
+    Reliable_Output_Stream &         stream,
+    Blocking_Single_Sample_Converter adc,
+    Delayer                          delay ) noexcept
 {
     adc.initialize();
 

--- a/include/picolibrary/testing/interactive/gpio.h
+++ b/include/picolibrary/testing/interactive/gpio.h
@@ -43,7 +43,7 @@ namespace picolibrary::Testing::Interactive::GPIO {
  *            state is gotten.
  */
 template<typename Input_Pin, typename Delayer>
-void state( Reliable_Output_Stream & stream, Input_Pin pin, Delayer delay ) noexcept
+[[noreturn]] void state( Reliable_Output_Stream & stream, Input_Pin pin, Delayer delay ) noexcept
 {
     pin.initialize();
 
@@ -68,7 +68,7 @@ void state( Reliable_Output_Stream & stream, Input_Pin pin, Delayer delay ) noex
  *            toggled.
  */
 template<typename Output_Pin, typename Delayer>
-void toggle( Output_Pin pin, Delayer delay ) noexcept
+[[noreturn]] void toggle( Output_Pin pin, Delayer delay ) noexcept
 {
     pin.initialize();
 

--- a/include/picolibrary/testing/interactive/ip/tcp.h
+++ b/include/picolibrary/testing/interactive/ip/tcp.h
@@ -230,7 +230,7 @@ auto connect( Client & client, ::picolibrary::IP::TCP::Endpoint const & endpoint
  * \param[in] remote_endpoint The remote endpoint to connect to.
  */
 template<typename Network_Stack, typename Socket_Options_Configurator>
-void echo_client(
+[[noreturn]] void echo_client(
     Reliable_Output_Stream &                 stream,
     Network_Stack &                          network_stack,
     Socket_Options_Configurator              configure_socket_options,

--- a/include/picolibrary/testing/interactive/microchip/mcp23008.h
+++ b/include/picolibrary/testing/interactive/microchip/mcp23008.h
@@ -52,7 +52,7 @@ namespace picolibrary::Testing::Interactive::Microchip::MCP23008 {
  *            state is gotten.
  */
 template<typename Controller, typename Delayer>
-void state(
+[[noreturn]] void state(
     Reliable_Output_Stream &                                stream,
     Controller                                              controller,
     ::picolibrary::Microchip::MCP23008::Address_Transmitted address,
@@ -86,7 +86,7 @@ void state(
  *            toggled.
  */
 template<template<typename> typename Output_Pin, typename Controller, typename Delayer>
-void toggle(
+[[noreturn]] void toggle(
     Controller                                              controller,
     ::picolibrary::Microchip::MCP23008::Address_Transmitted address,
     std::uint8_t                                            mask,

--- a/include/picolibrary/testing/interactive/microchip/mcp23s08.h
+++ b/include/picolibrary/testing/interactive/microchip/mcp23s08.h
@@ -57,7 +57,7 @@ namespace picolibrary::Testing::Interactive::Microchip::MCP23S08 {
  */
 template<typename Controller, typename Device_Selector, typename Delayer>
 // NOLINTNEXTLINE(readability-function-size)
-void state(
+[[noreturn]] void state(
     Reliable_Output_Stream &                                stream,
     Controller                                              controller,
     typename Controller::Configuration                      configuration,
@@ -104,7 +104,7 @@ void state(
  */
 template<template<typename> typename Output_Pin, typename Controller, typename Device_Selector, typename Delayer>
 // NOLINTNEXTLINE(readability-function-size)
-void toggle(
+[[noreturn]] void toggle(
     Controller                                              controller,
     typename Controller::Configuration                      configuration,
     Device_Selector                                         device_selector,

--- a/include/picolibrary/testing/interactive/microchip/mcp3008.h
+++ b/include/picolibrary/testing/interactive/microchip/mcp3008.h
@@ -54,7 +54,7 @@ namespace picolibrary::Testing::Interactive::Microchip::MCP3008 {
  */
 template<typename Controller, typename Device_Selector, typename Delayer>
 // NOLINTNEXTLINE(readability-function-size)
-void sample(
+[[noreturn]] void sample(
     Reliable_Output_Stream &                 stream,
     Controller                               controller,
     typename Controller::Configuration       configuration,

--- a/include/picolibrary/testing/interactive/spi.h
+++ b/include/picolibrary/testing/interactive/spi.h
@@ -50,7 +50,7 @@ namespace picolibrary::Testing::Interactive::SPI {
  *            exchanged.
  */
 template<typename Controller, typename Delayer>
-void echo(
+[[noreturn]] void echo(
     Reliable_Output_Stream &                   stream,
     Controller                                 controller,
     typename Controller::Configuration const & configuration,

--- a/include/picolibrary/testing/interactive/wiznet/w5500/ip/network_stack.h
+++ b/include/picolibrary/testing/interactive/wiznet/w5500/ip/network_stack.h
@@ -62,7 +62,7 @@ namespace picolibrary::Testing::Interactive::WIZnet::W5500::IP {
  */
 template<typename Controller, typename Device_Selector>
 // NOLINTNEXTLINE(readability-function-size)
-void ping(
+[[noreturn]] void ping(
     Reliable_Output_Stream &                  stream,
     Controller                                controller,
     typename Controller::Configuration        configuration,

--- a/include/picolibrary/testing/interactive/wiznet/w5500/ip/tcp.h
+++ b/include/picolibrary/testing/interactive/wiznet/w5500/ip/tcp.h
@@ -78,7 +78,7 @@ namespace picolibrary::Testing::Interactive::WIZnet::W5500::IP::TCP {
  */
 template<typename Controller, typename Device_Selector>
 // NOLINTNEXTLINE(readability-function-size)
-void echo_client(
+[[noreturn]] void echo_client(
     Reliable_Output_Stream &                           stream,
     Controller                                         controller,
     typename Controller::Configuration                 configuration,


### PR DESCRIPTION
Resolves #1749 (Add [[noreturn]] attribute to interactive test helpers that do not return).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
