### PR TITLE
Add CRC calculation parameters insertion operator to support automated testing

### DIFF
--- a/docs/crc.md
+++ b/docs/crc.md
@@ -11,6 +11,13 @@ header/source file pair.
 The `::picolibrary::CRC::Calculation_Parameters` struct captures a CRC calculation's
 parameters.
 
+A `std::ostream` insertion operator is defined for
+`::picolibrary::CRC::Calculation_Parameters` if the `PICOLIBRARY_ENABLE_AUTOMATED_TESTING`
+project configuration option is `ON`.
+The insertion operator is defined in the
+[`include/picolibrary/testing/automated/crc.h`](https://github.com/apcountryman/picolibrary/blob/main/include/picolibrary/testing/automated/crc.h)/[`source/picolibrary/testing/automated/crc.cc`](https://github.com/apcountryman/picolibrary/blob/main/source/picolibrary/testing/automated/crc.cc)
+header/source file pair.
+
 The `::picolibrary::CRC::Calculator_Concept` defines the expected interface of a CRC
 calculator implementation.
 - To calculate the remainder for a message, use a CRC calculator implementation's

--- a/include/picolibrary/testing/automated/crc.h
+++ b/include/picolibrary/testing/automated/crc.h
@@ -33,6 +33,42 @@
 
 #include "picolibrary/crc.h"
 
+namespace picolibrary::CRC {
+
+/**
+ * \brief Insertion operator.
+ *
+ * \tparam Register Calculation register type.
+ *
+ * \param[in] stream The stream to write the picolibrary::CRC::Calculation_Parameters to.
+ * \param[in] calculation_parameters The picolibrary::CRC::Calculation_Parameters to write
+ *            to the stream.
+ *
+ * \return stream
+ */
+template<typename Register>
+auto operator<<( std::ostream & stream, Calculation_Parameters<Register> const & calculation_parameters )
+    -> std::ostream &
+{
+    // clang-format off
+
+    return stream << "{ "
+                  << ".polynomial = 0x" << std::hex << std::uppercase << std::setw( std::numeric_limits<Register>::digits / 4 ) << std::setfill( '0' ) << static_cast<std::uint_fast64_t>( calculation_parameters.polynomial )
+                  << ", "
+                  << ".initial_remainder = 0x" << std::hex << std::uppercase << std::setw( std::numeric_limits<Register>::digits / 4 ) << std::setfill( '0' ) << static_cast<std::uint_fast64_t>( calculation_parameters.initial_remainder )
+                  << ", "
+                  << ".input_is_reflected = " << std::boolalpha << calculation_parameters.input_is_reflected
+                  << ", "
+                  << ".output_is_reflected = " << std::boolalpha << calculation_parameters.output_is_reflected
+                  << ", "
+                  << ".xor_output = 0x" << std::hex << std::uppercase << std::setw( std::numeric_limits<Register>::digits / 4 ) << std::setfill( '0' ) << static_cast<std::uint_fast64_t>( calculation_parameters.xor_output )
+                  << " }";
+
+    // clang-format on
+}
+
+} // namespace picolibrary::CRC
+
 /**
  * \brief CRC automated testing facilities.
  */


### PR DESCRIPTION
Resolves #2112 (Add CRC calculation parameters insertion operator to support automated testing).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
