### PR TITLE
Remove PICOLIBRARY_SPECIALIZED_ROM_ACCESS define

### DIFF
--- a/include/picolibrary/rom.h
+++ b/include/picolibrary/rom.h
@@ -24,14 +24,7 @@
 #define PICOLIBRARY_ROM_H
 
 #if __has_include( "picolibrary/hil/rom.h" )
-
 #include "picolibrary/hil/rom.h"
-
-/**
- * \brief ROM access is specialized.
- */
-#define PICOLIBRARY_SPECIALIZED_ROM_ACCESS
-
 #endif // __has_include( "picolibrary/hil/rom.h" )
 
 /**


### PR DESCRIPTION
Resolves #1770 (Remove PICOLIBRARY_SPECIALIZED_ROM_ACCESS define).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
