### PR TITLE
Use error code insertion operator in automated testing trap fatal error implementation

### DIFF
--- a/source/picolibrary/testing/automated/fatal_error.cc
+++ b/source/picolibrary/testing/automated/fatal_error.cc
@@ -27,21 +27,21 @@
 
 #include "picolibrary/error.h"
 #include "picolibrary/rom.h"
+#include "picolibrary/testing/automated/error.h"
 
 namespace picolibrary {
 
 #ifndef PICOLIBRARY_SUPPRESS_ASSERTION_FAILURE_LOCATION_INFORMATION
 void trap_fatal_error( ROM::String file, int line, Error_Code const & error ) noexcept
 {
-    std::cerr << file << ':' << line << ": " << error.category().name()
-              << "::" << error.description() << '\n';
+    std::cerr << file << ':' << line << ": " << error << '\n';
 
     std::abort();
 }
 #else  // PICOLIBRARY_SUPPRESS_ASSERTION_FAILURE_LOCATION_INFORMATION
 void trap_fatal_error( Error_Code const & error ) noexcept
 {
-    std::cerr << error.category().name() << "::" << error.description() << '\n';
+    std::cerr << error << '\n';
 
     std::abort();
 }


### PR DESCRIPTION
Resolves #2268 (Use error code insertion operator in automated testing trap fatal error implementation).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
