### PR TITLE
Add GPIO initial internal pull-up resistor state insertion operator to support automated testing

### DIFF
--- a/docs/gpio.md
+++ b/docs/gpio.md
@@ -4,10 +4,22 @@ GPIO facilities are defined in the
 header/source file pair.
 
 ## Table of Contents
+1. [Initial Internal Pull-Up Resistor State Identification](#initial-internal-pull-up-resistor-state-identification)
 1. [Input Pin](#input-pin)
 1. [Internally Pulled-Up Input Pin](#internally-pulled-up-input-pin)
 1. [Output Pin](#output-pin)
 1. [I/O Pin](#io-pin)
+
+## Initial Internal Pull-Up Resistor State Identification
+The `::picolibrary::GPIO::Initial_Internal_Pull_Up_State` enum class is used to identify
+initial internal pull-up resistor states.
+
+A `std::ostream` insertion operator is defined for
+`::picolibrary::GPIO::Initial_Pull_Up_State` if the `PICOLIBRARY_ENABLE_AUTOMATED_TESTING`
+project configuration option is `ON`.
+The insertion operator is defined in the
+[`include/picolibrary/testing/automated/gpio.h`](https://github.com/apcountryman/picolibrary/blob/main/include/picolibrary/testing/automated/gpio.h)/[`source/picolibrary/testing/automated/gpio.cc`](https://github.com/apcountryman/picolibrary/blob/main/source/picolibrary/testing/automated/gpio.cc)
+header/source file pair.
 
 ## Input Pin
 The `::picolibrary::GPIO::Input_Pin_Concept` concept class defines the expected interface

--- a/docs/gpio.md
+++ b/docs/gpio.md
@@ -11,8 +11,8 @@ header/source file pair.
 1. [I/O Pin](#io-pin)
 
 ## Initial Internal Pull-Up Resistor State Identification
-The `::picolibrary::GPIO::Initial_Internal_Pull_Up_State` enum class is used to identify
-initial internal pull-up resistor states.
+The `::picolibrary::GPIO::Initial_Pull_Up_State` enum class is used to identify initial
+internal pull-up resistor states.
 
 A `std::ostream` insertion operator is defined for
 `::picolibrary::GPIO::Initial_Pull_Up_State` if the `PICOLIBRARY_ENABLE_AUTOMATED_TESTING`

--- a/include/picolibrary/testing/automated/gpio.h
+++ b/include/picolibrary/testing/automated/gpio.h
@@ -23,9 +23,42 @@
 #ifndef PICOLIBRARY_TESTING_AUTOMATED_GPIO_H
 #define PICOLIBRARY_TESTING_AUTOMATED_GPIO_H
 
+#include <ostream>
+#include <stdexcept>
+
 #include "gmock/gmock.h"
 #include "picolibrary/gpio.h"
 #include "picolibrary/testing/automated/mock_handle.h"
+
+namespace picolibrary::GPIO {
+
+/**
+ * \brief Insertion operator.
+ *
+ * \param[in] stream The stream to write the picolibrary::GPIO::Initial_Pull_Up_State to.
+ * \param[in] initial_pull_up_state The picolibrary::GPIO::Initial_Pull_Up_State to write
+ *            to the stream.
+ *
+ * \return stream
+ */
+inline auto operator<<( std::ostream & stream, Initial_Pull_Up_State initial_pull_up_state )
+    -> std::ostream &
+{
+    switch ( initial_pull_up_state ) {
+            // clang-format off
+
+        case Initial_Pull_Up_State::DISABLED: return stream << "::picolibrary::GPIO::Initial_Pull_Up_State::DISABLED";
+        case Initial_Pull_Up_State::ENABLED:  return stream << "::picolibrary::GPIO::Initial_Pull_Up_State::ENABLED";
+
+            // clang-format on
+    } // switch
+
+    throw std::invalid_argument{
+        "initial_pull_up_state is not a valid ::picolibrary::GPIO::Initial_Pull_Up_State"
+    };
+}
+
+} // namespace picolibrary::GPIO
 
 /**
  * \brief GPIO automated testing facilities.


### PR DESCRIPTION
Resolves #2130 (Add GPIO initial internal pull-up resistor state insertion operator to support automated testing).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
