### PR TITLE
Add WIZnet W5500 PHY mode insertion operator to support automated testing

### DIFF
--- a/docs/device/wiznet/w5500.md
+++ b/docs/device/wiznet/w5500.md
@@ -14,6 +14,7 @@ header/source file pair.
 1. [ARP Forcing Configuration Identification](#arp-forcing-configuration-identification)
 1. [Ping Blocking Configuration Identification](#ping-blocking-configuration-identification)
 1. [Interrupt Masks](#interrupt-masks)
+1. [PHY Mode Identification](#phy-mode-identification)
 1. [Socket Interrupt Masks](#socket-interrupt-masks)
 
 ## Control Byte Information
@@ -343,6 +344,17 @@ header/source file pair.
 ## Interrupt Masks
 WIZnet W5500 interrupt masks are defined in the `::picolibrary::WIZnet::W5500::Interrupt`
 structure.
+
+## PHY Mode Identification
+The `::picolibrary::WIZnet::W5500::PHY_Mode` enum class is used to identify WIZnet W5500
+PHY modes.
+
+A `std::ostream` insertion operator is defined for
+`::picolibrary::WIZnet::W5500::PHY_Mode` if the `PICOLIBRARY_ENABLE_AUTOMATED_TESTING`
+project configuration option is `ON`.
+The insertion operator is defined in the
+[`include/picolibrary/testing/automated/wiznet/w5500.h`](https://github.com/apcountryman/picolibrary/blob/main/include/picolibrary/testing/automated/wiznet/w5500.h)/[`source/picolibrary/testing/automated/wiznet/w5500.cc`](https://github.com/apcountryman/picolibrary/blob/main/source/picolibrary/testing/automated/wiznet/w5500.cc)
+header/source file pair.
 
 ## Socket Interrupt Masks
 WIZnet W5500 socket interrupt masks are defined in the

--- a/include/picolibrary/testing/automated/wiznet/w5500.h
+++ b/include/picolibrary/testing/automated/wiznet/w5500.h
@@ -152,8 +152,7 @@ inline auto operator<<( std::ostream & stream, Ping_Blocking ping_blocking_confi
  * \brief Insertion operator.
  *
  * \param[in] stream The stream to write the picolibrary::WIZnet::W5500::PHY_Mode to.
- * \param[in] phy_blocking_configuration The picolibrary::WIZnet::W5500::PHY_Mode to write
- *            to the stream.
+ * \param[in] phy_mode The picolibrary::WIZnet::W5500::PHY_Mode to write to the stream.
  *
  * \return stream
  */

--- a/include/picolibrary/testing/automated/wiznet/w5500.h
+++ b/include/picolibrary/testing/automated/wiznet/w5500.h
@@ -148,6 +148,37 @@ inline auto operator<<( std::ostream & stream, Ping_Blocking ping_blocking_confi
     };
 }
 
+/**
+ * \brief Insertion operator.
+ *
+ * \param[in] stream The stream to write the picolibrary::WIZnet::W5500::PHY_Mode to.
+ * \param[in] phy_blocking_configuration The picolibrary::WIZnet::W5500::PHY_Mode to write
+ *            to the stream.
+ *
+ * \return stream
+ */
+inline auto operator<<( std::ostream & stream, PHY_Mode phy_mode ) -> std::ostream &
+{
+    switch ( phy_mode ) {
+            // clang-format off
+
+        case PHY_Mode::CONFIGURED_BY_HARDWARE:                       return stream << "::picolibrary::WIZnet::W5500::PHY_Mode::CONFIGURED_BY_HARDWARE";
+        case PHY_Mode::POWER_DOWN:                                   return stream << "::picolibrary::WIZnet::W5500::PHY_Mode::POWER_DOWN";
+        case PHY_Mode::_10BT_HALF_DUPLEX_AUTO_NEGOTIATION_DISABLED:  return stream << "::picolibrary::WIZnet::W5500::PHY_Mode::_10BT_HALF_DUPLEX_AUTO_NEGOTIATION_DISABLED";
+        case PHY_Mode::_10BT_FULL_DUPLEX_AUTO_NEGOTIATION_DISABLED:  return stream << "::picolibrary::WIZnet::W5500::PHY_Mode::_10BT_FULL_DUPLEX_AUTO_NEGOTIATION_DISABLED";
+        case PHY_Mode::_100BT_HALF_DUPLEX_AUTO_NEGOTIATION_DISABLED: return stream << "::picolibrary::WIZnet::W5500::PHY_Mode::_100BT_HALF_DUPLEX_AUTO_NEGOTIATION_DISABLED";
+        case PHY_Mode::_100BT_FULL_DUPLEX_AUTO_NEGOTIATION_DISABLED: return stream << "::picolibrary::WIZnet::W5500::PHY_Mode::_100BT_FULL_DUPLEX_AUTO_NEGOTIATION_DISABLED";
+        case PHY_Mode::_100BT_HALF_DUPLEX_AUTO_NEGOTIATION_ENABLED:  return stream << "::picolibrary::WIZnet::W5500::PHY_Mode::_100BT_HALF_DUPLEX_AUTO_NEGOTIATION_ENABLED";
+        case PHY_Mode::ALL_CAPABLE_AUTO_NEGOTIATION_ENABLED:         return stream << "::picolibrary::WIZnet::W5500::PHY_Mode::ALL_CAPABLE_AUTO_NEGOTIATION_ENABLED";
+
+            // clang-format on
+    } // switch
+
+    throw std::invalid_argument{
+        "phy_mode is not a valid ::picolibrary::WIZnet::W5500::PHY_Mode"
+    };
+}
+
 } // namespace picolibrary::WIZnet::W5500
 
 namespace picolibrary::Testing::Automated {


### PR DESCRIPTION
Resolves #2244 (Add WIZnet W5500 PHY mode insertion operator to support automated testing).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
