### PR TITLE
Add null-terminated ROM string length getter

### DIFF
--- a/include/picolibrary/rom.h
+++ b/include/picolibrary/rom.h
@@ -23,6 +23,8 @@
 #ifndef PICOLIBRARY_ROM_H
 #define PICOLIBRARY_ROM_H
 
+#include <cstddef>
+
 #if __has_include( "picolibrary/hil/rom.h" )
 #include "picolibrary/hil/rom.h"
 #endif // __has_include( "picolibrary/hil/rom.h" )
@@ -63,6 +65,24 @@ using String = char const *;
 // NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define PICOLIBRARY_ROM_STRING( string ) ( string )
 #endif // PICOLIBRARY_ROM_STRING
+
+/**
+ * \brief Get the length of a null-terminated ROM string that may be stored in ROM.
+ *
+ * \param[in] string The null-terminated ROM string that may be stored in ROM to get the
+ *            length of.
+ *
+ * \return The length of the null-terminated ROM string that may be stored in ROM.
+ */
+inline auto length( String string ) noexcept -> std::size_t
+{
+    auto const begin = string;
+    auto       end   = string;
+
+    while ( *end++ ) {} // while
+
+    return end - begin;
+}
 
 } // namespace picolibrary::ROM
 

--- a/include/picolibrary/rom.h
+++ b/include/picolibrary/rom.h
@@ -67,19 +67,21 @@ using String = char const *;
 #endif // PICOLIBRARY_ROM_STRING
 
 /**
- * \brief Get the length of a null-terminated ROM string that may be stored in ROM.
+ * \brief Get the length of a null-terminated string that may be stored in ROM.
  *
- * \param[in] string The null-terminated ROM string that may be stored in ROM to get the
+ * \relatedalso picolibrary::ROM::String
+ *
+ * \param[in] string The null-terminated string that may be stored in ROM to get the
  *            length of.
  *
- * \return The length of the null-terminated ROM string that may be stored in ROM.
+ * \return The length of the null-terminated string that may be stored in ROM.
  */
 inline auto length( String string ) noexcept -> std::size_t
 {
     auto const begin = string;
     auto       end   = string;
 
-    while ( *end++ ) {} // while
+    for ( ; *end; ++end ) {} // for
 
     return end - begin;
 }


### PR DESCRIPTION
Resolves #1791 (Add null-terminated ROM string length getter).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
