### PR TITLE
Fix I2C address numeric insertion operator documentation

### DIFF
--- a/include/picolibrary/testing/automated/i2c.h
+++ b/include/picolibrary/testing/automated/i2c.h
@@ -44,7 +44,7 @@ namespace picolibrary::I2C {
  * \brief Insertion operator.
  *
  * \param[in] stream The stream to write the picolibrary::I2C::Address_Numeric to.
- * \param[in] address The picolibrary::I2C::Address to write to the stream.
+ * \param[in] address The picolibrary::I2C::Address_Numeric to write to the stream.
  *
  * \return stream
  */


### PR DESCRIPTION
Resolves #2148 (Fix I2C address numeric insertion operator documentation).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
