### PR TITLE
Remove pseudo-random I2C operation generation

### DIFF
--- a/include/picolibrary/testing/automated/i2c.h
+++ b/include/picolibrary/testing/automated/i2c.h
@@ -127,17 +127,6 @@ inline auto random<I2C::Address_Transmitted>() -> I2C::Address_Transmitted
 }
 
 /**
- * \brief Generate a pseudo-random picolibrary::I2C::Operation.
- *
- * \return A pseudo-randomly generated picolibrary::I2C::Operation.
- */
-template<>
-inline auto random<I2C::Operation>() -> I2C::Operation
-{
-    return random<bool>() ? I2C::Operation::READ : I2C::Operation::WRITE;
-}
-
-/**
  * \brief Generate a pseudo-random picolibrary::I2C::Response.
  *
  * \return A pseudo-randomly generated picolibrary::I2C::Response.

--- a/test/automated/picolibrary/i2c/main.cc
+++ b/test/automated/picolibrary/i2c/main.cc
@@ -288,7 +288,7 @@ TEST( scan, worksProperly )
         EXPECT_CALL( functor, Call( _, _, _ ) ).WillOnce( Return( Result<void>{} ) );
 
         EXPECT_FALSE( result
-                          .value()( random<Address_Transmitted>(), random<Operation>(), random<Response>() )
+                          .value()( random<Address_Transmitted>(), Operation::READ, random<Response>() )
                           .is_error() );
     }
 


### PR DESCRIPTION
Resolves #1882 (Remove pseudo-random I2C operation generation).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
