### PR TITLE
Add null-terminated ROM string transmission to asynchronous serial reliable unbuffered output stream buffer

### DIFF
--- a/include/picolibrary/asynchronous_serial/stream.h
+++ b/include/picolibrary/asynchronous_serial/stream.h
@@ -25,6 +25,7 @@
 
 #include <utility>
 
+#include "picolibrary/rom.h"
 #include "picolibrary/stream.h"
 
 namespace picolibrary::Asynchronous_Serial {
@@ -162,6 +163,20 @@ class Reliable_Unbuffered_Output_Stream_Buffer final : public Reliable_Stream_Bu
             m_transmitter.transmit( character );
         } // while
     }
+
+#ifdef PICOLIBRARY_ROM_STRING_IS_HIL_DEFINED
+    /**
+     * \brief Transmit a null-terminated ROM string.
+     *
+     * \param[in] string The null-terminated ROM string to transmit.
+     */
+    void put( ROM::String string ) noexcept override final
+    {
+        while ( auto const character = *string++ ) {
+            m_transmitter.transmit( character );
+        } // while
+    }
+#endif // PICOLIBRARY_ROM_STRING_IS_HIL_DEFINED
 
     /**
      * \brief Transmit an unsigned byte.


### PR DESCRIPTION
Resolves #1782 (Add null-terminated ROM string transmission to asynchronous serial reliable unbuffered output stream buffer).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
