### PR TITLE
Add WIZnet W5500 no delayed ACK usage configuration insertion operator to support automated testing

### DIFF
--- a/docs/device/wiznet/w5500.md
+++ b/docs/device/wiznet/w5500.md
@@ -18,6 +18,7 @@ header/source file pair.
 1. [Link Status Identification](#link-status-identification)
 1. [Link Mode Identification](#link-mode-identification)
 1. [Link Speed Identification](#link-speed-identification)
+1. [No Delayed ACK Usage Configuration Identification](#no-delayed-ack-usage-configuration-identification)
 1. [Socket Interrupt Masks](#socket-interrupt-masks)
 
 ## Control Byte Information
@@ -388,6 +389,17 @@ link speeds.
 A `std::ostream` insertion operator is defined for
 `::picolibrary::WIZnet::W5500::Link_Speed` if the `PICOLIBRARY_ENABLE_AUTOMATED_TESTING`
 project configuration option is `ON`.
+The insertion operator is defined in the
+[`include/picolibrary/testing/automated/wiznet/w5500.h`](https://github.com/apcountryman/picolibrary/blob/main/include/picolibrary/testing/automated/wiznet/w5500.h)/[`source/picolibrary/testing/automated/wiznet/w5500.cc`](https://github.com/apcountryman/picolibrary/blob/main/source/picolibrary/testing/automated/wiznet/w5500.cc)
+header/source file pair.
+
+## No Delayed ACK Usage Configuration Identification
+The `::picolibrary::WIZnet::W5500::No_Delayed_ACK_Usage` enum class is used to identify
+WIZnet W5500 no delayed ACK usage configurations.
+
+A `std::ostream` insertion operator is defined for
+`::picolibrary::WIZnet::W5500::No_Delayed_ACK_Usage` if the
+`PICOLIBRARY_ENABLE_AUTOMATED_TESTING` project configuration option is `ON`.
 The insertion operator is defined in the
 [`include/picolibrary/testing/automated/wiznet/w5500.h`](https://github.com/apcountryman/picolibrary/blob/main/include/picolibrary/testing/automated/wiznet/w5500.h)/[`source/picolibrary/testing/automated/wiznet/w5500.cc`](https://github.com/apcountryman/picolibrary/blob/main/source/picolibrary/testing/automated/wiznet/w5500.cc)
 header/source file pair.

--- a/include/picolibrary/testing/automated/wiznet/w5500.h
+++ b/include/picolibrary/testing/automated/wiznet/w5500.h
@@ -252,6 +252,34 @@ inline auto operator<<( std::ostream & stream, Link_Speed link_speed ) -> std::o
     };
 }
 
+/**
+ * \brief Insertion operator.
+ *
+ * \param[in] stream The stream to write the
+ *            picolibrary::WIZnet::W5500::No_Delayed_ACK_Usage to.
+ * \param[in] no_delayed_ack_usage_configuration The
+ *            picolibrary::WIZnet::W5500::No_Delayed_ACK_Usage to write to the stream.
+ *
+ * \return stream
+ */
+inline auto operator<<( std::ostream & stream, No_Delayed_ACK_Usage no_delayed_ack_usage_configuration )
+    -> std::ostream &
+{
+    switch ( no_delayed_ack_usage_configuration ) {
+            // clang-format off
+
+        case No_Delayed_ACK_Usage::DISABLED: return stream << "::picolibrary::WIZnet::W5500::No_Delayed_ACK_Usage::DISABLED";
+        case No_Delayed_ACK_Usage::ENABLED:  return stream << "::picolibrary::WIZnet::W5500::No_Delayed_ACK_Usage::ENABLED";
+
+            // clang-format on
+    } // switch
+
+    throw std::invalid_argument{
+        "no_delayed_ack_usage_configuration is not a valid "
+        "::picolibrary::WIZnet::W5500::No_Delayed_ACK_Usage"
+    };
+}
+
 } // namespace picolibrary::WIZnet::W5500
 
 namespace picolibrary::Testing::Automated {


### PR DESCRIPTION
Resolves #2248 (Add WIZnet W5500 no delayed ACK usage configuration insertion operator to support automated testing).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
