### PR TITLE
Add Adafruit PID781 automated testing facilities namespace

### DIFF
--- a/include/picolibrary/testing/automated/adafruit/pid781.h
+++ b/include/picolibrary/testing/automated/adafruit/pid781.h
@@ -1,0 +1,32 @@
+/**
+ * picolibrary
+ *
+ * Copyright 2020-2023, Andrew Countryman <apcountryman@gmail.com> and the picolibrary
+ * contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/**
+ * \file
+ * \brief picolibrary::Testing::Automated::Adafruit::PID781 interface.
+ */
+
+#ifndef PICOLIBRARY_TESTING_AUTOMATED_ADAFRUIT_PID781_H
+#define PICOLIBRARY_TESTING_AUTOMATED_ADAFRUIT_PID781_H
+
+/**
+ * \brief Adafruit PID781 automated testing facilities.
+ */
+namespace picolibrary::Testing::Automated::Adafruit::PID781 {
+} // namespace picolibrary::Testing::Automated::Adafruit::PID781
+
+#endif // PICOLIBRARY_TESTING_AUTOMATED_ADAFRUIT_PID781_H

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -81,6 +81,7 @@ if( ${PICOLIBRARY_ENABLE_AUTOMATED_TESTING} )
         APPEND PICOLIBRARY_SOURCE_FILES
         "picolibrary/testing/automated.cc"
         "picolibrary/testing/automated/adafruit.cc"
+        "picolibrary/testing/automated/adafruit/pid781.cc"
         "picolibrary/testing/automated/adc.cc"
         "picolibrary/testing/automated/asynchronous_serial.cc"
         "picolibrary/testing/automated/crc.cc"

--- a/source/picolibrary/testing/automated/adafruit/pid781.cc
+++ b/source/picolibrary/testing/automated/adafruit/pid781.cc
@@ -1,0 +1,23 @@
+/**
+ * picolibrary
+ *
+ * Copyright 2020-2023, Andrew Countryman <apcountryman@gmail.com> and the picolibrary
+ * contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/**
+ * \file
+ * \brief picolibrary::Testing::Automated::Adafruit::PID781 implementation.
+ */
+
+#include "picolibrary/testing/automated/adafruit/pid781.h"


### PR DESCRIPTION
Resolves #1996 (Add Adafruit PID781 automated testing facilities namespace).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
