### PR TITLE
Add Adafruit PID781 LCD size insertion operator to support automated testing

### DIFF
--- a/docs/device/adafruit/pid781.md
+++ b/docs/device/adafruit/pid781.md
@@ -23,3 +23,10 @@ The `::picolibrary::Adafruit::PID781::LCD_Size` enum class is used to identify L
   `::picolibrary::Adafruit::PID781::columns()` function.
 - To get the number of rows an LCD has, use the `::picolibrary::Adafruit::PID781::rows()`
   function.
+
+A `std::ostream` insertion operator is defined for
+`::picolibrary::Adafruit::PID781::LCD_Size` if the `PICOLIBRARY_ENABLE_AUTOMATED_TESTING`
+project configuration option is `ON`.
+The insertion operator is defined in the
+[`include/picolibrary/testing/automated/adafruit/pid781.h`](https://github.com/apcountryman/picolibrary/blob/main/include/picolibrary/testing/automated/adafruit/pid781.h)/[`source/picolibrary/testing/automated/adafruit/pid781.cc`](https://github.com/apcountryman/picolibrary/blob/main/source/picolibrary/testing/automated/adafruit/pid781.cc)
+header/source file pair.

--- a/include/picolibrary/testing/automated/adafruit/pid781.h
+++ b/include/picolibrary/testing/automated/adafruit/pid781.h
@@ -61,6 +61,30 @@ inline auto operator<<( std::ostream & stream, Bit_Rate bit_rate ) -> std::ostre
     };
 }
 
+/**
+ * \brief Insertion operator.
+ *
+ * \param[in] stream The stream to write the picolibrary::Adafruit::PID781::LCD_Size to.
+ * \param[in] stream The picolibrary::Adafruit::PID781::LCD_Size to write to the stream.
+ *
+ * \return stream
+ */
+inline auto operator<<( std::ostream & stream, LCD_Size lcd_size ) -> std::ostream &
+{
+    switch ( lcd_size ) {
+            // clang-format off
+
+        case LCD_Size::_16X2: return stream << "::picolibrary::Adafruit::PID781::LCD_Size::_16X2";
+        case LCD_Size::_20X4: return stream << "::picolibrary::Adafruit::PID781::LCD_Size::_20X4";
+
+            // clang-format on
+    } // switch
+
+    throw std::invalid_argument{
+        "lcd_size is not a valid ::picolibrary::Adafruit::PID781::LCD_Size"
+    };
+}
+
 } // namespace picolibrary::Adafruit::PID781
 
 /**


### PR DESCRIPTION
Resolves #2102 (Add Adafruit PID781 LCD size insertion operator to support automated testing).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
