### PR TITLE
Remove unnecessary scope resolution from I2C address automated tests

### DIFF
--- a/test/automated/picolibrary/i2c/address_numeric/main.cc
+++ b/test/automated/picolibrary/i2c/address_numeric/main.cc
@@ -70,7 +70,7 @@ Address_Numeric::Unsigned_Integer const constructorUnsignedInteger_TEST_CASES[]{
  * \brief picolibrary::I2C::Address_Numeric::Address_Numeric(
  *        picolibrary::I2C::Address_Numeric::Unsigned_Integer ) test fixture.
  */
-class constructorUnsignedInteger : public ::testing::TestWithParam<Address_Numeric::Unsigned_Integer> {
+class constructorUnsignedInteger : public TestWithParam<Address_Numeric::Unsigned_Integer> {
 };
 
 /**
@@ -94,7 +94,7 @@ INSTANTIATE_TEST_SUITE_P( testCases, constructorUnsignedInteger, ValuesIn( const
  *        picolibrary::I2C::Address_Numeric::Unsigned_Integer ) test fixture.
  */
 class constructorBypassPreconditionExpectationChecksUnsignedInteger :
-    public ::testing::TestWithParam<Address_Numeric::Unsigned_Integer> {
+    public TestWithParam<Address_Numeric::Unsigned_Integer> {
 };
 
 /**

--- a/test/automated/picolibrary/i2c/address_transmitted/main.cc
+++ b/test/automated/picolibrary/i2c/address_transmitted/main.cc
@@ -72,8 +72,7 @@ Address_Transmitted::Unsigned_Integer const constructorUnsignedInteger_TEST_CASE
  * \brief picolibrary::I2C::Address_Transmitted::Address_Transmitted(
  *        picolibrary::I2C::Address_Transmitted::Unsigned_Integer ) test fixture.
  */
-class constructorUnsignedInteger :
-    public ::testing::TestWithParam<Address_Transmitted::Unsigned_Integer> {
+class constructorUnsignedInteger : public TestWithParam<Address_Transmitted::Unsigned_Integer> {
 };
 
 /**
@@ -97,7 +96,7 @@ INSTANTIATE_TEST_SUITE_P( testCases, constructorUnsignedInteger, ValuesIn( const
  *        picolibrary::I2C::Address_Transmitted::Unsigned_Integer ) test fixture.
  */
 class constructorBypassPreconditionExpectationChecksUnsignedInteger :
-    public ::testing::TestWithParam<Address_Transmitted::Unsigned_Integer> {
+    public TestWithParam<Address_Transmitted::Unsigned_Integer> {
 };
 
 /**


### PR DESCRIPTION
Resolves #2191 (Remove unnecessary scope resolution from I2C address automated tests).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
