### PR TITLE
Add WIZnet W5500 socket buffer size insertion operator to support automated testing

### DIFF
--- a/docs/device/wiznet/w5500.md
+++ b/docs/device/wiznet/w5500.md
@@ -20,6 +20,7 @@ header/source file pair.
 1. [Link Speed Identification](#link-speed-identification)
 1. [No Delayed ACK Usage Configuration Identification](#no-delayed-ack-usage-configuration-identification)
 1. [Socket Interrupt Masks](#socket-interrupt-masks)
+1. [Socket Buffer Size Identification](#socket-buffer-size-identification)
 
 ## Control Byte Information
 WIZnet W5500 control byte information is defined in the
@@ -407,3 +408,14 @@ header/source file pair.
 ## Socket Interrupt Masks
 WIZnet W5500 socket interrupt masks are defined in the
 `::picolibrary::WIZnet::W5500::Socket_Interrupt` structure.
+
+## Socket Buffer Size Identification
+The `::picolibrary::WIZnet::W5500::Socket_Buffer_Size` enum class is used to identify
+WIZnet W5500 socket buffer sizes.
+
+A `std::ostream` insertion operator is defined for
+`::picolibrary::WIZnet::W5500::Socket_Buffer_Size` if the
+`PICOLIBRARY_ENABLE_AUTOMATED_TESTING` project configuration option is `ON`.
+The insertion operator is defined in the
+[`include/picolibrary/testing/automated/wiznet/w5500.h`](https://github.com/apcountryman/picolibrary/blob/main/include/picolibrary/testing/automated/wiznet/w5500.h)/[`source/picolibrary/testing/automated/wiznet/w5500.cc`](https://github.com/apcountryman/picolibrary/blob/main/source/picolibrary/testing/automated/wiznet/w5500.cc)
+header/source file pair.

--- a/include/picolibrary/testing/automated/wiznet/w5500.h
+++ b/include/picolibrary/testing/automated/wiznet/w5500.h
@@ -280,6 +280,37 @@ inline auto operator<<( std::ostream & stream, No_Delayed_ACK_Usage no_delayed_a
     };
 }
 
+/**
+ * \brief Insertion operator.
+ *
+ * \param[in] stream The stream to write the
+ *            picolibrary::WIZnet::W5500::Socket_Buffer_Size to.
+ * \param[in] socket_buffer_size The picolibrary::WIZnet::W5500::Socket_Buffer_Size to
+ *            write to the stream.
+ *
+ * \return stream
+ */
+inline auto operator<<( std::ostream & stream, Socket_Buffer_Size socket_buffer_size ) -> std::ostream &
+{
+    switch ( socket_buffer_size ) {
+            // clang-format off
+
+        case Socket_Buffer_Size::_0_KiB:  return stream << "::picolibrary::WIZnet::W5500::Socket_Buffer_Size::_0_KiB";
+        case Socket_Buffer_Size::_1_KiB:  return stream << "::picolibrary::WIZnet::W5500::Socket_Buffer_Size::_1_KiB";
+        case Socket_Buffer_Size::_2_KiB:  return stream << "::picolibrary::WIZnet::W5500::Socket_Buffer_Size::_2_KiB";
+        case Socket_Buffer_Size::_4_KiB:  return stream << "::picolibrary::WIZnet::W5500::Socket_Buffer_Size::_4_KiB";
+        case Socket_Buffer_Size::_8_KiB:  return stream << "::picolibrary::WIZnet::W5500::Socket_Buffer_Size::_8_KiB";
+        case Socket_Buffer_Size::_16_KiB: return stream << "::picolibrary::WIZnet::W5500::Socket_Buffer_Size::_16_KiB";
+
+            // clang-format on
+    } // switch
+
+    throw std::invalid_argument{
+        "socket_buffer_size is not a valid "
+        "::picolibrary::WIZnet::W5500::Socket_Buffer_Size"
+    };
+}
+
 } // namespace picolibrary::WIZnet::W5500
 
 namespace picolibrary::Testing::Automated {


### PR DESCRIPTION
Resolves #2249 (Add WIZnet W5500 socket buffer size insertion operator to support automated testing).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
