### PR TITLE
Split WIZnet W5500 interrupt masks and socket interrupt masks documentation

### DIFF
--- a/docs/device/wiznet/w5500.md
+++ b/docs/device/wiznet/w5500.md
@@ -13,6 +13,7 @@ header/source file pair.
 1. [Driver](#driver)
 1. [ARP Forcing Configuration Identification](#arp-forcing-configuration-identification)
 1. [Interrupt Masks](#interrupt-masks)
+1. [Socket Interrupt Masks](#socket-interrupt-masks)
 
 ## Control Byte Information
 WIZnet W5500 control byte information is defined in the
@@ -331,5 +332,6 @@ header/source file pair.
 WIZnet W5500 interrupt masks are defined in the `::picolibrary::WIZnet::W5500::Interrupt`
 structure.
 
+## Socket Interrupt Masks
 WIZnet W5500 socket interrupt masks are defined in the
 `::picolibrary::WIZnet::W5500::Socket_Interrupt` structure.


### PR DESCRIPTION
Resolves #2252 (Split WIZnet W5500 interrupt masks and socket interrupt masks documentation).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
