### PR TITLE
Fix erroneous WIZnet W5500 TCP over IP client socket precondition documentation

### DIFF
--- a/include/picolibrary/wiznet/w5500/ip/tcp.h
+++ b/include/picolibrary/wiznet/w5500/ip/tcp.h
@@ -126,8 +126,6 @@ class Client {
 
     /**
      * \brief Destructor.
-     *
-     * \pre the W5500 is responsive
      */
     ~Client() noexcept
     {
@@ -136,8 +134,6 @@ class Client {
 
     /**
      * \brief Assignment operator.
-     *
-     * \pre the W5500 is responsive
      *
      * \param[in] expression The expression to be assigned.
      *


### PR DESCRIPTION
Resolves #2311 (Fix erroneous WIZnet W5500 TCP over IP client socket precondition documentation).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
