### PR TITLE
Add 16-bit register address space support to I2C device

### DIFF
--- a/include/picolibrary/testing/automated/i2c.h
+++ b/include/picolibrary/testing/automated/i2c.h
@@ -377,6 +377,18 @@ class Mock_Device {
         std::copy( data.begin(), data.end(), begin );
     }
 
+    MOCK_METHOD( std::uint8_t, read, ( std::uint16_t ), ( const ) );
+    MOCK_METHOD( std::vector<std::uint8_t>, read, (std::uint16_t, std::vector<std::uint8_t>), ( const ) );
+
+    void read( std::uint16_t register_address, std::uint8_t * begin, std::uint8_t * end ) const
+    {
+        static_cast<void>( end );
+
+        auto const data = read( register_address, std::vector<std::uint8_t>{} );
+
+        std::copy( data.begin(), data.end(), begin );
+    }
+
     MOCK_METHOD( void, write, ( std::uint8_t ) );
     MOCK_METHOD( void, write, (std::vector<std::uint8_t>));
 
@@ -389,6 +401,14 @@ class Mock_Device {
     MOCK_METHOD( void, write, (std::uint8_t, std::vector<std::uint8_t>));
 
     void write( std::uint8_t register_address, std::uint8_t const * begin, std::uint8_t const * end )
+    {
+        write( register_address, std::vector<std::uint8_t>{ begin, end } );
+    }
+
+    MOCK_METHOD( void, write, ( std::uint16_t, std::uint8_t ) );
+    MOCK_METHOD( void, write, (std::uint16_t, std::vector<std::uint8_t>));
+
+    void write( std::uint16_t register_address, std::uint8_t const * begin, std::uint8_t const * end )
     {
         write( register_address, std::vector<std::uint8_t>{ begin, end } );
     }

--- a/test/automated/picolibrary/microchip/mcp23008/driver/main.cc
+++ b/test/automated/picolibrary/microchip/mcp23008/driver/main.cc
@@ -36,7 +36,9 @@ using ::picolibrary::Microchip::MCP23008::Address_Transmitted;
 using ::picolibrary::Testing::Automated::Mock_Error;
 using ::picolibrary::Testing::Automated::I2C::Mock_Controller;
 using ::picolibrary::Testing::Automated::I2C::Mock_Device;
+using ::testing::Eq;
 using ::testing::Return;
+using ::testing::SafeMatcherCast;
 using ::testing::TestWithParam;
 using ::testing::ValuesIn;
 
@@ -103,7 +105,7 @@ TEST( readIODIR, worksProperly )
 
     auto const data = std::uint8_t{ 0x14 };
 
-    EXPECT_CALL( mcp23008, read( 0x00 ) ).WillOnce( Return( data ) );
+    EXPECT_CALL( mcp23008, read( SafeMatcherCast<std::uint8_t>( Eq( 0x00 ) ) ) ).WillOnce( Return( data ) );
 
     ASSERT_EQ( mcp23008.read_iodir(), data );
 }
@@ -117,7 +119,7 @@ TEST( writeIODIR, worksProperly )
 
     auto const data = std::uint8_t{ 0x1E };
 
-    EXPECT_CALL( mcp23008, write( 0x00, data ) );
+    EXPECT_CALL( mcp23008, write( SafeMatcherCast<std::uint8_t>( Eq( 0x00 ) ), data ) );
 
     mcp23008.write_iodir( data );
 }
@@ -131,7 +133,7 @@ TEST( readIPOL, worksProperly )
 
     auto const data = std::uint8_t{ 0x66 };
 
-    EXPECT_CALL( mcp23008, read( 0x01 ) ).WillOnce( Return( data ) );
+    EXPECT_CALL( mcp23008, read( SafeMatcherCast<std::uint8_t>( Eq( 0x01 ) ) ) ).WillOnce( Return( data ) );
 
     ASSERT_EQ( mcp23008.read_ipol(), data );
 }
@@ -145,7 +147,7 @@ TEST( writeIPOL, worksProperly )
 
     auto const data = std::uint8_t{ 0xFB };
 
