### PR TITLE
Add I2C address numeric insertion operator to support automated testing

### DIFF
--- a/docs/i2c.md
+++ b/docs/i2c.md
@@ -23,6 +23,12 @@ address in numeric (right justified) format.
 [`test/automated/picolibrary/i2c/address_numeric/main.cc`](https://github.com/apcountryman/picolibrary/blob/main/test/automated/picolibrary/i2c/address_numeric/main.cc)
 source file.
 
+A `std::ostream` insertion operator is defined for `::picolibrary::I2C::Address_Numeric`
+if the `PICOLIBRARY_ENABLE_AUTOMATED_TESTING` project configuration option is `ON`.
+The insertion operator is defined in the
+[`include/picolibrary/testing/automated/i2c.h`](https://github.com/apcountryman/picolibrary/blob/main/include/picolibrary/testing/automated/i2c.h)/[`source/picolibrary/testing/automated/i2c.cc`](https://github.com/apcountryman/picolibrary/blob/main/source/picolibrary/testing/automated/i2c.cc)
+header/source file pair.
+
 The `::picolibrary::I2C::Address_Transmitted` class is used to store an I<sup>2</sup>C
 device address in transmitted (left shifted) format.
 - To get the minimum valid address, use the

--- a/include/picolibrary/testing/automated/i2c.h
+++ b/include/picolibrary/testing/automated/i2c.h
@@ -26,6 +26,10 @@
 #include <algorithm>
 #include <cstdint>
 #include <functional>
+#include <iomanip>
+#include <ios>
+#include <limits>
+#include <ostream>
 #include <vector>
 
 #include "gmock/gmock.h"
@@ -33,6 +37,27 @@
 #include "picolibrary/i2c.h"
 #include "picolibrary/testing/automated/mock_handle.h"
 #include "picolibrary/testing/automated/random.h"
+
+namespace picolibrary::I2C {
+
+/**
+ * \brief Insertion operator.
+ *
+ * \param[in] stream The stream to write the picolibrary::I2C::Address_Numeric to.
+ * \param[in] address The picolibrary::I2C::Address to write to the stream.
+ *
+ * \return stream
+ */
+inline auto operator<<( std::ostream & stream, Address_Numeric address ) -> std::ostream &
+{
+    return stream << static_cast<std::uint_fast16_t>( address.as_unsigned_integer() )
+                  << " (0x" << std::hex << std::uppercase
+                  << std::setw( std::numeric_limits<std::uint8_t>::digits / 4 )
+                  << std::setfill( '0' )
+                  << static_cast<std::uint_fast16_t>( address.as_unsigned_integer() ) << ')';
+}
+
+} // namespace picolibrary::I2C
 
 namespace picolibrary::Testing::Automated {
 


### PR DESCRIPTION
Resolves #2136 (Add I2C address numeric insertion operator to support automated testing).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
