### PR TITLE
Fix null-terminated ROM string documentation

### DIFF
--- a/include/picolibrary/rom.h
+++ b/include/picolibrary/rom.h
@@ -53,6 +53,8 @@ using String = char const *;
 /**
  * \brief Create a string literal that can be stored in ROM.
  *
+ * \relatedalso picolibrary::ROM::String
+ *
  * \param[in] string The string literal that can be stored in ROM.
  *
  * \return A handle to the string literal that may be stored in ROM.


### PR DESCRIPTION
Resolves #1794 (Fix null-terminated ROM string documentation).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