-    EXPECT_CALL( mcp23008, write( 0x01, data ) );
+    EXPECT_CALL( mcp23008, write( SafeMatcherCast<std::uint8_t>( Eq( 0x01 ) ), data ) );
 
     mcp23008.write_ipol( data );
 }
@@ -159,7 +161,7 @@ TEST( readGPINTEN, worksProperly )
 
     auto const data = std::uint8_t{ 0x14 };
 
-    EXPECT_CALL( mcp23008, read( 0x02 ) ).WillOnce( Return( data ) );
+    EXPECT_CALL( mcp23008, read( SafeMatcherCast<std::uint8_t>( Eq( 0x02 ) ) ) ).WillOnce( Return( data ) );
 
     ASSERT_EQ( mcp23008.read_gpinten(), data );
 }
@@ -173,7 +175,7 @@ TEST( writeGPINTEN, worksProperly )
 
     auto const data = std::uint8_t{ 0x01 };
 
-    EXPECT_CALL( mcp23008, write( 0x02, data ) );
+    EXPECT_CALL( mcp23008, write( SafeMatcherCast<std::uint8_t>( Eq( 0x02 ) ), data ) );
 
     mcp23008.write_gpinten( data );
 }
@@ -187,7 +189,7 @@ TEST( readDEFVAL, worksProperly )
 
     auto const data = std::uint8_t{ 0x6F };
 
-    EXPECT_CALL( mcp23008, read( 0x03 ) ).WillOnce( Return( data ) );
+    EXPECT_CALL( mcp23008, read( SafeMatcherCast<std::uint8_t>( Eq( 0x03 ) ) ) ).WillOnce( Return( data ) );
 
     ASSERT_EQ( mcp23008.read_defval(), data );
 }
@@ -201,7 +203,7 @@ TEST( writeDEFVAL, worksProperly )
 
     auto const data = std::uint8_t{ 0xC5 };
 
-    EXPECT_CALL( mcp23008, write( 0x03, data ) );
+    EXPECT_CALL( mcp23008, write( SafeMatcherCast<std::uint8_t>( Eq( 0x03 ) ), data ) );
 
     mcp23008.write_defval( data );
 }
@@ -215,7 +217,7 @@ TEST( readINTCON, worksProperly )
 
     auto const data = std::uint8_t{ 0x37 };
 
-    EXPECT_CALL( mcp23008, read( 0x04 ) ).WillOnce( Return( data ) );
+    EXPECT_CALL( mcp23008, read( SafeMatcherCast<std::uint8_t>( Eq( 0x04 ) ) ) ).WillOnce( Return( data ) );
 
     ASSERT_EQ( mcp23008.read_intcon(), data );
 }
@@ -229,7 +231,7 @@ TEST( writeINTCON, worksProperly )
 
     auto const data = std::uint8_t{ 0x2B };
 
-    EXPECT_CALL( mcp23008, write( 0x04, data ) );
+    EXPECT_CALL( mcp23008, write( SafeMatcherCast<std::uint8_t>( Eq( 0x04 ) ), data ) );
 
     mcp23008.write_intcon( data );
 }
@@ -243,7 +245,7 @@ TEST( readIOCON, worksProperly )
 
     auto const data = std::uint8_t{ 0x06 };
 
-    EXPECT_CALL( mcp23008, read( 0x05 ) ).WillOnce( Return( data ) );
+    EXPECT_CALL( mcp23008, read( SafeMatcherCast<std::uint8_t>( Eq( 0x05 ) ) ) ).WillOnce( Return( data ) );
 
     ASSERT_EQ( mcp23008.read_iocon(), data );
 }
@@ -257,7 +259,7 @@ TEST( writeIOCON, worksProperly )
 
     auto const data = std::uint8_t{ 0x85 };
 
-    EXPECT_CALL( mcp23008, write( 0x05, data ) );
+    EXPECT_CALL( mcp23008, write( SafeMatcherCast<std::uint8_t>( Eq( 0x05 ) ), data ) );
 
     mcp23008.write_iocon( data );
 }
