### PR TITLE
Add WIZnet W5500 interrupt masks and socket interrupt masks documentation

### DIFF
--- a/docs/device/wiznet/w5500.md
+++ b/docs/device/wiznet/w5500.md
@@ -10,6 +10,7 @@ header/source file pair.
 1. [Communication Controller](#communication-controller)
 1. [Register Information](#register-information)
 1. [Driver](#driver)
+1. [Interrupt Masks](#interrupt-masks)
 
 ## Control Byte Information
 WIZnet W5500 control byte information is defined in the
@@ -294,3 +295,10 @@ configuration option is `ON`.
 The mock is defined in the
 [`include/picolibrary/testing/automated/wiznet/w5500.h`](https://github.com/apcountryman/picolibrary/blob/main/include/picolibrary/testing/automated/wiznet/w5500.h)/[`source/picolibrary/testing/automated/wiznet/w5500.cc`](https://github.com/apcountryman/picolibrary/blob/main/source/picolibrary/testing/automated/wiznet/w5500.cc)
 header/source file pair.
+
+## Interrupt Masks
+WIZnet W5500 interrupt masks are defined in the `::picolibrary::WIZnet::W5500::Interrupt`
+structure.
+
+WIZnet W5500 socket interrupt masks are defined in the
+`::picolibrary::WIZnet::W5500::Socket_Interrupt` structure.


### PR DESCRIPTION
Resolves #1973 (Add WIZnet W5500 interrupt masks and socket interrupt masks documentation).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
