### PR TITLE
Fix Microchip MCP23008/MCP23S08 open-drain I/O pin automated tests documentation

### DIFF
--- a/test/automated/picolibrary/microchip/mcp23x08/open_drain_io_pin/main.cc
+++ b/test/automated/picolibrary/microchip/mcp23x08/open_drain_io_pin/main.cc
@@ -58,7 +58,7 @@ TEST( constructorDefault, worksProperly )
 
 /**
  * \brief Verify picolibrary::Microchip::MCP23X08::Open_Drain_IO_Pin::Open_Drain_IO_Pin(
- *        Caching Driver &, std::uint8_t ) works properly.
+ *        Caching_Driver &, std::uint8_t ) works properly.
  */
 TEST( constructorCachingDriverMask, worksProperly )
 {


### PR DESCRIPTION
Resolves #2210 (Fix Microchip MCP23008/MCP23S08 open-drain I/O pin automated tests documentation).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
