### PR TITLE
Explicitly set numeric base in stream insertion operators

### DIFF
--- a/include/picolibrary/testing/automated/adc.h
+++ b/include/picolibrary/testing/automated/adc.h
@@ -24,6 +24,7 @@
 #define PICOLIBRARY_TESTING_AUTOMATED_ADC_H
 
 #include <cstdint>
+#include <ios>
 #include <limits>
 #include <ostream>
 
@@ -48,7 +49,7 @@ auto operator<<( std::ostream & stream, Sample<T, N> sample ) -> std::ostream &
 {
     static_assert( N <= std::numeric_limits<std::uint_fast32_t>::digits );
 
-    return stream << static_cast<std::uint_fast32_t>( sample.as_unsigned_integer() );
+    return stream << std::dec << static_cast<std::uint_fast32_t>( sample.as_unsigned_integer() );
 }
 
 } // namespace picolibrary::ADC

--- a/include/picolibrary/testing/automated/error.h
+++ b/include/picolibrary/testing/automated/error.h
@@ -24,6 +24,7 @@
 #define PICOLIBRARY_TESTING_AUTOMATED_ERROR_H
 
 #include <cstdint>
+#include <ios>
 #include <ostream>
 #include <stdexcept>
 #include <type_traits>
@@ -102,7 +103,7 @@ enum class Mock_Error : Error_ID {};
  */
 inline auto operator<<( std::ostream & stream, Mock_Error error ) -> std::ostream &
 {
-    return stream << "::picolibrary::Testing::Automated::Mock_Error::"
+    return stream << "::picolibrary::Testing::Automated::Mock_Error::" << std::dec
                   << static_cast<std::uint_fast16_t>( error );
 }
 
