### PR TITLE
Remove pseudo-random GPIO initial pull-up state generation

### DIFF
--- a/include/picolibrary/testing/automated/gpio.h
+++ b/include/picolibrary/testing/automated/gpio.h
@@ -31,18 +31,6 @@
 namespace picolibrary::Testing::Automated {
 
 /**
- * \brief Generate a pseudo-random picolibrary::GPIO::Initial_Pull_Up_State.
- *
- * \return A pseudo-randomly generated picolibrary::GPIO::Initial_Pull_Up_State.
- */
-template<>
-inline auto random<GPIO::Initial_Pull_Up_State>() -> GPIO::Initial_Pull_Up_State
-{
-    return random<bool>() ? GPIO::Initial_Pull_Up_State::DISABLED
-                          : GPIO::Initial_Pull_Up_State::ENABLED;
-}
-
-/**
  * \brief Generate a pseudo-random picolibrary::GPIO::Initial_Pin_State.
  *
  * \return A pseudo-randomly generated picolibrary::GPIO::Initial_Pin_State.


### PR DESCRIPTION
Resolves #1880 (Remove pseudo-random GPIO initial pull-up state generation).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
