### PR TITLE
Add direct nibble indexed lookup table CRC calculator testing to CRC automated test

### DIFF
--- a/test/automated/picolibrary/crc/main.cc
+++ b/test/automated/picolibrary/crc/main.cc
@@ -35,6 +35,7 @@ using ::picolibrary::CRC::Augmented_Nibble_Indexed_Lookup_Table_Calculator;
 using ::picolibrary::CRC::Bitwise_Calculator;
 using ::picolibrary::CRC::Calculation_Parameters;
 using ::picolibrary::CRC::Direct_Byte_Indexed_Lookup_Table_Calculator;
+using ::picolibrary::CRC::Direct_Nibble_Indexed_Lookup_Table_Calculator;
 using ::picolibrary::Testing::Automated::random;
 using ::picolibrary::Testing::Automated::random_container;
 using ::testing::Test;
@@ -97,6 +98,10 @@ TYPED_TEST( calculatorImplementations, areEquivalent )
 
         EXPECT_EQ(
             Augmented_Nibble_Indexed_Lookup_Table_Calculator{ test_case.calculation_parameters }
+                .calculate( message.begin(), message.end() ),
+            remainder );
+        EXPECT_EQ(
+            Direct_Nibble_Indexed_Lookup_Table_Calculator{ test_case.calculation_parameters }
                 .calculate( message.begin(), message.end() ),
             remainder );
     } // for


### PR DESCRIPTION
Resolves #1854 (Add direct nibble indexed lookup table CRC calculator testing to CRC automated test).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
