### PR TITLE
Add I2C response insertion operator to support automated testing

### DIFF
--- a/docs/i2c.md
+++ b/docs/i2c.md
@@ -6,6 +6,7 @@ header/source file pair.
 ## Table of Contents
 1. [Device Addressing](#device-addressing)
 1. [Operation Identification](#operation-identification)
+1. [Response Identification](#response-identification)
 1. [Controller](#controller)
 1. [Device](#device)
 
@@ -64,6 +65,16 @@ The `::picolibrary::I2C::Operation` enum class is used to identify I<sup>2</sup>
 operations.
 
 A `std::ostream` insertion operator is defined for `::picolibrary::I2C::Operation` if the
+`PICOLIBRARY_ENABLE_AUTOMATED_TESTING` project configuration option is `ON`.
+The insertion operator is defined in the
+[`include/picolibrary/testing/automated/i2c.h`](https://github.com/apcountryman/picolibrary/blob/main/include/picolibrary/testing/automated/i2c.h)/[`source/picolibrary/testing/automated/i2c.cc`](https://github.com/apcountryman/picolibrary/blob/main/source/picolibrary/testing/automated/i2c.cc)
+header/source file pair.
+
+## Response Identification
+The `::picolibrary::I2C::Response` enum class is used to identify I<sup>2</sup>C
+responses.
+
+A `std::ostream` insertion operator is defined for `::picolibrary::I2C::Response` if the
 `PICOLIBRARY_ENABLE_AUTOMATED_TESTING` project configuration option is `ON`.
 The insertion operator is defined in the
 [`include/picolibrary/testing/automated/i2c.h`](https://github.com/apcountryman/picolibrary/blob/main/include/picolibrary/testing/automated/i2c.h)/[`source/picolibrary/testing/automated/i2c.cc`](https://github.com/apcountryman/picolibrary/blob/main/source/picolibrary/testing/automated/i2c.cc)

--- a/include/picolibrary/testing/automated/i2c.h
+++ b/include/picolibrary/testing/automated/i2c.h
@@ -97,6 +97,28 @@ inline auto operator<<( std::ostream & stream, Operation operation ) -> std::ost
     };
 }
 
+/**
+ * \brief Insertion operator.
+ *
+ * \param[in] stream The stream to write the picolibrary::I2C::Response to.
+ * \param[in] response The picolibrary::I2C::Response to write to the stream.
+ *
+ * \return stream
+ */
+inline auto operator<<( std::ostream & stream, Response response ) -> std::ostream &
+{
+    switch ( response ) {
+            // clang-format off
+
+        case Response::ACK:  return stream << "::picolibrary::Response::ACK";
+        case Response::NACK: return stream << "::picolibrary::Response::NACK";
+
+            // clang-format on
+    } // switch
+
+    throw std::invalid_argument{ "response is not a valid ::picolibrary::I2C::Response" };
+}
+
 } // namespace picolibrary::I2C
 
 namespace picolibrary::Testing::Automated {


### PR DESCRIPTION
Resolves #2139 (Add I2C response insertion operator to support automated testing).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
