### PR TITLE
Add Adafruit PID781 bit rate insertion operator to support automated testing

### DIFF
--- a/docs/device/adafruit/pid781.md
+++ b/docs/device/adafruit/pid781.md
@@ -4,7 +4,18 @@ Adafruit PID781 facilities are defined in the
 header/source file pair.
 
 ## Table of Contents
+1. [Bit Rate Identification](#bit-rate-identification)
 1. [LCD Size Identification](#lcd-size-identification)
+
+## Bit Rate Identification
+The `::picolibrary::Adafruit::PID781::Bit_Rate` enum class is used to identify bit rates.
+
+A `std::ostream` insertion operator is defined for
+`::picolibrary::Adafruit::PID781::Bit_Rate` if the `PICOLIBRARY_ENABLE_AUTOMATED_TESTING`
+project configuration option is `ON`.
+The insertion operator is defined in the
+[`include/picolibrary/testing/automated/adafruit/pid781.h`](https://github.com/apcountryman/picolibrary/blob/main/include/picolibrary/testing/automated/adafruit/pid781.h)/[`source/picolibrary/testing/automated/adafruit/pid781.cc`](https://github.com/apcountryman/picolibrary/blob/main/source/picolibrary/testing/automated/adafruit/pid781.cc)
+header/source file pair.
 
 ## LCD Size Identification
 The `::picolibrary::Adafruit::PID781::LCD_Size` enum class is used to identify LCD sizes.

--- a/include/picolibrary/testing/automated/adafruit/pid781.h
+++ b/include/picolibrary/testing/automated/adafruit/pid781.h
@@ -24,6 +24,7 @@
 #define PICOLIBRARY_TESTING_AUTOMATED_ADAFRUIT_PID781_H
 
 #include <ostream>
+#include <stdexcept>
 
 #include "picolibrary/adafruit/pid781.h"
 
@@ -55,7 +56,7 @@ inline auto operator<<( std::ostream & stream, Bit_Rate bit_rate ) -> std::ostre
             // clang-format on
     } // switch
 
-    return stream << "UNKNOWN";
+    throw std::invalid_argument{ "invalid ::picolibrary::Adafruit::PID781::Bit_Rate" };
 }
 
 } // namespace picolibrary::Adafruit::PID781

--- a/include/picolibrary/testing/automated/adafruit/pid781.h
+++ b/include/picolibrary/testing/automated/adafruit/pid781.h
@@ -56,7 +56,7 @@ inline auto operator<<( std::ostream & stream, Bit_Rate bit_rate ) -> std::ostre
             // clang-format on
     } // switch
 
-    throw std::invalid_argument{ "invalid ::picolibrary::Adafruit::PID781::Bit_Rate" };
+    throw std::invalid_argument{ "bit_rate is not a valid ::picolibrary::Adafruit::PID781::Bit_Rate" };
 }
 
 } // namespace picolibrary::Adafruit::PID781

--- a/include/picolibrary/testing/automated/adafruit/pid781.h
+++ b/include/picolibrary/testing/automated/adafruit/pid781.h
@@ -23,6 +23,43 @@
 #ifndef PICOLIBRARY_TESTING_AUTOMATED_ADAFRUIT_PID781_H
 #define PICOLIBRARY_TESTING_AUTOMATED_ADAFRUIT_PID781_H
 
+#include <ostream>
+
+#include "picolibrary/adafruit/pid781.h"
+
+namespace picolibrary::Adafruit::PID781 {
+
+/**
+ * \brief Insertion operator.
+ *
+ * \param[in] stream The stream to write the picolibrary::Adafruit::PID781::Bit_Rate to.
+ * \param[in] stream The picolibrary::Adafruit::PID781::Bit_Rate to write to the stream.
+ *
+ * \return stream
+ */
+inline auto operator<<( std::ostream & stream, Bit_Rate bit_rate ) -> std::ostream &
+{
+    switch ( bit_rate ) {
+            // clang-format off
+
+        case Bit_Rate::_1200:   return stream << "::picolibrary::Adafruit::PID781::Bit_Rate::_1200";
+        case Bit_Rate::_2400:   return stream << "::picolibrary::Adafruit::PID781::Bit_Rate::_2400";
+        case Bit_Rate::_4800:   return stream << "::picolibrary::Adafruit::PID781::Bit_Rate::_4800";
+        case Bit_Rate::_9600:   return stream << "::picolibrary::Adafruit::PID781::Bit_Rate::_9600";
+        case Bit_Rate::_19200:  return stream << "::picolibrary::Adafruit::PID781::Bit_Rate::_19200";
+        case Bit_Rate::_28800:  return stream << "::picolibrary::Adafruit::PID781::Bit_Rate::_28800";
+        case Bit_Rate::_38400:  return stream << "::picolibrary::Adafruit::PID781::Bit_Rate::_38400";
+        case Bit_Rate::_57600:  return stream << "::picolibrary::Adafruit::PID781::Bit_Rate::_57600";
+        case Bit_Rate::_115200: return stream << "::picolibrary::Adafruit::PID781::Bit_Rate::_115200";
+
+            // clang-format on
+    } // switch
+
+    return stream << "UNKNOWN";
+}
+
+} // namespace picolibrary::Adafruit::PID781
+
 /**
  * \brief Adafruit PID781 automated testing facilities.
  */

--- a/include/picolibrary/testing/automated/adafruit/pid781.h
+++ b/include/picolibrary/testing/automated/adafruit/pid781.h
@@ -56,7 +56,9 @@ inline auto operator<<( std::ostream & stream, Bit_Rate bit_rate ) -> std::ostre
             // clang-format on
     } // switch
 
-    throw std::invalid_argument{ "bit_rate is not a valid ::picolibrary::Adafruit::PID781::Bit_Rate" };
+    throw std::invalid_argument{
+        "bit_rate is not a valid ::picolibrary::Adafruit::PID781::Bit_Rate"
+    };
 }
 
 } // namespace picolibrary::Adafruit::PID781


### PR DESCRIPTION
Resolves #2101 (Add Adafruit PID781 bit rate insertion operator to support automated testing).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