@@ -186,13 +187,13 @@ struct is_error_code_enum<Testing::Automated::Mock_Error> : std::true_type {
 inline auto operator<<( std::ostream & stream, Error_Code const & error ) -> std::ostream &
 {
     if ( &error.category() == &Testing::Automated::Mock_Error_Category::instance() ) {
-        return stream << "::picolibrary::Testing::Automated::Mock_Error::"
+        return stream << "::picolibrary::Testing::Automated::Mock_Error::" << std::dec
                       << static_cast<std::uint_fast16_t>( error.id() );
     } // if
 
     if ( typeid( error.category() ) == typeid( Testing::Automated::Mock_Error_Category ) ) {
         return stream << "::picolibrary::Testing::Automated::Mock_Error( " << &error.category()
-                      << " )::" << static_cast<std::uint_fast16_t>( error.id() );
+                      << " )::" << std::dec << static_cast<std::uint_fast16_t>( error.id() );
     } // if
 
     return stream << error.category().name() << "::" << error.description();

--- a/include/picolibrary/testing/automated/event.h
+++ b/include/picolibrary/testing/automated/event.h
@@ -24,6 +24,7 @@
 #define PICOLIBRARY_TESTING_AUTOMATED_EVENT_H
 
 #include <cstddef>
+#include <ios>
 #include <ostream>
 #include <typeinfo>
 
@@ -111,13 +112,13 @@ namespace picolibrary {
 inline auto operator<<( std::ostream & stream, Event const & event ) -> std::ostream &
 {
     if ( &event.category() == &Testing::Automated::Mock_Event_Category::instance() ) {
-        return stream << "::picolibrary::Testing::Automated::Mock_Event::"
+        return stream << "::picolibrary::Testing::Automated::Mock_Event::" << std::dec
                       << static_cast<std::uint_fast16_t>( event.id() );
     } // if
 
     if ( typeid( event.category() ) == typeid( Testing::Automated::Mock_Event_Category ) ) {
         return stream << "::picolibrary::Testing::Automated::Mock_Event( " << &event.category()
-                      << " )::" << static_cast<std::uint_fast16_t>( event.id() );
+                      << " )::" << std::dec << static_cast<std::uint_fast16_t>( event.id() );
     } // if
 
     stream << event.category().name() << "::" << event.description();

--- a/include/picolibrary/testing/automated/ip.h
+++ b/include/picolibrary/testing/automated/ip.h
@@ -23,6 +23,7 @@
 #ifndef PICOLIBRARY_TESTING_AUTOMATED_IP_H
 #define PICOLIBRARY_TESTING_AUTOMATED_IP_H
 
+#include <ios>
 #include <ostream>
 #include <stdexcept>
 
@@ -74,7 +75,7 @@ inline auto operator<<( std::ostream & stream, Address const & address ) -> std:
  */
 inline auto operator<<( std::ostream & stream, Port port ) -> std::ostream &
 {
-    return stream << port.as_unsigned_integer();
+    return stream << std::dec << port.as_unsigned_integer();
 }
 
 /**

--- a/include/picolibrary/testing/automated/ipv4.h
+++ b/include/picolibrary/testing/automated/ipv4.h
@@ -24,6 +24,7 @@
 #define PICOLIBRARY_TESTING_AUTOMATED_IPV4_H
 
 #include <cstdint>
+#include <ios>
 #include <ostream>
 
 #include "picolibrary/ipv4.h"
@@ -41,10 +42,14 @@ namespace picolibrary::IPv4 {
  */
 inline auto operator<<( std::ostream & stream, Address const & address ) -> std::ostream &
 {
-    return stream << static_cast<std::uint_fast16_t>( address.as_byte_array()[ 0 ] ) << '.'
-                  << static_cast<std::uint_fast16_t>( address.as_byte_array()[ 1 ] ) << '.'
-                  << static_cast<std::uint_fast16_t>( address.as_byte_array()[ 2 ] ) << '.'
-                  << static_cast<std::uint_fast16_t>( address.as_byte_array()[ 3 ] );
+    // clang-format off
+
+    return stream << std::dec << static_cast<std::uint_fast16_t>( address.as_byte_array()[ 0 ] ) << '.'
+                  << std::dec << static_cast<std::uint_fast16_t>( address.as_byte_array()[ 1 ] ) << '.'
+                  << std::dec << static_cast<std::uint_fast16_t>( address.as_byte_array()[ 2 ] ) << '.'
+                  << std::dec << static_cast<std::uint_fast16_t>( address.as_byte_array()[ 3 ] );
+
+    // clang-format on
 }
 
 } // namespace picolibrary::IPv4

--- a/test/automated/picolibrary/adafruit/pid781/lcd_size/main.cc
+++ b/test/automated/picolibrary/adafruit/pid781/lcd_size/main.cc
@@ -21,6 +21,7 @@
  */
 
 #include <cstdint>
+#include <ios>
 #include <ostream>
 
 #include "gmock/gmock.h"
@@ -65,9 +66,9 @@ auto operator<<( std::ostream & stream, lcdSize_Test_Case const & test_case ) ->
     return stream << "{ "
                   << ".lcd_size = " << test_case.lcd_size
                   << ", "
-                  << ".columns = " << static_cast<std::uint_fast16_t>( test_case.columns )
+                  << ".columns = " << std::dec << static_cast<std::uint_fast16_t>( test_case.columns )
                   << ", "
-                  << ".rows = " << static_cast<std::uint_fast16_t>( test_case.rows )
+                  << ".rows = " << std::dec << static_cast<std::uint_fast16_t>( test_case.rows )
                   << " }";
 
     // clang-format on

--- a/test/automated/picolibrary/bit_manipulation/main.cc
+++ b/test/automated/picolibrary/bit_manipulation/main.cc
@@ -68,7 +68,7 @@ auto operator<<( std::ostream & stream, highestBitSet_Test_Case<T> const & test_
     return stream << "{ "
                   << ".value = 0b" << std::bitset<std::numeric_limits<T>::digits>{ test_case.value }
                   << ", "
-                  << ".highest_bit_set = " << static_cast<std::uint_fast16_t>( test_case.highest_bit_set )
+                  << ".highest_bit_set = " << std::dec << static_cast<std::uint_fast16_t>( test_case.highest_bit_set )
                   << " }";
 
     // clang-format on
@@ -355,9 +355,9 @@ auto operator<<( std::ostream & stream, mask_Test_Case<T> const & test_case ) ->
     // clang-format off
 
     return stream << "{ "
-                  << ".size = " << static_cast<std::uint_fast16_t>( test_case.size )
+                  << ".size = " << std::dec << static_cast<std::uint_fast16_t>( test_case.size )
                   << ", "
-                  << ".bit = " << static_cast<std::uint_fast16_t>( test_case.bit )
+                  << ".bit = " << std::dec << static_cast<std::uint_fast16_t>( test_case.bit )
                   << ", "
                   << ".mask = 0b" << std::bitset<std::numeric_limits<T>::digits>{ test_case.mask }
                   << " }";

--- a/test/automated/picolibrary/generic_error_category/main.cc
+++ b/test/automated/picolibrary/generic_error_category/main.cc
@@ -21,6 +21,7 @@
  */
 
 #include <cstdint>
+#include <ios>
 #include <ostream>
 
 #include "gmock/gmock.h"
@@ -59,7 +60,7 @@ auto operator<<( std::ostream & stream, errorDescription_Test_Case const & test_
     // clang-format off
 
     return stream << "{ "
-                  << ".id = " << static_cast<std::uint_fast16_t>( test_case.id )
+                  << ".id = " << std::dec << static_cast<std::uint_fast16_t>( test_case.id )
                   << ", "
                   << ".error_description = " << test_case.error_description
                   << " }";

--- a/test/automated/picolibrary/ip/port/main.cc
+++ b/test/automated/picolibrary/ip/port/main.cc
@@ -79,7 +79,7 @@ auto operator<<( std::ostream & stream, constructorUnsignedInteger_Test_Case con
     // clang-format off
 
     return stream << "{ "
-                  << ".port = " << test_case.port
+                  << ".port = " << std::dec << test_case.port
                   << ", "
                   << ".is_any = " << std::boolalpha << test_case.is_any
                   << " }";

--- a/test/automated/picolibrary/ipv4/address/main.cc
+++ b/test/automated/picolibrary/ipv4/address/main.cc
@@ -106,10 +106,10 @@ auto operator<<( std::ostream & stream, constructor_Test_Case const & test_case 
     // clang-format off
 
     return stream << "{ "
-                  << ".byte_array = { " << static_cast<std::uint_fast16_t>( test_case.byte_array[ 0 ] ) << ", "
-                                        << static_cast<std::uint_fast16_t>( test_case.byte_array[ 1 ] ) << ", "
-                                        << static_cast<std::uint_fast16_t>( test_case.byte_array[ 2 ] ) << ", "
-                                        << static_cast<std::uint_fast16_t>( test_case.byte_array[ 3 ] ) << " }"
+                  << ".byte_array = { " << std::dec << static_cast<std::uint_fast16_t>( test_case.byte_array[ 0 ] ) << ", "
+                                        << std::dec << static_cast<std::uint_fast16_t>( test_case.byte_array[ 1 ] ) << ", "
+                                        << std::dec << static_cast<std::uint_fast16_t>( test_case.byte_array[ 2 ] ) << ", "
+                                        << std::dec << static_cast<std::uint_fast16_t>( test_case.byte_array[ 3 ] ) << " }"
                   << ", "
                   << ".unsigned_integer = 0x" << std::hex << std::uppercase << std::setw( std::numeric_limits<Address::Unsigned_Integer>::digits / 4 ) << std::setfill( '0' ) << test_case.unsigned_integer
                   << ", "

--- a/test/automated/picolibrary/microchip/mcp3008/driver/main.cc
+++ b/test/automated/picolibrary/microchip/mcp3008/driver/main.cc
@@ -91,7 +91,7 @@ auto operator<<( std::ostream & stream, sample_Test_Case const & test_case ) -> 
                                 << "0x" << std::hex << std::uppercase << std::setw( std::numeric_limits<std::uint8_t>::digits / 4 ) << std::setfill( '0' ) << static_cast<std::uint_fast16_t>( test_case.rx[ 1 ] ) << ", "
                                 << "0x" << std::hex << std::uppercase << std::setw( std::numeric_limits<std::uint8_t>::digits / 4 ) << std::setfill( '0' ) << static_cast<std::uint_fast16_t>( test_case.rx[ 2 ] ) << " }"
                   << ", "
-                  << ".sample = " << std::dec << test_case.sample
+                  << ".sample = " << test_case.sample
                   << " }";
 
     // clang-format on


### PR DESCRIPTION
Resolves #2218 (Explicitly set numeric base in stream insertion operators).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
