### PR TITLE
Add IPv4 address insertion operator to support automated testing

### DIFF
--- a/docs/network/ipv4.md
+++ b/docs/network/ipv4.md
@@ -44,6 +44,12 @@ defined in the
 [`test/automated/picolibrary/ipv4/address/main.cc`](https://github.com/apcountryman/picolibrary/blob/main/test/automated/picolibrary/ipv4/address/main.cc)
 source file.
 
+A `std::ostream` insertion operator is defined for `::picolibrary::IPv4::Address` if the
+`PICOLIBRARY_ENABLE_AUTOMATED_TESTING` project configuration option is on.
+The insertion operator is defined in the
+[`include/picolibrary/testing/automated/ipv4.h`](https://github.com/apcountryman/picolibrary/blob/main/include/picolibrary/testing/automated/ipv4.h)/[`source/picolibrary/testing/automated/ipv4.cc`](https://github.com/apcountryman/picolibrary/blob/main/source/picolibrary/testing/automated/ipv4.cc)
+header/source file pair.
+
 A `::picolibrary::Testing::Automated::random()` specialization for
 `::picolibrary::IPv4::Address` is available if the `PICOLIBRARY_ENABLE_AUTOMATED_TESTING`
 project configuration option is `ON`.

--- a/include/picolibrary/testing/automated/ipv4.h
+++ b/include/picolibrary/testing/automated/ipv4.h
@@ -23,8 +23,31 @@
 #ifndef PICOLIBRARY_TESTING_AUTOMATED_IPV4_H
 #define PICOLIBRARY_TESTING_AUTOMATED_IPV4_H
 
+#include <cstdint>
+#include <ostream>
+
 #include "picolibrary/ipv4.h"
 #include "picolibrary/testing/automated/random.h"
+
+namespace picolibrary::IPv4 {
+
+/**
+ * \brief Insertion operator.
+ *
+ * \param[in] stream The stream to write the picolibrary::IPv4::Address to.
+ * \param[in] address The picolibrary::IPv4::Address to write to the stream.
+ *
+ * \return stream
+ */
+inline auto operator<<( std::ostream & stream, Address const & address ) -> std::ostream &
+{
+    return stream << static_cast<std::uint_fast16_t>( address.as_byte_array()[ 0 ] ) << '.'
+                  << static_cast<std::uint_fast16_t>( address.as_byte_array()[ 1 ] ) << '.'
+                  << static_cast<std::uint_fast16_t>( address.as_byte_array()[ 2 ] ) << '.'
+                  << static_cast<std::uint_fast16_t>( address.as_byte_array()[ 3 ] );
+}
+
+} // namespace picolibrary::IPv4
 
 namespace picolibrary::Testing::Automated {
 


### PR DESCRIPTION
Resolves #2097 (Add IPv4 address insertion operator to support automated testing).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
