### PR TITLE
Add Microchip MCP3008 input insertion operator to support automated testing

### DIFF
--- a/docs/device/microchip/mcp3008.md
+++ b/docs/device/microchip/mcp3008.md
@@ -12,6 +12,13 @@ header/source file pair.
 The `::picolibrary::Microchip::MCP3008::Input` enum class is used to identify Microchip
 MCP3008 inputs.
 
+A `std::ostream` insertion operator is defined for
+`::picolibrary::Microchip::MCP3008::Input` if the `PICOLIBRARY_ENABLE_AUTOMATED_TESTING`
+project configuration option is `ON`.
+The insertion operator is defined in the
+[`include/picolibrary/testing/automated/microchip/mcp3008.h`](https://github.com/apcountryman/picolibrary/blob/main/include/picolibrary/testing/automated/microchip/mcp3008.h)/[`source/picolibrary/testing/automated/microchip/mcp3008.cc`](https://github.com/apcountryman/picolibrary/blob/main/source/picolibrary/testing/automated/microchip/mcp3008.cc)
+header/source file pair.
+
 A `::picolibrary::Testing::Automated::random()` specialization for
 `::picolibrary::Microchip::MCP3008::Input` is available if the
 `PICOLIBRARY_ENABLE_AUTOMATED_TESTING` project configuration option is `ON`.

--- a/include/picolibrary/testing/automated/microchip/mcp3008.h
+++ b/include/picolibrary/testing/automated/microchip/mcp3008.h
@@ -38,6 +38,8 @@ namespace picolibrary::Microchip::MCP3008 {
  *
  * \param[in] stream The stream to write the picolibrary::Microchip::MCP3008::Input to.
  * \param[in] input The picolibrary::Microchip::MCP3008::Input to write to the stream.
+ *
+ * \return stream
  */
 inline auto operator<<( std::ostream & stream, Input input ) -> std::ostream &
 {

--- a/include/picolibrary/testing/automated/microchip/mcp3008.h
+++ b/include/picolibrary/testing/automated/microchip/mcp3008.h
@@ -24,10 +24,53 @@
 #define PICOLIBRARY_TESTING_AUTOMATED_MICROCHIP_MCP3008_H
 
 #include <cstdint>
+#include <ostream>
+#include <stdexcept>
 
 #include "picolibrary/microchip/mcp3008.h"
 #include "picolibrary/testing/automated/random.h"
 #include "picolibrary/testing/automated/spi.h"
+
+namespace picolibrary::Microchip::MCP3008 {
+
+/**
+ * \brief Insertion operator.
+ *
+ * \param[in] stream The stream to write the picolibrary::Microchip::MCP3008::Input to.
+ * \param[in] input The picolibrary::Microchip::MCP3008::Input to write to the stream.
+ */
+inline auto operator<<( std::ostream & stream, Input input ) -> std::ostream &
+{
+    switch ( input ) {
+            // clang-format off
+
+        case Input::CH0: return stream << "::picolibrary::Microchip::MCP3008::Input::CH0";
+        case Input::CH1: return stream << "::picolibrary::Microchip::MCP3008::Input::CH1";
+        case Input::CH2: return stream << "::picolibrary::Microchip::MCP3008::Input::CH2";
+        case Input::CH3: return stream << "::picolibrary::Microchip::MCP3008::Input::CH3";
+        case Input::CH4: return stream << "::picolibrary::Microchip::MCP3008::Input::CH4";
+        case Input::CH5: return stream << "::picolibrary::Microchip::MCP3008::Input::CH5";
+        case Input::CH6: return stream << "::picolibrary::Microchip::MCP3008::Input::CH6";
+        case Input::CH7: return stream << "::picolibrary::Microchip::MCP3008::Input::CH7";
+
+        case Input::CH0_RELATIVE_TO_CH1: return stream << "::picolibrary::Microchip::MCP3008::Input::CH0_RELATIVE_TO_CH1";
+        case Input::CH1_RELATIVE_TO_CH0: return stream << "::picolibrary::Microchip::MCP3008::Input::CH1_RELATIVE_TO_CH0";
+        case Input::CH2_RELATIVE_TO_CH3: return stream << "::picolibrary::Microchip::MCP3008::Input::CH2_RELATIVE_TO_CH3";
+        case Input::CH3_RELATIVE_TO_CH2: return stream << "::picolibrary::Microchip::MCP3008::Input::CH3_RELATIVE_TO_CH2";
+        case Input::CH4_RELATIVE_TO_CH5: return stream << "::picolibrary::Microchip::MCP3008::Input::CH4_RELATIVE_TO_CH5";
+        case Input::CH5_RELATIVE_TO_CH4: return stream << "::picolibrary::Microchip::MCP3008::Input::CH5_RELATIVE_TO_CH4";
+        case Input::CH6_RELATIVE_TO_CH7: return stream << "::picolibrary::Microchip::MCP3008::Input::CH6_RELATIVE_TO_CH7";
+        case Input::CH7_RELATIVE_TO_CH6: return stream << "::picolibrary::Microchip::MCP3008::Input::CH7_RELATIVE_TO_CH6";
+
+            // clang-format on
+    } // switch
+
+    throw std::invalid_argument{
+        "input is not a valid ::picolibrary::Microchip::MCP3008::Input"
+    };
+}
+
+} // namespace picolibrary::Microchip::MCP3008
 
 namespace picolibrary::Testing::Automated {
 

--- a/include/picolibrary/testing/automated/microchip/mcp3008.h
+++ b/include/picolibrary/testing/automated/microchip/mcp3008.h
@@ -41,6 +41,8 @@ namespace picolibrary::Microchip::MCP3008 {
  */
 inline auto operator<<( std::ostream & stream, Input input ) -> std::ostream &
 {
+    // #lizard forgives the length
+
     switch ( input ) {
             // clang-format off
 


### PR DESCRIPTION
Resolves #2212 (Add Microchip MCP3008 input insertion operator to support automated testing).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
