### PR TITLE
Add Microchip MCP23S08 address transmitted insertion operator to support automated testing

### DIFF
--- a/docs/device/microchip/mcp23s08.md
+++ b/docs/device/microchip/mcp23s08.md
@@ -69,6 +69,13 @@ the
 [`test/automated/picolibrary/microchip/mcp23s08/address_transmitted/main.cc`](https://github.com/apcountryman/picolibrary/blob/main/test/automated/picolibrary/microchip/mcp23s08/address_transmitted/main.cc)
 source file.
 
+A `std::ostream` insertion operator is defined for
+`::picolibrary::Microchip::MCP23S08::Address_Numeric` if the
+`PICOLIBRARY_ENABLE_AUTOMATED_TESTING` project configuration option is `ON`.
+The insertion operator is defined in the
+[`include/picolibrary/testing/automated/microchip/mcp23s08.h`](https://github.com/apcountryman/picolibrary/blob/main/include/picolibrary/testing/automated/microchip/mcp23s08.h)/[`source/picolibrary/testing/automated/microchip/mcp23s08.cc`](https://github.com/apcountryman/picolibrary/blob/main/source/picolibrary/testing/automated/microchip/mcp23s08.cc)
+header/source file pair.
+
 `::picolibrary::Testing::Automated::random()` specializations for
 `::picolibrary::Microchip::MCP23S08::Address_Numeric` and
 `::picolibrary::Microchip::MCP23S08::Address_Transmitted` are available if the

--- a/docs/device/microchip/mcp23s08.md
+++ b/docs/device/microchip/mcp23s08.md
@@ -70,7 +70,7 @@ the
 source file.
 
 A `std::ostream` insertion operator is defined for
-`::picolibrary::Microchip::MCP23S08::Address_Numeric` if the
+`::picolibrary::Microchip::MCP23S08::Address_Transmitted` if the
 `PICOLIBRARY_ENABLE_AUTOMATED_TESTING` project configuration option is `ON`.
 The insertion operator is defined in the
 [`include/picolibrary/testing/automated/microchip/mcp23s08.h`](https://github.com/apcountryman/picolibrary/blob/main/include/picolibrary/testing/automated/microchip/mcp23s08.h)/[`source/picolibrary/testing/automated/microchip/mcp23s08.cc`](https://github.com/apcountryman/picolibrary/blob/main/source/picolibrary/testing/automated/microchip/mcp23s08.cc)

--- a/include/picolibrary/testing/automated/microchip/mcp23s08.h
+++ b/include/picolibrary/testing/automated/microchip/mcp23s08.h
@@ -55,6 +55,24 @@ inline auto operator<<( std::ostream & stream, Address_Numeric address ) -> std:
                   << static_cast<std::uint_fast16_t>( address.as_unsigned_integer() );
 }
 
+/**
+ * \brief Insertion operator.
+ *
+ * \param[in] stream The stream to write the
+ *            picolibrary::Microchip::MCP23S08::Address_Transmitted to.
+ * \param[in] address The picolibrary::Microchip::MCP23S08::Address_Transmitted to write
+ *            to the stream.
+ *
+ * \return stream
+ */
+inline auto operator<<( std::ostream & stream, Address_Transmitted address ) -> std::ostream &
+{
+    return stream << "0x" << std::hex << std::uppercase
+                  << std::setw( std::numeric_limits<std::uint8_t>::digits / 4 )
+                  << std::setfill( '0' )
+                  << static_cast<std::uint_fast16_t>( address.as_unsigned_integer() );
+}
+
 } // namespace picolibrary::Microchip::MCP23S08
 
 namespace picolibrary::Testing::Automated {


### PR DESCRIPTION
Resolves #2181 (Add Microchip MCP23S08 address transmitted insertion operator to support automated testing).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
