### PR TITLE
Add WIZnet W5500 socket ID insertion operator to support automated testing

### DIFF
--- a/docs/device/wiznet/w5500.md
+++ b/docs/device/wiznet/w5500.md
@@ -33,6 +33,13 @@ The `::picolibrary::WIZnet::W5500::SOCKETS` constant stores the WIZnet W5500 soc
 The `::picolibrary::WIZnet::W5500::Socket_ID` enum class is used to identify WIZnet W5500
 sockets.
 
+A `std::ostream` insertion operator is defined for
+`::picolibrary::WIZnet::W5500::Socket_ID` if the `PICOLIBRARY_ENABLE_AUTOMATED_TESTING`
+project configuration option is `ON`.
+The insertion operator is defined in the
+[`include/picolibrary/testing/automated/wiznet/w5500.h`](https://github.com/apcountryman/picolibrary/blob/main/include/picolibrary/testing/automated/wiznet/w5500.h)/[`source/picolibrary/testing/automated/wiznet/w5500.cc`](https://github.com/apcountryman/picolibrary/blob/main/source/picolibrary/testing/automated/wiznet/w5500.cc)
+header/source file pair.
+
 A `::picolibrary::Testing::Automated::random()` specialization for
 `::picolibrary::WIZnet::W5500::Socket_ID` is available if the
 `PICOLIBRARY_ENABLE_AUTOMATED_TESTING` project configuration option is `ON`.

--- a/include/picolibrary/testing/automated/wiznet/w5500.h
+++ b/include/picolibrary/testing/automated/wiznet/w5500.h
@@ -25,12 +25,48 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <ostream>
+#include <stdexcept>
 #include <vector>
 
 #include "picolibrary/array.h"
 #include "picolibrary/testing/automated/random.h"
 #include "picolibrary/testing/automated/spi.h"
 #include "picolibrary/wiznet/w5500.h"
+
+namespace picolibrary::WIZnet::W5500 {
+
+/**
+ * \brief Insertion operator.
+ *
+ * \param[in] stream The stream to write the picolibrary::WIZnet::W5500::Socket_ID to.
+ * \param[in] socket_id The picolibrary::WIZnet::W5500::Socket_ID to write to the stream.
+ *
+ * \return stream
+ */
+inline auto operator<<( std::ostream & stream, Socket_ID socket_id ) -> std::ostream &
+{
+    switch ( socket_id ) {
+            // clang-format off
+
+        case Socket_ID::_0: return stream << "::picolibrary::WIZnet::W5500::Socket_ID::_0";
+        case Socket_ID::_1: return stream << "::picolibrary::WIZnet::W5500::Socket_ID::_1";
+        case Socket_ID::_2: return stream << "::picolibrary::WIZnet::W5500::Socket_ID::_2";
+        case Socket_ID::_3: return stream << "::picolibrary::WIZnet::W5500::Socket_ID::_3";
+        case Socket_ID::_4: return stream << "::picolibrary::WIZnet::W5500::Socket_ID::_4";
+        case Socket_ID::_5: return stream << "::picolibrary::WIZnet::W5500::Socket_ID::_5";
+        case Socket_ID::_6: return stream << "::picolibrary::WIZnet::W5500::Socket_ID::_6";
+        case Socket_ID::_7: return stream << "::picolibrary::WIZnet::W5500::Socket_ID::_7";
+
+            // clang-format on
+    } // switch
+
+    throw std::invalid_argument{
+        "socket_id is not a valid ::picolibrary::WIZnet::W5500::Socket_ID"
+    };
+}
+
+} // namespace picolibrary::WIZnet::W5500
 
 namespace picolibrary::Testing::Automated {
 


### PR DESCRIPTION
Resolves #2234 (Add WIZnet W5500 socket ID insertion operator to support automated testing).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
