### PR TITLE
Add socket flags to WIZnet W5500 IP network stack

### DIFF
--- a/docs/device/wiznet/w5500/ip.md
+++ b/docs/device/wiznet/w5500/ip.md
@@ -147,6 +147,12 @@ docuentation](../../../network/ip.md#network-stack) for more information.
   `::picolibrary::WIZnet::W5500::IP::Network_Stack::allocate_sockets()` member functions.
 - To deallocate sockets, use the
   `::picolibrary::WIZnet::W5500::IP::Network_Stack::deallocate_sockets()` member function.
+- To set a socket's flags, use the
+  `::picolibrary::WIZnet::W5500::IP::Network_Stack::set_socket_flags()` member function.
+- To clear a socket's flags, use the
+  `::picolibrary::WIZnet::W5500::IP::Network_Stack::clear_socket_flags()` member function.
+- To get a socket's flags, use the
+  `::picolibrary::WIZnet::W5500::IP::Network_Stack::socket_flags()` member function.
 - To access the TCP over IP port allocator, us the
   `::picolibrary::WIZnet::W5500::IP::Network_Stack::tcp_port_allocator()` member function.
 

--- a/include/picolibrary/testing/automated/wiznet/w5500/ip/network_stack.h
+++ b/include/picolibrary/testing/automated/wiznet/w5500/ip/network_stack.h
@@ -138,6 +138,10 @@ class Mock_Network_Stack {
         deallocate_sockets( std::vector<::picolibrary::WIZnet::W5500::Socket_ID>{ begin, end } );
     }
 
+    MOCK_METHOD( void, set_socket_flags, ( ::picolibrary::WIZnet::W5500::Socket_ID, std::uint_fast8_t ) );
+    MOCK_METHOD( void, clear_socket_flags, ( ::picolibrary::WIZnet::W5500::Socket_ID, std::uint_fast8_t ) );
+    MOCK_METHOD( std::uint_fast8_t, socket_flags, ( ::picolibrary::WIZnet::W5500::Socket_ID ), ( const ) );
+
     MOCK_METHOD( Mock_Port_Allocator &, tcp_port_allocator, () );
 
     MOCK_METHOD( TCP_Client, make_tcp_client, () );


### PR DESCRIPTION
Resolves #2307 (Add socket flags to WIZnet W5500 IP network stack).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
