### PR TITLE
Add IP protocol port insertion operator to support automated testing

### DIFF
--- a/docs/network/ip.md
+++ b/docs/network/ip.md
@@ -78,6 +78,12 @@ the
 [`test/automated/picolibrary/ip/port/main.cc`](https://github.com/apcountryman/picolibrary/blob/main/test/automated/picolibrary/ip/port/main.cc)
 source file.
 
+A `std::ostream` insertion operator is defined for `::picolibrary::IP::Port` if the
+`PICOLIBRARY_ENABLE_AUTOMATED_TESTING` project configuration option is on.
+The insertion operator is defined in the
+[`include/picolibrary/testing/automated/ip.h`](https://github.com/apcountryman/picolibrary/blob/main/include/picolibrary/testing/automated/ip.h)/[`source/picolibrary/testing/automated/ip.cc`](https://github.com/apcountryman/picolibrary/blob/main/source/picolibrary/testing/automated/ip.cc)
+header/source file pair.
+
 A `::picolibrary::Testing::Automated::random()` specialization for
 `::picolibrary::IP::Port` is available if the `PICOLIBRARY_ENABLE_AUTOMATED_TESTING`
 project configuration option is `ON`.

--- a/include/picolibrary/testing/automated/ip.h
+++ b/include/picolibrary/testing/automated/ip.h
@@ -64,6 +64,19 @@ inline auto operator<<( std::ostream & stream, Address const & address ) -> std:
     };
 }
 
+/**
+ * \brief Insertion operator.
+ *
+ * \param[in] stream The stream to write the picolibrary::IP::Port to.
+ * \param[in] port The picolibrary::IP::Port to write to the stream.
+ *
+ * \return stream
+ */
+inline auto operator<<( std::ostream & stream, Port port ) -> std::ostream &
+{
+    return stream << port.as_unsigned_integer();
+}
+
 } // namespace picolibrary::IP
 
 namespace picolibrary::Testing::Automated {


### PR DESCRIPTION
Resolves #2162 (Add IP protocol port insertion operator to support automated testing).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
