### PR TITLE
Add WIZnet W5500 ping blocking configuration insertion operator to support automated testing

### DIFF
--- a/docs/device/wiznet/w5500.md
+++ b/docs/device/wiznet/w5500.md
@@ -12,6 +12,7 @@ header/source file pair.
 1. [Register Information](#register-information)
 1. [Driver](#driver)
 1. [ARP Forcing Configuration Identification](#arp-forcing-configuration-identification)
+1. [Ping Blocking Configuration Identification](#ping-blocking-configuration-identification)
 1. [Interrupt Masks](#interrupt-masks)
 1. [Socket Interrupt Masks](#socket-interrupt-masks)
 
@@ -324,6 +325,17 @@ W5500 ARP forcing configurations.
 A `std::ostream` insertion operator is defined for
 `::picolibrary::WIZnet::W5500::ARP_Forcing` if the `PICOLIBRARY_ENABLE_AUTOMATED_TESTING`
 project configuration option is `ON`.
+The insertion operator is defined in the
+[`include/picolibrary/testing/automated/wiznet/w5500.h`](https://github.com/apcountryman/picolibrary/blob/main/include/picolibrary/testing/automated/wiznet/w5500.h)/[`source/picolibrary/testing/automated/wiznet/w5500.cc`](https://github.com/apcountryman/picolibrary/blob/main/source/picolibrary/testing/automated/wiznet/w5500.cc)
+header/source file pair.
+
+## Ping Blocking Configuration Identification
+The `::picolibrary::WIZnet::W5500::Ping_Blocking` enum class is used to identify WIZnet
+W5500 Ping blocking configurations.
+
+A `std::ostream` insertion operator is defined for
+`::picolibrary::WIZnet::W5500::Ping_Blocking` if the
+`PICOLIBRARY_ENABLE_AUTOMATED_TESTING` project configuration option is `ON`.
 The insertion operator is defined in the
 [`include/picolibrary/testing/automated/wiznet/w5500.h`](https://github.com/apcountryman/picolibrary/blob/main/include/picolibrary/testing/automated/wiznet/w5500.h)/[`source/picolibrary/testing/automated/wiznet/w5500.cc`](https://github.com/apcountryman/picolibrary/blob/main/source/picolibrary/testing/automated/wiznet/w5500.cc)
 header/source file pair.

--- a/include/picolibrary/testing/automated/wiznet/w5500.h
+++ b/include/picolibrary/testing/automated/wiznet/w5500.h
@@ -121,6 +121,33 @@ inline auto operator<<( std::ostream & stream, ARP_Forcing arp_forcing_configura
     };
 }
 
+/**
+ * \brief Insertion operator.
+ *
+ * \param[in] stream The stream to write the picolibrary::WIZnet::W5500::Ping_Blocking to.
+ * \param[in] ping_blocking_configuration The picolibrary::WIZnet::W5500::Ping_Blocking to
+ *            write to the stream.
+ *
+ * \return stream
+ */
+inline auto operator<<( std::ostream & stream, Ping_Blocking ping_blocking_configuration )
+    -> std::ostream &
+{
+    switch ( ping_blocking_configuration ) {
+            // clang-format off
+
+        case Ping_Blocking::DISABLED: return stream << "::picolibrary::WIZnet::W5500::Ping_Blocking::DISABLED";
+        case Ping_Blocking::ENABLED:  return stream << "::picolibrary::WIZnet::W5500::Ping_Blocking::ENABLED";
+
+            // clang-format on
+    } // switch
+
+    throw std::invalid_argument{
+        "ping_blocking_configuration is not a valid "
+        "::picolibrary::WIZnet::W5500::Ping_Blocking"
+    };
+}
+
 } // namespace picolibrary::WIZnet::W5500
 
 namespace picolibrary::Testing::Automated {


### PR DESCRIPTION
Resolves #2243 (Add WIZnet W5500 ping blocking configuration insertion operator to support automated testing).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
