### PR TITLE
Fix Microchip MCP23S08 address numeric automated tests inconsistent variable naming

### DIFF
--- a/test/automated/picolibrary/microchip/mcp23s08/address_numeric/main.cc
+++ b/test/automated/picolibrary/microchip/mcp23s08/address_numeric/main.cc
@@ -45,9 +45,9 @@ using ::testing::ValuesIn;
  */
 TEST( constructorDefault, worksProperly )
 {
-    auto const address = Address_Numeric{};
+    auto const address_numeric = Address_Numeric{};
 
-    ASSERT_EQ( address.as_unsigned_integer(), 0b01000'00 );
+    ASSERT_EQ( address_numeric.as_unsigned_integer(), 0b01000'00 );
 }
 
 /**


### PR DESCRIPTION
Resolves #2190 (Fix Microchip MCP23S08 address numeric automated tests inconsistent variable naming).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
