### PR TITLE
Remove pseudo-random I2C response generation

### DIFF
--- a/include/picolibrary/testing/automated/i2c.h
+++ b/include/picolibrary/testing/automated/i2c.h
@@ -126,17 +126,6 @@ inline auto random<I2C::Address_Transmitted>() -> I2C::Address_Transmitted
         I2C::Address_Transmitted::min(), I2C::Address_Transmitted::max() );
 }
 
-/**
- * \brief Generate a pseudo-random picolibrary::I2C::Response.
- *
- * \return A pseudo-randomly generated picolibrary::I2C::Response.
- */
-template<>
-inline auto random<I2C::Response>() -> I2C::Response
-{
-    return random<bool>() ? I2C::Response::ACK : I2C::Response::NACK;
-}
-
 } // namespace picolibrary::Testing::Automated
 
 /**

--- a/test/automated/picolibrary/i2c/controller/main.cc
+++ b/test/automated/picolibrary/i2c/controller/main.cc
@@ -50,12 +50,25 @@ using Controller = ::picolibrary::I2C::Controller<::picolibrary::Testing::Automa
 TEST( read, worksProperly )
 {
     {
-        auto controller = Controller{};
+        struct {
+            Response response;
+        } const test_cases[]{
+            // clang-format off
 
-        EXPECT_CALL( controller, read( _ ) ).Times( 0 );
+            { Response::ACK  },
+            { Response::NACK },
 
-        auto data = std::vector<std::uint8_t>{};
-        controller.read( &*data.begin(), &*data.end(), random<Response>() );
+            // clang-format on
+        };
+
+        for ( auto const test_case : test_cases ) {
+            auto controller = Controller{};
+
+            EXPECT_CALL( controller, read( _ ) ).Times( 0 );
+
+            auto data = std::vector<std::uint8_t>{};
+            controller.read( &*data.begin(), &*data.end(), test_case.response );
+        } // for
     }
 
     {

--- a/test/automated/picolibrary/i2c/main.cc
+++ b/test/automated/picolibrary/i2c/main.cc
@@ -51,6 +51,11 @@ using ::testing::InSequence;
 using ::testing::MockFunction;
 using ::testing::Return;
 
+auto random_response() noexcept -> Response
+{
+    return random<bool>() ? Response::ACK : Response::NACK;
+}
+
 } // namespace
 
 /**
@@ -170,7 +175,7 @@ TEST( scan, functorError )
         auto const error = random<Mock_Error>();
 
         EXPECT_CALL( controller, start() );
-        EXPECT_CALL( controller, address( _, _ ) ).WillOnce( Return( random<Response>() ) );
+        EXPECT_CALL( controller, address( _, _ ) ).WillOnce( Return( random_response() ) );
         EXPECT_CALL( controller, read( _ ) ).WillRepeatedly( Return( random<std::uint8_t>() ) );
         EXPECT_CALL( controller, stop() );
         EXPECT_CALL( functor, Call( _, _, _ ) ).WillOnce( Return( error ) );
@@ -189,7 +194,7 @@ TEST( scan, functorError )
         auto const error = random<Mock_Error>();
 
         EXPECT_CALL( controller, start() );
-        EXPECT_CALL( controller, address( _, _ ) ).WillOnce( Return( random<Response>() ) );
+        EXPECT_CALL( controller, address( _, _ ) ).WillOnce( Return( random_response() ) );
         EXPECT_CALL( controller, read( _ ) ).WillRepeatedly( Return( random<std::uint8_t>() ) );
         EXPECT_CALL( controller, stop() );
         EXPECT_CALL( functor, Call( _, _, _ ) ).WillOnce( Return( error ) );
@@ -218,7 +223,7 @@ TEST( scan, worksProperly )
             auto const address_transmitted = Address_Transmitted{ Address_Numeric{ address_numeric } };
 
             {
-                auto const response = random<Response>();
+                auto const response = random_response();
 
                 EXPECT_CALL( controller, start() );
                 EXPECT_CALL( controller, address( address_transmitted, Operation::READ ) ).WillOnce( Return( response ) );
@@ -230,7 +235,7 @@ TEST( scan, worksProperly )
             }
 
             {
-                auto const response = random<Response>();
+                auto const response = random_response();
 
                 EXPECT_CALL( controller, start() );
                 EXPECT_CALL( controller, address( address_transmitted, Operation::WRITE ) )
@@ -254,7 +259,7 @@ TEST( scan, worksProperly )
             auto const address_transmitted = Address_Transmitted{ Address_Numeric{ address_numeric } };
 
             {
-                auto const response = random<Response>();
+                auto const response = random_response();
 
                 EXPECT_CALL( controller, start() );
                 EXPECT_CALL( controller, address( address_transmitted, Operation::READ ) ).WillOnce( Return( response ) );
@@ -267,7 +272,7 @@ TEST( scan, worksProperly )
             }
 
             {
-                auto const response = random<Response>();
+                auto const response = random_response();
 
                 EXPECT_CALL( controller, start() );
                 EXPECT_CALL( controller, address( address_transmitted, Operation::WRITE ) )
@@ -288,7 +293,7 @@ TEST( scan, worksProperly )
         EXPECT_CALL( functor, Call( _, _, _ ) ).WillOnce( Return( Result<void>{} ) );
 
         EXPECT_FALSE( result
-                          .value()( random<Address_Transmitted>(), Operation::READ, random<Response>() )
+                          .value()( random<Address_Transmitted>(), Operation::READ, Response::ACK )
                           .is_error() );
     }
 
@@ -303,7 +308,7 @@ TEST( scan, worksProperly )
             auto const address_transmitted = Address_Transmitted{ Address_Numeric{ address_numeric } };
 
             {
-                auto const response = random<Response>();
+                auto const response = random_response();
 
                 EXPECT_CALL( controller, start() );
                 EXPECT_CALL( controller, address( address_transmitted, Operation::READ ) ).WillOnce( Return( response ) );
@@ -316,7 +321,7 @@ TEST( scan, worksProperly )
             }
 
             {
-                auto const response = random<Response>();
+                auto const response = random_response();
 
                 EXPECT_CALL( controller, start() );
                 EXPECT_CALL( controller, address( address_transmitted, Operation::WRITE ) )


### PR DESCRIPTION
Resolves #1883 (Remove pseudo-random I2C response generation).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
