### PR TITLE
Fix hex dump output format specifier output formatter automated tests comments

### DIFF
--- a/test/automated/picolibrary/format/hex_dump/main.cc
+++ b/test/automated/picolibrary/format/hex_dump/main.cc
@@ -45,7 +45,8 @@ using ::testing::ValuesIn;
 } // namespace
 
 /**
- * \brief Verify picolibrary::Output_Formatter<Hex_Dump<Iterator>>::print(
+ * \brief Verify
+ *        picolibrary::Output_Formatter<picolibrary::Format::Hex_Dump<Iterator>>::print(
  *        picolibrary::Output_Stream &, picolibrary::Format::Hex_Dump<Iterator> const & )
  *        properly handles a put error.
  */
@@ -70,7 +71,8 @@ TEST( outputFormatterFormatHexDumpPrintOutputStreamErrorHandling, putError )
 }
 
 /**
- * \brief picolibrary::Output_Formatter<Hex_Dump<Iterator>>::print() test case.
+ * \brief picolibrary::Output_Formatter<picolibrary::Format::Hex_Dump<Iterator>>::print()
+ *        test case.
  */
 struct outputFormatterFormatHexDumpPrint_Test_Case {
     /**
@@ -91,7 +93,8 @@ auto operator<<( std::ostream & stream, outputFormatterFormatHexDumpPrint_Test_C
 }
 
 /**
- * \brief picolibrary::Output_Formatter<Hex_Dump<Iterator>>::print() test cases.
+ * \brief picolibrary::Output_Formatter<picolibrary::Format::Hex_Dump<Iterator>>::print()
+ *        test cases.
  */
 outputFormatterFormatHexDumpPrint_Test_Case const outputFormatterFormatHexDumpPrint_TEST_CASES[]{
     // clang-format off
@@ -123,7 +126,7 @@ outputFormatterFormatHexDumpPrint_Test_Case const outputFormatterFormatHexDumpPr
 };
 
 /**
- * \brief picolibrary::Output_Formatter<Hex_Dump<Iterator>>::print(
+ * \brief picolibrary::Output_Formatter<picolibrary::Format::Hex_Dump<Iterator>>::print(
  *        picolibrary::Output_Stream &, picolibrary::Format::Hex_Dump<Iterator> const & )
  *        test fixture.
  */
@@ -132,7 +135,8 @@ class outputFormatterFormatHexDumpPrintOutputStream :
 };
 
 /**
- * \brief Verify picolibrary::Output_Formatter<Hex_Dump<Iterator>>::print(
+ * \brief Verify
+ *        picolibrary::Output_Formatter<picolibrary::Format::Hex_Dump<Iterator>>::print(
  *        picolibrary::Output_Stream &, picolibrary::Format::Hex_Dump<Iterator> const & )
  *        works properly.
  */
@@ -154,18 +158,19 @@ TEST_P( outputFormatterFormatHexDumpPrintOutputStream, worksProperly )
 INSTANTIATE_TEST_SUITE_P( testCases, outputFormatterFormatHexDumpPrintOutputStream, ValuesIn( outputFormatterFormatHexDumpPrint_TEST_CASES ) );
 
 /**
- * \brief picolibrary::Output_Formatter<Hex_Dump<Iterator>>::print(
+ * \brief picolibrary::Output_Formatter<picolibrary::Format::Hex_Dump<Iterator>>::print(
  *        picolibrary::Reliable_Output_Stream &, picolibrary::Format::Hex_Dump<Iterator>
- *        const & ) test fixture.
+ *        const &) test fixture.
  */
 class outputFormatterFormatHexDumpPrintReliableOutputStream :
     public TestWithParam<outputFormatterFormatHexDumpPrint_Test_Case> {
 };
 
 /**
- * \brief Verify picolibrary::Output_Formatter<Hex_Dump<Iterator>>::print(
+ * \brief Verify
+ *        picolibrary::Output_Formatter<picolibrary::Format::Hex_Dump<Iterator>>::print(
  *        picolibrary::Reliable_Output_Stream &, picolibrary::Format::Hex_Dump<Iterator>
- *        const & ) works properly.
+ *        const &) works properly.
  */
 TEST_P( outputFormatterFormatHexDumpPrintReliableOutputStream, worksProperly )
 {

--- a/test/automated/picolibrary/format/hex_dump/main.cc
+++ b/test/automated/picolibrary/format/hex_dump/main.cc
@@ -160,7 +160,7 @@ INSTANTIATE_TEST_SUITE_P( testCases, outputFormatterFormatHexDumpPrintOutputStre
 /**
  * \brief picolibrary::Output_Formatter<picolibrary::Format::Hex_Dump<Iterator>>::print(
  *        picolibrary::Reliable_Output_Stream &, picolibrary::Format::Hex_Dump<Iterator>
- *        const &) test fixture.
+ *        const & ) test fixture.
  */
 class outputFormatterFormatHexDumpPrintReliableOutputStream :
     public TestWithParam<outputFormatterFormatHexDumpPrint_Test_Case> {
@@ -170,7 +170,7 @@ class outputFormatterFormatHexDumpPrintReliableOutputStream :
  * \brief Verify
  *        picolibrary::Output_Formatter<picolibrary::Format::Hex_Dump<Iterator>>::print(
  *        picolibrary::Reliable_Output_Stream &, picolibrary::Format::Hex_Dump<Iterator>
- *        const &) works properly.
+ *        const & ) works properly.
  */
 TEST_P( outputFormatterFormatHexDumpPrintReliableOutputStream, worksProperly )
 {


### PR DESCRIPTION
Resolves #2095 (Fix hex dump output format specifier output formatter automated tests comments).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
