### PR TITLE
Add Microchip MCP23S08 address numeric insertion operator to support automated testing

### DIFF
--- a/docs/device/microchip/mcp23s08.md
+++ b/docs/device/microchip/mcp23s08.md
@@ -46,6 +46,13 @@ Microchip MCP23S08 address is numeric (right justified) format.
 [`test/automated/picolibrary/microchip/mcp23s08/address_numeric/main.cc`](https://github.com/apcountryman/picolibrary/blob/main/test/automated/picolibrary/microchip/mcp23s08/address_numeric/main.cc)
 source file.
 
+A `std::ostream` insertion operator is defined for
+`::picolibrary::Microchip::MCP23S08::Address_Numeric` if the
+`PICOLIBRARY_ENABLE_AUTOMATED_TESTING` project configuration option is `ON`.
+The insertion operator is defined in the
+[`include/picolibrary/testing/automated/microchip/mcp23s08.h`](https://github.com/apcountryman/picolibrary/blob/main/include/picolibrary/testing/automated/microchip/mcp23s08.h)/[`source/picolibrary/testing/automated/microchip/mcp23s08.cc`](https://github.com/apcountryman/picolibrary/blob/main/source/picolibrary/testing/automated/microchip/mcp23s08.cc)
+header/source file pair.
+
 The `::picolibrary::Microchip::MCP23S08::Address_Transmitted` class is used to store a
 Microchip MCP23S08 address is transmitted (left shifted) format.
 - To get the minimum valid address, use the

--- a/include/picolibrary/testing/automated/microchip/mcp23s08.h
+++ b/include/picolibrary/testing/automated/microchip/mcp23s08.h
@@ -24,12 +24,38 @@
 #define PICOLIBRARY_TESTING_AUTOMATED_MICROCHIP_MCP23S08_H
 
 #include <cstdint>
+#include <iomanip>
+#include <ios>
+#include <limits>
+#include <ostream>
 
 #include "gmock/gmock.h"
 #include "picolibrary/microchip/mcp23s08.h"
 #include "picolibrary/testing/automated/microchip/mcp23x08.h"
 #include "picolibrary/testing/automated/random.h"
 #include "picolibrary/testing/automated/spi.h"
+
+namespace picolibrary::Microchip::MCP23S08 {
+
+/**
+ * \brief Insertion operator.
+ *
+ * \param[in] stream The stream to write the
+ *            picolibrary::Microchip::MCP23S08::Address_Numeric to.
+ * \param[in] address The picolibrary::Microchip::MCP23S08::Address_Numeric to write to
+ *            the stream.
+ *
+ * \return stream
+ */
+inline auto operator<<( std::ostream & stream, Address_Numeric address ) -> std::ostream &
+{
+    return stream << "0x" << std::hex << std::uppercase
+                  << std::setw( std::numeric_limits<std::uint8_t>::digits / 4 )
+                  << std::setfill( '0' )
+                  << static_cast<std::uint_fast16_t>( address.as_unsigned_integer() );
+}
+
+} // namespace picolibrary::Microchip::MCP23S08
 
 namespace picolibrary::Testing::Automated {
 


### PR DESCRIPTION
Resolves #2180 (Add Microchip MCP23S08 address numeric insertion operator to support automated testing).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
