### PR TITLE
Add Adafruit PID781 LCD size columns/rows getters

### DIFF
--- a/docs/device/adafruit/pid781.md
+++ b/docs/device/adafruit/pid781.md
@@ -6,7 +6,7 @@ header/source file pair.
 ## Table of Contents
 1. [LCD Size Identification](#lcd-size-identification)
 
-## LCD Size
+## LCD Size Identification
 The `::picolibrary::Adafruit::PID781::LCD_Size` enum class is used to identify LCD sizes.
 - To get the number of columns an LCD has, use the
   `::picolibrary::Adafruit::PID781::columns()` function.

--- a/docs/device/adafruit/pid781.md
+++ b/docs/device/adafruit/pid781.md
@@ -4,3 +4,11 @@ Adafruit PID781 facilities are defined in the
 header/source file pair.
 
 ## Table of Contents
+1. [LCD Size Identification](#lcd-size-identification)
+
+## LCD Size
+The `::picolibrary::Adafruit::PID781::LCD_Size` enum class is used to identify LCD sizes.
+- To get the number of columns an LCD has, use the
+  `::picolibrary::Adafruit::PID781::columns()` function.
+- To get the number of rows an LCD has, use the `::picolibrary::Adafruit::PID781::rows()`
+  function.

--- a/include/picolibrary/adafruit/pid781.h
+++ b/include/picolibrary/adafruit/pid781.h
@@ -26,6 +26,8 @@
 #include <cstdint>
 #include <limits>
 
+#include "picolibrary/utility.h"
+
 /**
  * \brief Adafruit PID781 facilities.
  */
@@ -53,6 +55,30 @@ enum class LCD_Size : std::uint16_t {
     _16X2 = ( 16 << std::numeric_limits<std::uint8_t>::digits ) | 2, ///< 16 columns, 2 rows.
     _20X4 = ( 20 << std::numeric_limits<std::uint8_t>::digits ) | 4, ///< 20 columns, 4 rows.
 };
+
+/**
+ * \brief Get the number of columns an LCD has.
+ *
+ * \param[in] lcd_size The size of the LCD.
+ *
+ * \return The number of columns the LCD has.
+ */
+constexpr auto columns( LCD_Size lcd_size ) noexcept -> std::uint8_t
+{
+    return to_underlying( lcd_size ) >> std::numeric_limits<std::uint8_t>::digits;
+}
+
+/**
+ * \brief Get the number of rows an LCD has.
+ *
+ * \param[in] lcd_size The size of the LCD.
+ *
+ * \return The number of rows the LCD has.
+ */
+constexpr auto rows( LCD_Size lcd_size ) noexcept -> std::uint8_t
+{
+    return to_underlying( lcd_size );
+}
 
 } // namespace picolibrary::Adafruit::PID781
 

--- a/test/automated/picolibrary/adafruit/pid781/lcd_size/CMakeLists.txt
+++ b/test/automated/picolibrary/adafruit/pid781/lcd_size/CMakeLists.txt
@@ -13,7 +13,21 @@
 # KIND, either express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
-# Description: picolibrary::Adafruit::PID781 automated tests CMake rules.
+# Description: picolibrary::Adafruit::PID781::LCD_Size automated tests CMake rules.
 
 # build the picolibrary::Adafruit::PID781::LCD_Size automated tests
-add_subdirectory( lcd_size )
+if( ${PICOLIBRARY_ENABLE_AUTOMATED_TESTING} )
+    add_executable(
+        test-automated-picolibrary-adafruit-pid781-lcd_size
+        main.cc
+    )
+    target_link_libraries(
+        test-automated-picolibrary-adafruit-pid781-lcd_size
+        picolibrary
+        picolibrary-testing-automated-fatal_error
+    )
+    add_test(
+        NAME    test-automated-picolibrary-adafruit-pid781-lcd_size
+        COMMAND test-automated-picolibrary-adafruit-pid781-lcd_size --gtest_color=yes
+    )
+endif( ${PICOLIBRARY_ENABLE_AUTOMATED_TESTING} )

--- a/test/automated/picolibrary/adafruit/pid781/lcd_size/main.cc
+++ b/test/automated/picolibrary/adafruit/pid781/lcd_size/main.cc
@@ -62,6 +62,9 @@ struct lcdSize_Test_Case {
 class lcdSize : public TestWithParam<lcdSize_Test_Case> {
 };
 
+/**
+ * \brief picolibrary::Adafruit::PID781::LCD_Size test cases.
+ */
 INSTANTIATE_TEST_SUITE_P(
     lcdSizes,
     lcdSize,

--- a/test/automated/picolibrary/adafruit/pid781/lcd_size/main.cc
+++ b/test/automated/picolibrary/adafruit/pid781/lcd_size/main.cc
@@ -1,0 +1,103 @@
+/**
+ * picolibrary
+ *
+ * Copyright 2020-2023, Andrew Countryman <apcountryman@gmail.com> and the picolibrary
+ * contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/**
+ * \file
+ * \brief picolibrary::Adafruit::PID781::LCD_Size automated test program.
+ */
+
+#include <cstdint>
+
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "picolibrary/adafruit/pid781.h"
+
+namespace {
+
+using ::picolibrary::Adafruit::PID781::columns;
+using ::picolibrary::Adafruit::PID781::LCD_Size;
+using ::picolibrary::Adafruit::PID781::rows;
+using ::testing::TestWithParam;
+using ::testing::Values;
+
+} // namespace
+
+/**
+ * \brief picolibrary::Adafruit::PID781::LCD_Size test case.
+ */
+struct lcdSize_Test_Case {
+    /**
+     * \brief The LCD size.
+     */
+    LCD_Size lcd_size;
+
+    /**
+     * \brief The number of columns the LCD has.
+     */
+    std::uint8_t columns;
+
+    /**
+     * \brief The number of rows the LCD has.
+     */
+    std::uint8_t rows;
+};
+
+/**
+ * \brief picolibrary::Adafruit::PID781::LCD_Size automated test fixture.
+ */
+class lcdSize : public TestWithParam<lcdSize_Test_Case> {
+};
+
+INSTANTIATE_TEST_SUITE_P(
+    lcdSizes,
+    lcdSize,
+    Values( lcdSize_Test_Case{ LCD_Size::_16X2, 16, 2 }, lcdSize_Test_Case{ LCD_Size::_20X4, 20, 4 } ) );
+
+/**
+ * \brief Verify picolibrary::Adafruit::PID781::columns() works properly.
+ */
+TEST_P( lcdSize, columnsWorksProperly )
+{
+    auto const test_case = GetParam();
+
+    EXPECT_EQ( columns( test_case.lcd_size ), test_case.columns );
+}
+
+/**
+ * \brief Verify picolibrary::Adafruit::PID781::rows() works properly.
+ */
+TEST_P( lcdSize, rowsWorksProperly )
+{
+    auto const test_case = GetParam();
+
+    EXPECT_EQ( rows( test_case.lcd_size ), test_case.rows );
+}
+
+/**
+ * \brief Execute the picolibrary::Adafruit::PID781::LCD_Size automated tests.
+ *
+ * \param[in] argc The number of arguments to pass to testing::InitGoogleMock().
+ * \param[in] argc The array of arguments to pass to testing::InitGoogleMock().
+ *
+ * \return See Google Test's RUN_ALL_TESTS().
+ */
+int main( int argc, char * argv[] )
+{
+    ::testing::InitGoogleMock( &argc, argv );
+
+    return RUN_ALL_TESTS();
+}

--- a/test/automated/picolibrary/adafruit/pid781/lcd_size/main.cc
+++ b/test/automated/picolibrary/adafruit/pid781/lcd_size/main.cc
@@ -68,22 +68,14 @@ INSTANTIATE_TEST_SUITE_P(
     Values( lcdSize_Test_Case{ LCD_Size::_16X2, 16, 2 }, lcdSize_Test_Case{ LCD_Size::_20X4, 20, 4 } ) );
 
 /**
- * \brief Verify picolibrary::Adafruit::PID781::columns() works properly.
+ * \brief Verify picolibrary::Adafruit::PID781::columns() and
+ *        picolibrary::Adafruit::PID781::rows() work properly.
  */
-TEST_P( lcdSize, columnsWorksProperly )
+TEST_P( lcdSize, worksProperly )
 {
     auto const test_case = GetParam();
 
     EXPECT_EQ( columns( test_case.lcd_size ), test_case.columns );
-}
-
-/**
- * \brief Verify picolibrary::Adafruit::PID781::rows() works properly.
- */
-TEST_P( lcdSize, rowsWorksProperly )
-{
-    auto const test_case = GetParam();
-
     EXPECT_EQ( rows( test_case.lcd_size ), test_case.rows );
 }
 


### PR DESCRIPTION
Resolves #2020 (Add Adafruit PID781 LCD size columns/rows getters).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