@@ -271,7 +273,7 @@ TEST( readGPPU, worksProperly )
 
     auto const data = std::uint8_t{ 0xD5 };
 
-    EXPECT_CALL( mcp23008, read( 0x06 ) ).WillOnce( Return( data ) );
+    EXPECT_CALL( mcp23008, read( SafeMatcherCast<std::uint8_t>( Eq( 0x06 ) ) ) ).WillOnce( Return( data ) );
 
     ASSERT_EQ( mcp23008.read_gppu(), data );
 }
@@ -285,7 +287,7 @@ TEST( writeGPPU, worksProperly )
 
     auto const data = std::uint8_t{ 0x25 };
 
-    EXPECT_CALL( mcp23008, write( 0x06, data ) );
+    EXPECT_CALL( mcp23008, write( SafeMatcherCast<std::uint8_t>( Eq( 0x06 ) ), data ) );
 
     mcp23008.write_gppu( data );
 }
@@ -299,7 +301,7 @@ TEST( readINTF, worksProperly )
 
     auto const data = std::uint8_t{ 0x94 };
 
-    EXPECT_CALL( mcp23008, read( 0x07 ) ).WillOnce( Return( data ) );
+    EXPECT_CALL( mcp23008, read( SafeMatcherCast<std::uint8_t>( Eq( 0x07 ) ) ) ).WillOnce( Return( data ) );
 
     ASSERT_EQ( mcp23008.read_intf(), data );
 }
@@ -313,7 +315,7 @@ TEST( readINTCAP, worksProperly )
 
     auto const data = std::uint8_t{ 0x2D };
 
-    EXPECT_CALL( mcp23008, read( 0x08 ) ).WillOnce( Return( data ) );
+    EXPECT_CALL( mcp23008, read( SafeMatcherCast<std::uint8_t>( Eq( 0x08 ) ) ) ).WillOnce( Return( data ) );
 
     ASSERT_EQ( mcp23008.read_intcap(), data );
 }
@@ -327,7 +329,7 @@ TEST( readGPIO, worksProperly )
 
     auto const data = std::uint8_t{ 0x9C };
 
-    EXPECT_CALL( mcp23008, read( 0x09 ) ).WillOnce( Return( data ) );
+    EXPECT_CALL( mcp23008, read( SafeMatcherCast<std::uint8_t>( Eq( 0x09 ) ) ) ).WillOnce( Return( data ) );
 
     ASSERT_EQ( mcp23008.read_gpio(), data );
 }
@@ -341,7 +343,7 @@ TEST( writeGPIO, worksProperly )
 
     auto const data = std::uint8_t{ 0x04 };
 
-    EXPECT_CALL( mcp23008, write( 0x09, data ) );
+    EXPECT_CALL( mcp23008, write( SafeMatcherCast<std::uint8_t>( Eq( 0x09 ) ), data ) );
 
     mcp23008.write_gpio( data );
 }
@@ -355,7 +357,7 @@ TEST( readOLAT, worksProperly )
 
     auto const data = std::uint8_t{ 0x38 };
 
-    EXPECT_CALL( mcp23008, read( 0x0A ) ).WillOnce( Return( data ) );
+    EXPECT_CALL( mcp23008, read( SafeMatcherCast<std::uint8_t>( Eq( 0x0A ) ) ) ).WillOnce( Return( data ) );
 
     ASSERT_EQ( mcp23008.read_olat(), data );
 }
@@ -369,7 +371,7 @@ TEST( writeOLAT, worksProperly )
 
     auto const data = std::uint8_t{ 0xF5 };
 
-    EXPECT_CALL( mcp23008, write( 0x0A, data ) );
+    EXPECT_CALL( mcp23008, write( SafeMatcherCast<std::uint8_t>( Eq( 0x0A ) ), data ) );
 
     mcp23008.write_olat( data );
 }


### PR DESCRIPTION
Resolves #2304 (Add 16-bit register address space support to I2C device).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
