### PR TITLE
Add WIZnet W5500 link status insertion operator to support automated testing

### DIFF
--- a/docs/device/wiznet/w5500.md
+++ b/docs/device/wiznet/w5500.md
@@ -15,6 +15,7 @@ header/source file pair.
 1. [Ping Blocking Configuration Identification](#ping-blocking-configuration-identification)
 1. [Interrupt Masks](#interrupt-masks)
 1. [PHY Mode Identification](#phy-mode-identification)
+1. [Link Status Identification](#link-status-identification)
 1. [Socket Interrupt Masks](#socket-interrupt-masks)
 
 ## Control Byte Information
@@ -351,6 +352,17 @@ PHY modes.
 
 A `std::ostream` insertion operator is defined for
 `::picolibrary::WIZnet::W5500::PHY_Mode` if the `PICOLIBRARY_ENABLE_AUTOMATED_TESTING`
+project configuration option is `ON`.
+The insertion operator is defined in the
+[`include/picolibrary/testing/automated/wiznet/w5500.h`](https://github.com/apcountryman/picolibrary/blob/main/include/picolibrary/testing/automated/wiznet/w5500.h)/[`source/picolibrary/testing/automated/wiznet/w5500.cc`](https://github.com/apcountryman/picolibrary/blob/main/source/picolibrary/testing/automated/wiznet/w5500.cc)
+header/source file pair.
+
+## Link Status Identification
+The `::picolibrary::WIZnet::W5500::Link_Status` enum class is used to identify WIZnet
+W5500 link statuses.
+
+A `std::ostream` insertion operator is defined for
+`::picolibrary::WIZnet::W5500::Link_Status` if the `PICOLIBRARY_ENABLE_AUTOMATED_TESTING`
 project configuration option is `ON`.
 The insertion operator is defined in the
 [`include/picolibrary/testing/automated/wiznet/w5500.h`](https://github.com/apcountryman/picolibrary/blob/main/include/picolibrary/testing/automated/wiznet/w5500.h)/[`source/picolibrary/testing/automated/wiznet/w5500.cc`](https://github.com/apcountryman/picolibrary/blob/main/source/picolibrary/testing/automated/wiznet/w5500.cc)

--- a/include/picolibrary/testing/automated/wiznet/w5500.h
+++ b/include/picolibrary/testing/automated/wiznet/w5500.h
@@ -178,6 +178,31 @@ inline auto operator<<( std::ostream & stream, PHY_Mode phy_mode ) -> std::ostre
     };
 }
 
+/**
+ * \brief Insertion operator.
+ *
+ * \param[in] stream The stream to write the picolibrary::WIZnet::W5500::Link_Status to.
+ * \param[in] link_status The picolibrary::WIZnet::W5500::Link_Status to write to the
+ *            stream.
+ *
+ * \return stream
+ */
+inline auto operator<<( std::ostream & stream, Link_Status link_status ) -> std::ostream &
+{
+    switch ( link_status ) {
+            // clang-format off
+
+        case Link_Status::DOWN: return stream << "::picolibrary::WIZnet::W5500::Link_Status::DOWN";
+        case Link_Status::UP:   return stream << "::picolibrary::WIZnet::W5500::Link_Status::UP";
+
+            // clang-format on
+    } // switch
+
+    throw std::invalid_argument{
+        "link_status is not a valid ::picolibrary::WIZnet::W5500::Link_Status"
+    };
+}
+
 } // namespace picolibrary::WIZnet::W5500
 
 namespace picolibrary::Testing::Automated {


### PR DESCRIPTION
Resolves #2245 (Add WIZnet W5500 link status insertion operator to support automated testing).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
