### PR TITLE
Add null-terminated ROM string writing to reliable output stream

### DIFF
--- a/include/picolibrary/stream.h
+++ b/include/picolibrary/stream.h
@@ -1284,6 +1284,22 @@ class Reliable_Output_Stream : public Reliable_Stream {
         buffer()->put( string );
     }
 
+#ifdef PICOLIBRARY_ROM_STRING_IS_HIL_DEFINED
+    /**
+     * \brief Write a null-terminated ROM string to the stream.
+     *
+     * \pre picolibrary::Reliable_Stream::is_nominal()
+     *
+     * \oaram[in] string The null-terminated ROM string to write to the stream.
+     */
+    void put( ROM::String string ) noexcept
+    {
+        expect( is_nominal(), Generic_Error::IO_STREAM_DEGRADED );
+
+        buffer()->put( string );
+    }
+#endif // PICOLIBRARY_ROM_STRING_IS_HIL_DEFINED
+
     /**
      * \brief Write an unsigned byte to the stream.
      *


### PR DESCRIPTION
Resolves #1784 (Add null-terminated ROM string writing to reliable output stream).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
