### PR TITLE
Add null-terminated ROM string writing to reliable stream buffer

### DIFF
--- a/include/picolibrary/stream.h
+++ b/include/picolibrary/stream.h
@@ -904,6 +904,19 @@ class Reliable_Stream_Buffer {
         while ( auto const character = *string++ ) { put( character ); } // while
     }
 
+#ifdef PICOLIBRARY_ROM_STRING_IS_HIL_DEFINED
+    /**
+     * \brief Write a null-terminated ROM string to the put area of the buffer.
+     *
+     * \param[in] string The null-terminated ROM string to write to the put area of the
+     *            buffer.
+     */
+    virtual void put( ROM::String string ) noexcept
+    {
+        while ( auto const character = *string++ ) { put( character ); } // while
+    }
+#endif // PICOLIBRARY_ROM_STRING_IS_HIL_DEFINED
+
     /**
      * \brief Write an unsigned byte to the put area of the buffer.
      *


### PR DESCRIPTION
Resolves #1781 (Add null-terminated ROM string writing to reliable stream buffer).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
