### PR TITLE
Add Adafruit PID781 driver hello world interactive test helper

### DIFF
--- a/include/picolibrary/testing/interactive/adafruit/pid781.h
+++ b/include/picolibrary/testing/interactive/adafruit/pid781.h
@@ -23,10 +23,65 @@
 #ifndef PICOLIBRARY_TESTING_INTERACTIVE_ADAFRUIT_PID781_H
 #define PICOLIBRARY_TESTING_INTERACTIVE_ADAFRUIT_PID781_H
 
+#include <utility>
+
+#include "picolibrary/adafruit/pid781.h"
+#include "picolibrary/asynchronous_serial.h"
+#include "picolibrary/rom.h"
+
 /**
  * \brief Adafruit PID781 interactive testing facilities.
  */
 namespace picolibrary::Testing::Interactive::Adafruit::PID781 {
+
+/**
+ * \brief Driver hello world interactive test helper.
+ *
+ * \tparam Transmitter The type of asynchronous serial transmitter used to communicate
+ *         with the PID781.
+ *
+ * \param[in] transmitter The asynchronous serial transmitter to use to communicate with
+ *            the PID781.
+ */
+template<typename Transmitter>
+void hello_world( Transmitter transmitter ) noexcept
+{
+    transmitter.initialize();
+
+    auto pid781 = ::picolibrary::Adafruit::PID781::Driver<Asynchronous_Serial::Reliable_Unbuffered_Output_Stream<Transmitter>>{
+        std::move( transmitter )
+    };
+
+    auto const smiley_face = ::picolibrary::Adafruit::PID781::Custom_Character_ID::_0;
+
+    pid781.set_and_save_backlight_color( { 51, 0, 111 } );
+    pid781.set_and_save_backlight_brightness( 255 );
+    pid781.set_and_save_lcd_contrast( 200 );
+    pid781.illuminate_backlight();
+    pid781.enable_auto_scrolling();
+    pid781.enable_cursor_blink();
+    pid781.create_custom_character(
+        smiley_face,
+        {
+            0b00000,
+            0b01010,
+            0b01010,
+            0b00000,
+            0b00000,
+            0b10001,
+            0b01110,
+            0b00000,
+        } );
+
+    pid781.clear_screen();
+
+    pid781.home_cursor();
+    pid781.put( PICOLIBRARY_ROM_STRING( "Adafruit PID781" ) );
+    pid781.set_cursor_position( { 2, 2 } );
+    pid781.print( PICOLIBRARY_ROM_STRING( "Hello, world! " ), smiley_face );
+    pid781.flush();
+}
+
 } // namespace picolibrary::Testing::Interactive::Adafruit::PID781
 
 #endif // PICOLIBRARY_TESTING_INTERACTIVE_ADAFRUIT_PID781_H

--- a/include/picolibrary/testing/interactive/adafruit/pid781.h
+++ b/include/picolibrary/testing/interactive/adafruit/pid781.h
@@ -81,7 +81,7 @@ void hello_world( Transmitter transmitter ) noexcept
     pid781.home_cursor();
     pid781.put( PICOLIBRARY_ROM_STRING( "Adafruit PID781" ) );
     pid781.set_cursor_position( { 2, 2 } );
-    pid781.print( PICOLIBRARY_ROM_STRING( "Hello, world! " ), smiley_face );
+    pid781.print( PICOLIBRARY_ROM_STRING( "Hello, world!" ), smiley_face );
     pid781.flush();
 }
 

--- a/include/picolibrary/testing/interactive/adafruit/pid781.h
+++ b/include/picolibrary/testing/interactive/adafruit/pid781.h
@@ -44,8 +44,11 @@ namespace picolibrary::Testing::Interactive::Adafruit::PID781 {
  *            the PID781.
  */
 template<typename Transmitter>
+// NOLINTNEXTLINE(readability-function-size)
 void hello_world( Transmitter transmitter ) noexcept
 {
+    // #lizard forgives the length
+
     transmitter.initialize();
 
     auto pid781 = ::picolibrary::Adafruit::PID781::Driver<Asynchronous_Serial::Reliable_Unbuffered_Output_Stream<Transmitter>>{


### PR DESCRIPTION
Resolves #2297 (Add Adafruit PID781 driver hello world interactive test helper).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
