### PR TITLE
Fix Microchip MCP23008/MCP23S08 internally pulled-up input pin automated tests pin constness

### DIFF
--- a/test/automated/picolibrary/microchip/mcp23x08/internally_pulled_up_input_pin/main.cc
+++ b/test/automated/picolibrary/microchip/mcp23x08/internally_pulled_up_input_pin/main.cc
@@ -396,7 +396,7 @@ TEST_P( pullUpIsDisabled, worksProperly )
 
     auto mcp23x08 = Mock_Caching_Driver{};
 
-    auto pin = Internally_Pulled_Up_Input_Pin{ mcp23x08, 0b0000'1000 };
+    auto const pin = Internally_Pulled_Up_Input_Pin{ mcp23x08, 0b0000'1000 };
 
     EXPECT_CALL( mcp23x08, gppu() ).WillOnce( Return( test_case.gppu ) );
 
@@ -468,7 +468,7 @@ TEST_P( pullUpIsEnabled, worksProperly )
 
     auto mcp23x08 = Mock_Caching_Driver{};
 
-    auto pin = Internally_Pulled_Up_Input_Pin{ mcp23x08, 0b0001'0000 };
+    auto const pin = Internally_Pulled_Up_Input_Pin{ mcp23x08, 0b0001'0000 };
 
     EXPECT_CALL( mcp23x08, gppu() ).WillOnce( Return( test_case.gppu ) );
 
@@ -584,7 +584,7 @@ TEST_P( isLow, worksProperly )
 
     auto mcp23x08 = Mock_Caching_Driver{};
 
-    auto pin = Internally_Pulled_Up_Input_Pin{ mcp23x08, 0b0100'0000 };
+    auto const pin = Internally_Pulled_Up_Input_Pin{ mcp23x08, 0b0100'0000 };
 
     EXPECT_CALL( mcp23x08, read_gpio() ).WillOnce( Return( test_case.gpio ) );
 
@@ -656,7 +656,7 @@ TEST_P( isHigh, worksProperly )
 
     auto mcp23x08 = Mock_Caching_Driver{};
 
-    auto pin = Internally_Pulled_Up_Input_Pin{ mcp23x08, 0b0001'0000 };
+    auto const pin = Internally_Pulled_Up_Input_Pin{ mcp23x08, 0b0001'0000 };
 
     EXPECT_CALL( mcp23x08, read_gpio() ).WillOnce( Return( test_case.gpio ) );
 


### PR DESCRIPTION
Resolves #2205 (Fix Microchip MCP23008/MCP23S08 internally pulled-up input pin automated tests pin constness).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
