### PR TITLE
Remove decimal output from I2C address numeric insertion operator

### DIFF
--- a/include/picolibrary/testing/automated/i2c.h
+++ b/include/picolibrary/testing/automated/i2c.h
@@ -50,11 +50,10 @@ namespace picolibrary::I2C {
  */
 inline auto operator<<( std::ostream & stream, Address_Numeric address ) -> std::ostream &
 {
-    return stream << static_cast<std::uint_fast16_t>( address.as_unsigned_integer() )
-                  << " (0x" << std::hex << std::uppercase
+    return stream << "0x" << std::hex << std::uppercase
                   << std::setw( std::numeric_limits<std::uint8_t>::digits / 4 )
                   << std::setfill( '0' )
-                  << static_cast<std::uint_fast16_t>( address.as_unsigned_integer() ) << ')';
+                  << static_cast<std::uint_fast16_t>( address.as_unsigned_integer() );
 }
 
 } // namespace picolibrary::I2C


### PR DESCRIPTION
Resolves #2145 (Remove decimal output from I2C address numeric insertion operator).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
