### PR TITLE
Fix Microchip MCP23S08 communication controller documentation error

### DIFF
--- a/include/picolibrary/microchip/mcp23s08.h
+++ b/include/picolibrary/microchip/mcp23s08.h
@@ -532,9 +532,9 @@ class Communication_Controller : public Device {
     auto operator=( Communication_Controller const & ) = delete;
 
     /**
-     * \brief Get the device's address.
+     * \brief Get the MCP23S08's address.
      *
-     * \return The device's address.
+     * \return The MCP23S08's address.
      */
     constexpr auto address() const noexcept -> Address_Transmitted
     {


### PR DESCRIPTION
Resolves #1951 (Fix Microchip MCP23S08 communication controller documentation error).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
