### PR TITLE
Add GPIO initial pin state insertion operator to support automated testing

### DIFF
--- a/docs/gpio.md
+++ b/docs/gpio.md
@@ -5,6 +5,7 @@ header/source file pair.
 
 ## Table of Contents
 1. [Initial Internal Pull-Up Resistor State Identification](#initial-internal-pull-up-resistor-state-identification)
+1. [Initial Pin State Identification](#initial-pin-state-identification)
 1. [Input Pin](#input-pin)
 1. [Internally Pulled-Up Input Pin](#internally-pulled-up-input-pin)
 1. [Output Pin](#output-pin)
@@ -16,6 +17,17 @@ internal pull-up resistor states.
 
 A `std::ostream` insertion operator is defined for
 `::picolibrary::GPIO::Initial_Pull_Up_State` if the `PICOLIBRARY_ENABLE_AUTOMATED_TESTING`
+project configuration option is `ON`.
+The insertion operator is defined in the
+[`include/picolibrary/testing/automated/gpio.h`](https://github.com/apcountryman/picolibrary/blob/main/include/picolibrary/testing/automated/gpio.h)/[`source/picolibrary/testing/automated/gpio.cc`](https://github.com/apcountryman/picolibrary/blob/main/source/picolibrary/testing/automated/gpio.cc)
+header/source file pair.
+
+## Initial Pin State Identification
+The `::picolibrary::GPIO::Initial_Pin_State` enum class is used to identify initial pin
+states.
+
+A `std::ostream` insertion operator is defined for
+`::picolibrary::GPIO::Initial_Pin_State` if the `PICOLIBRARY_ENABLE_AUTOMATED_TESTING`
 project configuration option is `ON`.
 The insertion operator is defined in the
 [`include/picolibrary/testing/automated/gpio.h`](https://github.com/apcountryman/picolibrary/blob/main/include/picolibrary/testing/automated/gpio.h)/[`source/picolibrary/testing/automated/gpio.cc`](https://github.com/apcountryman/picolibrary/blob/main/source/picolibrary/testing/automated/gpio.cc)

--- a/include/picolibrary/testing/automated/gpio.h
+++ b/include/picolibrary/testing/automated/gpio.h
@@ -58,6 +58,31 @@ inline auto operator<<( std::ostream & stream, Initial_Pull_Up_State initial_pul
     };
 }
 
+/**
+ * \brief Insertion operator.
+ *
+ * \param[in] stream The stream to write the picolibrary::GPIO::Initial_Pin_State to.
+ * \param[in] initial_pin_state The picolibrary::GPIO::Initial_Pin_State to write to the
+ *            stream.
+ *
+ * \return stream
+ */
+inline auto operator<<( std::ostream & stream, Initial_Pin_State initial_pin_state ) -> std::ostream &
+{
+    switch ( initial_pin_state ) {
+            // clang-format off
+
+        case Initial_Pin_State::LOW:  return stream << "::picolibrary::GPIO::Initial_Pin_State::LOW";
+        case Initial_Pin_State::HIGH: return stream << "::picolibrary::GPIO::Initial_Pin_State::HIGH";
+
+            // clang-format on
+    } // switch
+
+    throw std::invalid_argument{
+        "initial_pin_state is not a valid ::picolibrary::GPIO::Initial_Pin_State"
+    };
+}
+
 } // namespace picolibrary::GPIO
 
 /**


### PR DESCRIPTION
Resolves #2131 (Add GPIO initial pin state insertion operator to support automated testing).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
