### PR TITLE
Add I2C address transmitted insertion operator to support automated testing

### DIFF
--- a/docs/i2c.md
+++ b/docs/i2c.md
@@ -43,6 +43,13 @@ device address in transmitted (left shifted) format.
 [`test/automated/picolibrary/i2c/address_transmitted/main.cc`](https://github.com/apcountryman/picolibrary/blob/main/test/automated/picolibrary/i2c/address_transmitted/main.cc)
 source file.
 
+A `std::ostream` insertion operator is defined for
+`::picolibrary::I2C::Address_Transmitted` if the `PICOLIBRARY_ENABLE_AUTOMATED_TESTING`
+project configuration option is `ON`.
+The insertion operator is defined in the
+[`include/picolibrary/testing/automated/i2c.h`](https://github.com/apcountryman/picolibrary/blob/main/include/picolibrary/testing/automated/i2c.h)/[`source/picolibrary/testing/automated/i2c.cc`](https://github.com/apcountryman/picolibrary/blob/main/source/picolibrary/testing/automated/i2c.cc)
+header/source file pair.
+
 `::picolibrary::Testing::Automated::random()` specializations for
 `::picolibrary::I2C::Address_Numeric` and `::picolibrary::I2C::Address_Transmitted` are
 available if the `PICOLIBRARY_ENABLE_AUTOMATED_TESTING` project configuration option is

--- a/include/picolibrary/testing/automated/i2c.h
+++ b/include/picolibrary/testing/automated/i2c.h
@@ -56,6 +56,22 @@ inline auto operator<<( std::ostream & stream, Address_Numeric address ) -> std:
                   << static_cast<std::uint_fast16_t>( address.as_unsigned_integer() );
 }
 
+/**
+ * \brief Insertion operator.
+ *
+ * \param[in] stream The stream to write the picolibrary::I2C::Address_Transmitted to.
+ * \param[in] address The picolibrary::I2C::Address to write to the stream.
+ *
+ * \return stream
+ */
+inline auto operator<<( std::ostream & stream, Address_Transmitted address ) -> std::ostream &
+{
+    return stream << "0x" << std::hex << std::uppercase
+                  << std::setw( std::numeric_limits<std::uint8_t>::digits / 4 )
+                  << std::setfill( '0' )
+                  << static_cast<std::uint_fast16_t>( address.as_unsigned_integer() );
+}
+
 } // namespace picolibrary::I2C
 
 namespace picolibrary::Testing::Automated {

--- a/include/picolibrary/testing/automated/i2c.h
+++ b/include/picolibrary/testing/automated/i2c.h
@@ -60,7 +60,7 @@ inline auto operator<<( std::ostream & stream, Address_Numeric address ) -> std:
  * \brief Insertion operator.
  *
  * \param[in] stream The stream to write the picolibrary::I2C::Address_Transmitted to.
- * \param[in] address The picolibrary::I2C::Address to write to the stream.
+ * \param[in] address The picolibrary::I2C::Address_Transmitted to write to the stream.
  *
  * \return stream
  */


### PR DESCRIPTION
Resolves #2137 (Add I2C address transmitted insertion operator to support automated testing).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
