### PR TITLE
Add WIZnet W5500 ARP forcing configuration insertion operator to support automated testing

### DIFF
--- a/docs/definitions.md
+++ b/docs/definitions.md
@@ -1,5 +1,6 @@
 ## Definitions
 - ADC: Analog-to-Digital Converter
+- ARP: Address Resolution Protocol
 - CRC: Cyclic Redundancy Check
 - GPIO: General Purpose Input/Output
 - HIL: Hardware Interface Layer

--- a/docs/device/wiznet/w5500.md
+++ b/docs/device/wiznet/w5500.md
@@ -11,6 +11,7 @@ header/source file pair.
 1. [Communication Controller](#communication-controller)
 1. [Register Information](#register-information)
 1. [Driver](#driver)
+1. [ARP Forcing Configuration Identification](#arp-forcing-configuration-identification)
 1. [Interrupt Masks](#interrupt-masks)
 
 ## Control Byte Information
@@ -312,6 +313,17 @@ The `::picolibrary::Testing::Automated::WIZnet::W5500::Mock_Driver` mock WIZnet 
 driver class is available if the `PICOLIBRARY_ENABLE_AUTOMATED_TESTING` project
 configuration option is `ON`.
 The mock is defined in the
+[`include/picolibrary/testing/automated/wiznet/w5500.h`](https://github.com/apcountryman/picolibrary/blob/main/include/picolibrary/testing/automated/wiznet/w5500.h)/[`source/picolibrary/testing/automated/wiznet/w5500.cc`](https://github.com/apcountryman/picolibrary/blob/main/source/picolibrary/testing/automated/wiznet/w5500.cc)
+header/source file pair.
+
+## ARP Forcing Configuration Identification
+The `::picolibrary::WIZnet::W5500::ARP_Forcing` enum class is used to identify WIZnet
+W5500 ARP forcing configurations.
+
+A `std::ostream` insertion operator is defined for
+`::picolibrary::WIZnet::W5500::ARP_Forcing` if the `PICOLIBRARY_ENABLE_AUTOMATED_TESTING`
+project configuration option is `ON`.
+The insertion operator is defined in the
 [`include/picolibrary/testing/automated/wiznet/w5500.h`](https://github.com/apcountryman/picolibrary/blob/main/include/picolibrary/testing/automated/wiznet/w5500.h)/[`source/picolibrary/testing/automated/wiznet/w5500.cc`](https://github.com/apcountryman/picolibrary/blob/main/source/picolibrary/testing/automated/wiznet/w5500.cc)
 header/source file pair.
 

--- a/include/picolibrary/testing/automated/wiznet/w5500.h
+++ b/include/picolibrary/testing/automated/wiznet/w5500.h
@@ -95,6 +95,32 @@ inline auto operator<<( std::ostream & stream, Socket_Memory_Block socket_memory
     };
 }
 
+/**
+ * \brief Insertion operator.
+ *
+ * \param[in] stream The stream to write the picolibrary::WIZnet::W5500::ARP_Forcing to.
+ * \param[in] arp_forcing_configuration The picolibrary::WIZnet::W5500::ARP_Forcing to
+ *            write to the stream.
+ *
+ * \return stream
+ */
+inline auto operator<<( std::ostream & stream, ARP_Forcing arp_forcing_configuration ) -> std::ostream &
+{
+    switch ( arp_forcing_configuration ) {
+            // clang-format off
+
+        case ARP_Forcing::DISABLED: return stream << "::picolibrary::WIZnet::W5500::ARP_Forcing::DISABLED";
+        case ARP_Forcing::ENABLED:  return stream << "::picolibrary::WIZnet::W5500::ARP_Forcing::ENABLED";
+
+            // clang-format on
+    } // switch
+
+    throw std::invalid_argument{
+        "arp_forcing_configuration is not a valid "
+        "::picolibrary::WIZnet::W5500::ARP_Forcing"
+    };
+}
+
 } // namespace picolibrary::WIZnet::W5500
 
 namespace picolibrary::Testing::Automated {


### PR DESCRIPTION
Resolves #2242 (Add WIZnet W5500 ARP forcing configuration insertion operator to support automated testing).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
