### PR TITLE
Fix Adafruit PID781 driver base class function accessibility

### DIFF
--- a/include/picolibrary/adafruit/pid781.h
+++ b/include/picolibrary/adafruit/pid781.h
@@ -154,6 +154,8 @@ class Driver : public Reliable_Output_Stream {
   public:
     using Reliable_Output_Stream::Reliable_Output_Stream;
 
+    using Reliable_Output_Stream::put;
+
     /**
      * \brief Set and save the bit rate.
      *


### PR DESCRIPTION
Resolves #2299 (Fix Adafruit PID781 driver base class function accessibility).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
