### PR TITLE
Rename null-terminated ROM string length getter

### DIFF
--- a/include/picolibrary/rom.h
+++ b/include/picolibrary/rom.h
@@ -78,7 +78,7 @@ using String = char const *;
  *
  * \return The length of the null-terminated string that may be stored in ROM.
  */
-inline auto length( String string ) noexcept -> std::size_t
+inline auto strlen( String string ) noexcept -> std::size_t
 {
     auto const begin = string;
     auto       end   = string;

--- a/include/picolibrary/stream.h
+++ b/include/picolibrary/stream.h
@@ -1737,7 +1737,7 @@ class Output_Formatter<ROM::String> {
             return result.error();
         } // if
 
-        return ROM::length( string );
+        return ROM::strlen( string );
     }
 
     /**
@@ -1752,7 +1752,7 @@ class Output_Formatter<ROM::String> {
     {
         stream.put( string );
 
-        return ROM::length( string );
+        return ROM::strlen( string );
     }
 };
 #endif // PICOLIBRARY_ROM_STRING_IS_HIL_DEFINED


### PR DESCRIPTION
Resolves #1818 (Rename null-terminated ROM string length getter).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
