### PR TITLE
Move event category names to ROM

### DIFF
--- a/include/picolibrary/event.h
+++ b/include/picolibrary/event.h
@@ -31,6 +31,7 @@
 
 #include "picolibrary/error.h"
 #include "picolibrary/result.h"
+#include "picolibrary/rom.h"
 #include "picolibrary/stream.h"
 #include "picolibrary/void.h"
 
@@ -60,11 +61,11 @@ class Event_Category {
      * \return The name of the event category.
      */
 #ifndef PICOLIBRARY_SUPPRESS_HUMAN_READABLE_EVENT_INFORMATION
-    virtual auto name() const noexcept -> char const * = 0;
+    virtual auto name() const noexcept -> ROM::String = 0;
 #else  // PICOLIBRARY_SUPPRESS_HUMAN_READABLE_EVENT_INFORMATION
-    constexpr auto name() const noexcept -> char const *
+    auto name() const noexcept -> ROM::String
     {
-        return "";
+        return PICOLIBRARY_ROM_STRING( "" );
     }
 #endif // PICOLIBRARY_SUPPRESS_HUMAN_READABLE_EVENT_INFORMATION
 

--- a/include/picolibrary/hsm.h
+++ b/include/picolibrary/hsm.h
@@ -32,6 +32,7 @@
 #include "picolibrary/event.h"
 #include "picolibrary/fixed_capacity_vector.h"
 #include "picolibrary/precondition.h"
+#include "picolibrary/rom.h"
 
 namespace picolibrary {
 
@@ -79,9 +80,9 @@ class HSM {
          * \return The name of the pseudo-event category.
          */
 #ifndef PICOLIBRARY_SUPPRESS_HUMAN_READABLE_EVENT_INFORMATION
-        auto name() const noexcept -> char const * override final
+        auto name() const noexcept -> ROM::String override final
         {
-            return "::picolibrary::HSM::Pseudo_Event";
+            return PICOLIBRARY_ROM_STRING( "::picolibrary::HSM::Pseudo_Event" );
         }
 #endif // PICOLIBRARY_SUPPRESS_HUMAN_READABLE_EVENT_INFORMATION
 

--- a/include/picolibrary/state_machine.h
+++ b/include/picolibrary/state_machine.h
@@ -29,6 +29,7 @@
 #include "picolibrary/error.h"
 #include "picolibrary/event.h"
 #include "picolibrary/precondition.h"
+#include "picolibrary/rom.h"
 
 namespace picolibrary {
 
@@ -74,9 +75,9 @@ class State_Machine {
          * \return The name of the pseudo-event category.
          */
 #ifndef PICOLIBRARY_SUPPRESS_HUMAN_READABLE_EVENT_INFORMATION
-        auto name() const noexcept -> char const * override final
+        auto name() const noexcept -> ROM::String override final
         {
-            return "::picolibrary::State_Machine::Pseudo_Event";
+            return PICOLIBRARY_ROM_STRING( "::picolibrary::State_Machine::Pseudo_Event" );
         }
 #endif // PICOLIBRARY_SUPPRESS_HUMAN_READABLE_EVENT_INFORMATION
 


### PR DESCRIPTION
Resolves #1798 (Move event category names to ROM).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
