### PR TITLE
Fix null-terminated ROM string facilities documentation formatting

### DIFF
--- a/include/picolibrary/rom.h
+++ b/include/picolibrary/rom.h
@@ -36,14 +36,13 @@ namespace picolibrary::ROM {
 /**
  * \brief A handle to a null-terminated string that may be stored in ROM.
  *
- * To create a string literal that can be stored in ROM, use `PICOLIBRARY_ROM_STRING()`.
+ * To create a string literal that can be stored in ROM, use PICOLIBRARY_ROM_STRING().
  *
  * A HIL can replace this type with a HIL specific version by doing the following:
- * - Configure the `PICOLIBRARY_HIL_INCLUDE_DIR` picolibrary project configuration option
- * - Provide `picolibrary/hil/rom.h`
- * - Define `PICOLIBRARY_ROM_STRING_IS_HIL_DEFINED` in `picolibrary/hil/rom.h`
- * - Define the HIL specific version of `::picolibrary::ROM::String` in
- *   `picolibrary/hil/rom.h`
+ * - Configure the PICOLIBRARY_HIL_INCLUDE_DIR picolibrary project configuration option
+ * - Provide picolibrary/hil/rom.h
+ * - Define PICOLIBRARY_ROM_STRING_IS_HIL_DEFINED in picolibrary/hil/rom.h
+ * - Define the HIL specific version of picolibrary::ROM::String in picolibrary/hil/rom.h
  */
 using String = char const *;
 #endif // PICOLIBRARY_ROM_STRING_IS_HIL_DEFINED
@@ -57,9 +56,9 @@ using String = char const *;
  * \return A handle to the string literal that may be stored in ROM.
  *
  * A HIL can replace this macro by doing the following:
- * - Configure the `PICOLIBRARY_HIL_INCLUDE_DIR` picolibrary project configuration option
- * - Provide `picolibrary/hil/rom.h`
- * - Define the macro replacement in `picolibrary/hil/rom.h`
+ * - Configure the PICOLIBRARY_HIL_INCLUDE_DIR picolibrary project configuration option
+ * - Provide picolibrary/hil/rom.h
+ * - Define the macro replacement in picolibrary/hil/rom.h
  */
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define PICOLIBRARY_ROM_STRING( string ) ( string )


### PR DESCRIPTION
Resolves #1777 (Fix null-terminated ROM string facilities documentation formatting).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
