### PR TITLE
Add Adafruit PID781 driver hello world interactive test helper documentation

### DIFF
--- a/docs/device/adafruit/pid781.md
+++ b/docs/device/adafruit/pid781.md
@@ -160,3 +160,10 @@ configuration option is `ON`.
 The mock is defined in the
 [`include/picolibrary/testing/automated/adafruit/pid781.h`](https://github.com/apcountryman/picolibrary/blob/main/include/picolibrary/testing/automated/adafruit/pid781.h)/[`source/picolibrary/testing/automated/adafruit/pid781.cc`](https://github.com/apcountryman/picolibrary/blob/main/source/picolibrary/testing/automated/adafruit/pid781.cc)
 header/source file pair.
+
+The `::picolibrary::Testing::Interactive::Adafruit::PID781::hello_world()` interactive
+test helper is available if the `PICOLIBRARY_ENABLE_INTERACTIVE_TESTING` project
+configuration option is `ON`.
+The interactive test helper is defined in the
+[`include/picolibrary/testing/interactive/adafruit/pid781.h`](https://github.com/apcountryman/picolibrary/blob/main/include/picolibrary/testing/interactive/adafruit/pid781.h)/[`source/picolibrary/testing/interactive/adafruit/pid781.cc`](https://github.com/apcountryman/picolibrary/blob/main/source/picolibrary/testing/interactive/adafruit/pid781.cc)
+header/source file pair.


### PR DESCRIPTION
Resolves #2345 (Add Adafruit PID781 driver hello world interactive test helper documentation).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
