### PR TITLE
Add WIZnet W5500 link speed insertion operator to support automated testing

### DIFF
--- a/docs/device/wiznet/w5500.md
+++ b/docs/device/wiznet/w5500.md
@@ -17,6 +17,7 @@ header/source file pair.
 1. [PHY Mode Identification](#phy-mode-identification)
 1. [Link Status Identification](#link-status-identification)
 1. [Link Mode Identification](#link-mode-identification)
+1. [Link Speed Identification](#link-speed-identification)
 1. [Socket Interrupt Masks](#socket-interrupt-masks)
 
 ## Control Byte Information
@@ -375,6 +376,17 @@ link modes.
 
 A `std::ostream` insertion operator is defined for
 `::picolibrary::WIZnet::W5500::Link_Mode` if the `PICOLIBRARY_ENABLE_AUTOMATED_TESTING`
+project configuration option is `ON`.
+The insertion operator is defined in the
+[`include/picolibrary/testing/automated/wiznet/w5500.h`](https://github.com/apcountryman/picolibrary/blob/main/include/picolibrary/testing/automated/wiznet/w5500.h)/[`source/picolibrary/testing/automated/wiznet/w5500.cc`](https://github.com/apcountryman/picolibrary/blob/main/source/picolibrary/testing/automated/wiznet/w5500.cc)
+header/source file pair.
+
+## Link Speed Identification
+The `::picolibrary::WIZnet::W5500::Link_Speed` enum class is used to identify WIZnet W5500
+link speeds.
+
+A `std::ostream` insertion operator is defined for
+`::picolibrary::WIZnet::W5500::Link_Speed` if the `PICOLIBRARY_ENABLE_AUTOMATED_TESTING`
 project configuration option is `ON`.
 The insertion operator is defined in the
 [`include/picolibrary/testing/automated/wiznet/w5500.h`](https://github.com/apcountryman/picolibrary/blob/main/include/picolibrary/testing/automated/wiznet/w5500.h)/[`source/picolibrary/testing/automated/wiznet/w5500.cc`](https://github.com/apcountryman/picolibrary/blob/main/source/picolibrary/testing/automated/wiznet/w5500.cc)

--- a/include/picolibrary/testing/automated/wiznet/w5500.h
+++ b/include/picolibrary/testing/automated/wiznet/w5500.h
@@ -227,6 +227,31 @@ inline auto operator<<( std::ostream & stream, Link_Mode link_mode ) -> std::ost
     };
 }
 
+/**
+ * \brief Insertion operator.
+ *
+ * \param[in] stream The stream to write the picolibrary::WIZnet::W5500::Link_Speed to.
+ * \param[in] link_speed The picolibrary::WIZnet::W5500::Link_Speed to write to the
+ *            stream.
+ *
+ * \return stream
+ */
+inline auto operator<<( std::ostream & stream, Link_Speed link_speed ) -> std::ostream &
+{
+    switch ( link_speed ) {
+            // clang-format off
+
+        case Link_Speed::_10_MbPs:  return stream << "::picolibrary::WIZnet::W5500::Link_Speed::_10_MbPs";
+        case Link_Speed::_100_MbPs: return stream << "::picolibrary::WIZnet::W5500::Link_Speed::_100_MbPs";
+
+            // clang-format on
+    } // switch
+
+    throw std::invalid_argument{
+        "link_speed is not a valid ::picolibrary::WIZnet::W5500::Link_Speed"
+    };
+}
+
 } // namespace picolibrary::WIZnet::W5500
 
 namespace picolibrary::Testing::Automated {


### PR DESCRIPTION
Resolves #2247 (Add WIZnet W5500 link speed insertion operator to support automated testing).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
