### PR TITLE
Add I2C operation insertion operator to support automated testing

### DIFF
--- a/docs/i2c.md
+++ b/docs/i2c.md
@@ -5,6 +5,7 @@ header/source file pair.
 
 ## Table of Contents
 1. [Device Addressing](#device-addressing)
+1. [Operation Identification](#operation-identification)
 1. [Controller](#controller)
 1. [Device](#device)
 
@@ -55,6 +56,16 @@ header/source file pair.
 available if the `PICOLIBRARY_ENABLE_AUTOMATED_TESTING` project configuration option is
 `ON`.
 The specializations are defined in the
+[`include/picolibrary/testing/automated/i2c.h`](https://github.com/apcountryman/picolibrary/blob/main/include/picolibrary/testing/automated/i2c.h)/[`source/picolibrary/testing/automated/i2c.cc`](https://github.com/apcountryman/picolibrary/blob/main/source/picolibrary/testing/automated/i2c.cc)
+header/source file pair.
+
+## Operation Identification
+The `::picolibrary::I2C::Operation` enum class is used to identify I<sup>2</sup>C
+operations.
+
+A `std::ostream` insertion operator is defined for `::picolibrary::I2C::Operation` if the
+`PICOLIBRARY_ENABLE_AUTOMATED_TESTING` project configuration option is `ON`.
+The insertion operator is defined in the
 [`include/picolibrary/testing/automated/i2c.h`](https://github.com/apcountryman/picolibrary/blob/main/include/picolibrary/testing/automated/i2c.h)/[`source/picolibrary/testing/automated/i2c.cc`](https://github.com/apcountryman/picolibrary/blob/main/source/picolibrary/testing/automated/i2c.cc)
 header/source file pair.
 

--- a/include/picolibrary/testing/automated/i2c.h
+++ b/include/picolibrary/testing/automated/i2c.h
@@ -30,6 +30,7 @@
 #include <ios>
 #include <limits>
 #include <ostream>
+#include <stdexcept>
 #include <vector>
 
 #include "gmock/gmock.h"
@@ -70,6 +71,30 @@ inline auto operator<<( std::ostream & stream, Address_Transmitted address ) -> 
                   << std::setw( std::numeric_limits<std::uint8_t>::digits / 4 )
                   << std::setfill( '0' )
                   << static_cast<std::uint_fast16_t>( address.as_unsigned_integer() );
+}
+
+/**
+ * \brief Insertion operator.
+ *
+ * \param[in] stream The stream to write the picolibrary::I2C::Operation to.
+ * \param[in] address The picolibrary::I2C::Operation to write to the stream.
+ *
+ * \return stream
+ */
+inline auto operator<<( std::ostream & stream, Operation operation ) -> std::ostream &
+{
+    switch ( operation ) {
+            // clang-format off
+
+        case Operation::READ:  return stream << "::picolibrary::Operation::READ";
+        case Operation::WRITE: return stream << "::picolibrary::Operation::WRITE";
+
+            // clang-format on
+    } // switch
+
+    throw std::invalid_argument{
+        "operation is not a valid ::picolibrary::I2C::Operation"
+    };
 }
 
 } // namespace picolibrary::I2C


### PR DESCRIPTION
Resolves #2138 (Add I2C operation insertion operator to support automated testing).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
