### PR TITLE
Add WIZnet W5500 socket memory block insertion operator to support automated testing

### DIFF
--- a/docs/device/wiznet/w5500.md
+++ b/docs/device/wiznet/w5500.md
@@ -7,6 +7,7 @@ header/source file pair.
 1. [Control Byte Information](#control-byte-information)
 1. [Socket Count](#socket-count)
 1. [Socket Identification](#socket-identification)
+1. [Socket Memory Block Identification](#socket-memory-block-identification)
 1. [Communication Controller](#communication-controller)
 1. [Register Information](#register-information)
 1. [Driver](#driver)
@@ -44,6 +45,17 @@ A `::picolibrary::Testing::Automated::random()` specialization for
 `::picolibrary::WIZnet::W5500::Socket_ID` is available if the
 `PICOLIBRARY_ENABLE_AUTOMATED_TESTING` project configuration option is `ON`.
 The specialization is defined in the
+[`include/picolibrary/testing/automated/wiznet/w5500.h`](https://github.com/apcountryman/picolibrary/blob/main/include/picolibrary/testing/automated/wiznet/w5500.h)/[`source/picolibrary/testing/automated/wiznet/w5500.cc`](https://github.com/apcountryman/picolibrary/blob/main/source/picolibrary/testing/automated/wiznet/w5500.cc)
+header/source file pair.
+
+## Socket Memory Block Identification
+The `::picolibrary::WIZnet::W5500::Socket_Memory_Block` enum class is used to identify
+WIZnet W5500 socket memory blocks.
+
+A `std::ostream` insertion operator is defined for
+`::picolibrary::WIZnet::W5500::Socket_Memory_Block` if the
+`PICOLIBRARY_ENABLE_AUTOMATED_TESTING` project configuration option is `ON`.
+The insertion operator is defined in the
 [`include/picolibrary/testing/automated/wiznet/w5500.h`](https://github.com/apcountryman/picolibrary/blob/main/include/picolibrary/testing/automated/wiznet/w5500.h)/[`source/picolibrary/testing/automated/wiznet/w5500.cc`](https://github.com/apcountryman/picolibrary/blob/main/source/picolibrary/testing/automated/wiznet/w5500.cc)
 header/source file pair.
 

--- a/include/picolibrary/testing/automated/wiznet/w5500.h
+++ b/include/picolibrary/testing/automated/wiznet/w5500.h
@@ -66,6 +66,35 @@ inline auto operator<<( std::ostream & stream, Socket_ID socket_id ) -> std::ost
     };
 }
 
+/**
+ * \brief Insertion operator.
+ *
+ * \param[in] stream The stream to write the
+ *            picolibrary::WIZnet::W5500::Socket_Memory_Block to.
+ * \param[in] socket_memory_block The picolibrary::WIZnet::W5500::Socket_Memory_Block to
+ *            write to the stream.
+ *
+ * \return stream
+ */
+inline auto operator<<( std::ostream & stream, Socket_Memory_Block socket_memory_block )
+    -> std::ostream &
+{
+    switch ( socket_memory_block ) {
+            // clang-format off
+
+        case Socket_Memory_Block::REGISTERS: return stream << "::picolibrary::WIZnet::W5500::Socket_Memory_Block::REGISTERS";
+        case Socket_Memory_Block::TX_BUFFER: return stream << "::picolibrary::WIZnet::W5500::Socket_Memory_Block::TX_BUFFER";
+        case Socket_Memory_Block::RX_BUFFER: return stream << "::picolibrary::WIZnet::W5500::Socket_Memory_Block::RX_BUFFER";
+
+            // clang-format on
+    } // switch
+
+    throw std::invalid_argument{
+        "socket_memory_block is not a valid "
+        "::picolibrary::WIZnet::W5500::Socket_Memory_Block"
+    };
+}
+
 } // namespace picolibrary::WIZnet::W5500
 
 namespace picolibrary::Testing::Automated {


### PR DESCRIPTION
Resolves #2235 (Add WIZnet W5500 socket memory block insertion operator to support automated testing).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
