### PR TITLE
Remove pseudo-random GPIO initial pin state generation

### DIFF
--- a/include/picolibrary/testing/automated/gpio.h
+++ b/include/picolibrary/testing/automated/gpio.h
@@ -26,22 +26,6 @@
 #include "gmock/gmock.h"
 #include "picolibrary/gpio.h"
 #include "picolibrary/testing/automated/mock_handle.h"
-#include "picolibrary/testing/automated/random.h"
-
-namespace picolibrary::Testing::Automated {
-
-/**
- * \brief Generate a pseudo-random picolibrary::GPIO::Initial_Pin_State.
- *
- * \return A pseudo-randomly generated picolibrary::GPIO::Initial_Pin_State.
- */
-template<>
-inline auto random<GPIO::Initial_Pin_State>() -> GPIO::Initial_Pin_State
-{
-    return random<bool>() ? GPIO::Initial_Pin_State::LOW : GPIO::Initial_Pin_State::HIGH;
-}
-
-} // namespace picolibrary::Testing::Automated
 
 /**
  * \brief General Purpose Input/Output (GPIO) automated testing facilities.


### PR DESCRIPTION
Resolves #1881 (Remove pseudo-random GPIO initial pin state generation).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
