### PR TITLE
Add ADC sample insertion operator to support automated testing

### DIFF
--- a/docs/adc.md
+++ b/docs/adc.md
@@ -25,6 +25,12 @@ The `::picolibrary::ADC::Sample` template class is used to store ADC samples.
 [`test/automated/picolibrary/adc/sample/main.cc`](https://github.com/apcountryman/picolibrary/blob/main/test/automated/picolibrary/adc/sample/main.cc)
 source file.
 
+A `std::ostream` insertion operator is defined for `::picolibrary::ADC::Sample` if the
+`PICOLIBRARY_ENABLE_AUTOMATED_TESTING` project configuration option is `ON`.
+The insertion operator is defined in the
+[`include/picolibrary/testing/automated/adc.h`](https://github.com/apcountryman/picolibrary/blob/main/include/picolibrary/testing/automated/adc.h)/[`source/picolibrary/testing/automated/adc.cc`](https://github.com/apcountryman/picolibrary/blob/main/source/picolibrary/testing/automated/adc.cc)
+header/source file pair.
+
 `::picolibrary::Testing::Automated::random()` specializations for several
 `::picolibrary::ADC::Sample` types are available if the
 `PICOLIBRARY_ENABLE_AUTOMATED_TESTING` project configuration option is `ON`.

--- a/include/picolibrary/testing/automated/adc.h
+++ b/include/picolibrary/testing/automated/adc.h
@@ -24,11 +24,34 @@
 #define PICOLIBRARY_TESTING_AUTOMATED_ADC_H
 
 #include <cstdint>
+#include <limits>
+#include <ostream>
 
 #include "gmock/gmock.h"
 #include "picolibrary/adc.h"
 #include "picolibrary/testing/automated/mock_handle.h"
 #include "picolibrary/testing/automated/random.h"
+
+namespace picolibrary::ADC {
+
+/**
+ * \brief Insertion operator.
+ *
+ * \tparam T The sample unsigned integer representation.
+ * \tparam N The number of bits in the sample.
+ *
+ * \param[in] stream The stream to write the picolibrary::ADC::Sample to.
+ * \param[in] sample The picolibrary::ADC::Sample to write to the stream.
+ */
+template<typename T, std::uint_fast8_t N>
+auto operator<<( std::ostream & stream, Sample<T, N> sample ) -> std::ostream &
+{
+    static_assert( N <= std::numeric_limits<std::uint_fast32_t>::digits );
+
+    return stream << static_cast<std::uint_fast32_t>( sample.as_unsigned_integer() );
+}
+
+} // namespace picolibrary::ADC
 
 namespace picolibrary::Testing::Automated {
 


### PR DESCRIPTION
Resolves #2110 (Add ADC sample insertion operator to support automated testing).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
