### PR TITLE
Fix I2C device address transmitted format static assertions

### DIFF
--- a/include/picolibrary/i2c.h
+++ b/include/picolibrary/i2c.h
@@ -1131,10 +1131,10 @@ class Device_Address_Numeric : public Address_Numeric {
 template<Address_Transmitted::Unsigned_Integer MIN, Address_Transmitted::Unsigned_Integer MAX>
 class Device_Address_Transmitted : public Address_Transmitted {
   public:
-    static_assert( MIN >= Address_Numeric::min().as_unsigned_integer() );
+    static_assert( MIN >= Address_Transmitted::min().as_unsigned_integer() );
     static_assert( not( MIN & 0b1 ) );
 
-    static_assert( MAX <= Address_Numeric::max().as_unsigned_integer() );
+    static_assert( MAX <= Address_Transmitted::max().as_unsigned_integer() );
     static_assert( not( MAX & 0b1 ) );
 
     static_assert( MIN <= MAX );


### PR DESCRIPTION
Resolves #2350 (Fix I2C device address transmitted format static assertions).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
