### PR TITLE
Fix Adafruit PID781 LCD size insertion operator documentation

### DIFF
--- a/include/picolibrary/testing/automated/adafruit/pid781.h
+++ b/include/picolibrary/testing/automated/adafruit/pid781.h
@@ -65,7 +65,7 @@ inline auto operator<<( std::ostream & stream, Bit_Rate bit_rate ) -> std::ostre
  * \brief Insertion operator.
  *
  * \param[in] stream The stream to write the picolibrary::Adafruit::PID781::LCD_Size to.
- * \param[in] stream The picolibrary::Adafruit::PID781::LCD_Size to write to the stream.
+ * \param[in] lcd_size The picolibrary::Adafruit::PID781::LCD_Size to write to the stream.
  *
  * \return stream
  */


### PR DESCRIPTION
Resolves #2118 (Fix Adafruit PID781 LCD size insertion operator documentation).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
