### PR TITLE
Fix missing Adafruit PID781 LCD size automated tests documentation

### DIFF
--- a/docs/device/adafruit/pid781.md
+++ b/docs/device/adafruit/pid781.md
@@ -25,6 +25,10 @@ The `::picolibrary::Adafruit::PID781::LCD_Size` enum class is used to identify L
 - To get the number of rows an LCD has, use the `::picolibrary::Adafruit::PID781::rows()`
   function.
 
+`::picolibrary::Adafruit::PID781::LCD_Size` automated tests are defined in the
+[`test/automated/picolibrary/adafruit/pid781/lcd_size/main.cc`](https://github.com/apcountryman/picolibrary/blob/main/test/automated/picolibrary/adafruit/pid781/lcd_size/main.cc)
+source file.
+
 A `std::ostream` insertion operator is defined for
 `::picolibrary::Adafruit::PID781::LCD_Size` if the `PICOLIBRARY_ENABLE_AUTOMATED_TESTING`
 project configuration option is `ON`.


### PR DESCRIPTION
Resolves #2272 (Fix missing Adafruit PID781 LCD size automated tests documentation).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
