### PR TITLE
Standardize HSM pseudo-event category event description switch statement formatting

### DIFF
--- a/include/picolibrary/hsm.h
+++ b/include/picolibrary/hsm.h
@@ -97,12 +97,14 @@ class HSM {
         auto event_description( Event_ID id ) const noexcept -> ROM::String override final
         {
             switch ( static_cast<Pseudo_Event>( id ) ) {
-                case Pseudo_Event::DISCOVERY:
-                    return PICOLIBRARY_ROM_STRING( "DISCOVERY" );
+                    // clang-format off
+
+                case Pseudo_Event::DISCOVERY: return PICOLIBRARY_ROM_STRING( "DISCOVERY" );
                 case Pseudo_Event::ENTRY: return PICOLIBRARY_ROM_STRING( "ENTRY" );
                 case Pseudo_Event::EXIT: return PICOLIBRARY_ROM_STRING( "EXIT" );
-                case Pseudo_Event::NESTED_INITIAL_TRANSITION:
-                    return PICOLIBRARY_ROM_STRING( "NESTED_INITIAL_TRANSITION" );
+                case Pseudo_Event::NESTED_INITIAL_TRANSITION: return PICOLIBRARY_ROM_STRING( "NESTED_INITIAL_TRANSITION" );
+
+                    // clang-format on
             } // switch
 
             return PICOLIBRARY_ROM_STRING( "UNKNOWN" );


### PR DESCRIPTION
Resolves #1804 (Standardize HSM pseudo-event category event description switch statement formatting).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
