### PR TITLE
Remove pseudo-random WIZnet W5500 socket memory block generation

### DIFF
--- a/include/picolibrary/testing/automated/wiznet/w5500.h
+++ b/include/picolibrary/testing/automated/wiznet/w5500.h
@@ -45,18 +45,6 @@ inline auto random<WIZnet::W5500::Socket_ID>() -> WIZnet::W5500::Socket_ID
     return static_cast<WIZnet::W5500::Socket_ID>( random<std::uint_fast8_t>( 0, 7 ) << 5 );
 }
 
-/**
- * \brief Generate a pseudo-random picolibrary::WIZnet::W5500::Socket_Memory_Block.
- *
- * \return A pseudo-randomly generated picolibrary::WIZnet::W5500::Socket_Memory_Block.
- */
-template<>
-inline auto random<WIZnet::W5500::Socket_Memory_Block>() -> WIZnet::W5500::Socket_Memory_Block
-{
-    return static_cast<WIZnet::W5500::Socket_Memory_Block>(
-        random<std::uint_fast8_t>( 0b01, 0b11 ) << 3 );
-}
-
 } // namespace picolibrary::Testing::Automated
 
 /**


### PR DESCRIPTION
Resolves #1887 (Remove pseudo-random WIZnet W5500 socket memory block generation).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
