### PR TITLE
Add 0-bit register address space support to I2C device

### DIFF
--- a/include/picolibrary/i2c.h
+++ b/include/picolibrary/i2c.h
@@ -1446,6 +1446,50 @@ class Device {
      *
      * \pre the device is responsive
      *
+     * \return The data read from the register.
+     */
+    auto read() const noexcept -> std::uint8_t
+    {
+        m_align_bus_multiplexer();
+
+        auto const guard = Bus_Control_Guard{ *m_controller };
+
+        PICOLIBRARY_EXPECT(
+            m_controller->address( m_address, Operation::READ ) == Response::ACK,
+            m_nonresponsive_device_error );
+        return m_controller->read( Response::NACK );
+    }
+
+    /**
+     * \brief Read a block of registers.
+     *
+     * \pre the device is responsive
+     *
+     * \param[out] begin The beginning of the data read from the block of registers.
+     * \param[out] end The end of the data read from the block of registers.
+     *
+     * \warning This function does not verify that the register block size is non-zero. If
+     *          the register block size is zero, a NACK terminated read will never be
+     *          performed which results in the device retaining control of the SDA signal,
+     *          locking up the bus.
+     */
+    void read( std::uint8_t * begin, std::uint8_t * end ) const noexcept
+    {
+        m_align_bus_multiplexer();
+
+        auto const guard = Bus_Control_Guard{ *m_controller };
+
+        PICOLIBRARY_EXPECT(
+            m_controller->address( m_address, Operation::READ ) == Response::ACK,
+            m_nonresponsive_device_error );
+        m_controller->read( begin, end, Response::NACK );
+    }
+
+    /**
+     * \brief Read a register.
+     *
+     * \pre the device is responsive
+     *
      * \param[in] register_address The address of the register to read.
      *
      * \return The data read from the register.
@@ -1500,6 +1544,45 @@ class Device {
             m_controller->address( m_address, Operation::READ ) == Response::ACK,
             m_nonresponsive_device_error );
         m_controller->read( begin, end, Response::NACK );
+    }
+
+    /**
+     * \brief Write to a register.
+     *
+     * \pre the device is responsive
+     *
+     * \param[in] data The data to write to the register.
+     */
+    void write( std::uint8_t data ) noexcept
+    {
+        m_align_bus_multiplexer();
+
+        auto const guard = Bus_Control_Guard{ *m_controller };
+
+        PICOLIBRARY_EXPECT(
+            m_controller->address( m_address, Operation::WRITE ) == Response::ACK,
+            m_nonresponsive_device_error );
+        PICOLIBRARY_EXPECT( m_controller->write( data ) == Response::ACK, m_nonresponsive_device_error );
+    }
+
+    /**
+     * \brief Write to a block of registers.
+     *
+     * \pre the device is responsive
+     *
+     * \param[in] begin, The beginning of the data to write to the block of registers.
+     * \param[in] end, The end of the data to write to the block of registers.
+     */
+    void write( std::uint8_t const * begin, std::uint8_t const * end ) noexcept
+    {
+        m_align_bus_multiplexer();
+
+        auto const guard = Bus_Control_Guard{ *m_controller };
+
+        PICOLIBRARY_EXPECT(
+            m_controller->address( m_address, Operation::WRITE ) == Response::ACK,
+            m_nonresponsive_device_error );
+        PICOLIBRARY_EXPECT( m_controller->write( begin, end ) == Response::ACK, m_nonresponsive_device_error );
     }
 
     /**

--- a/include/picolibrary/testing/automated/i2c.h
+++ b/include/picolibrary/testing/automated/i2c.h
@@ -353,6 +353,18 @@ class Mock_Device {
 
     MOCK_METHOD( Mock_Controller &, controller, (), ( const ) );
 
+    MOCK_METHOD( std::uint8_t, read, (), ( const ) );
+    MOCK_METHOD( std::vector<std::uint8_t>, read, (std::vector<std::uint8_t>), ( const ) );
+
+    void read( std::uint8_t * begin, std::uint8_t * end ) const
+    {
+        static_cast<void>( end );
+
+        auto const data = read( std::vector<std::uint8_t>{} );
+
+        std::copy( data.begin(), data.end(), begin );
+    }
+
     MOCK_METHOD( std::uint8_t, read, ( std::uint8_t ), ( const ) );
     MOCK_METHOD( std::vector<std::uint8_t>, read, (std::uint8_t, std::vector<std::uint8_t>), ( const ) );
 
@@ -363,6 +375,14 @@ class Mock_Device {
         auto const data = read( register_address, std::vector<std::uint8_t>{} );
 
         std::copy( data.begin(), data.end(), begin );
+    }
+
+    MOCK_METHOD( void, write, ( std::uint8_t ) );
+    MOCK_METHOD( void, write, (std::vector<std::uint8_t>));
+
+    void write( std::uint8_t const * begin, std::uint8_t const * end )
+    {
+        write( std::vector<std::uint8_t>{ begin, end } );
     }
 
     MOCK_METHOD( void, write, ( std::uint8_t, std::uint8_t ) );


### PR DESCRIPTION
Resolves #2303 (Add 0-bit register address space support to I2C device).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
