### PR TITLE
Add Texas Instruments TCA9548A driver scan interactive test helper

### DIFF
--- a/docs/device/texas_instruments/tca9548a.md
+++ b/docs/device/texas_instruments/tca9548a.md
@@ -46,6 +46,13 @@ The mock is defined in the
 [`include/picolibrary/testing/automated/texas_instruments/tca9548a.h`](https://github.com/apcountryman/picolibrary/blob/main/include/picolibrary/testing/automated/texas_instruments/tca9548a.h)/[`source/picolibrary/testing/automated/texas_instruments/tca9548a.cc`](https://github.com/apcountryman/picolibrary/blob/main/source/picolibrary/testing/automated/texas_instruments/tca9548a.cc)
 header/source file pair.
 
+The `::picolibrary::Testing::Interactive::Texas_Instruments::TCA9548A::scan()` interactive
+test helper is available if the `PICOLIBRARY_ENABLE_INTERACTIVE_TESTING` project
+configuration option is `ON`.
+The interactive test helper is defined in the
+[`include/picolibrary/testing/interactive/texas_instruments/tca9548a.h`](https://github.com/apcountryman/picolibrary/blob/main/include/picolibrary/testing/interactive/texas_instruments/tca9548a.h)/[`source/picolibrary/testing/interactive/texas_instruments/tca9548a.cc`](https://github.com/apcountryman/picolibrary/blob/main/source/picolibrary/testing/interactive/texas_instruments/tca9548a.cc)
+header/source file pair.
+
 The `::picolibrary::Texas_Instruments::TCA9548A::Caching_Driver` Texas Instruments
 TCA9548A caching driver template class adds register caching to
 `::picolibrary::Texas_Instruments::TCA9548A::Driver`.

--- a/include/picolibrary/testing/interactive/texas_instruments/tca9548a.h
+++ b/include/picolibrary/testing/interactive/texas_instruments/tca9548a.h
@@ -49,11 +49,14 @@ namespace picolibrary::Testing::Interactive::Texas_Instruments::TCA9548A {
  * \param[in] tca9548a_address the TCA9548A's address.
  */
 template<typename Controller>
+// NOLINTNEXTLINE(readability-function-size)
 void scan(
     Reliable_Output_Stream &                                        stream,
     Controller                                                      controller,
     ::picolibrary::Texas_Instruments::TCA9548A::Address_Transmitted tca9548a_address ) noexcept
 {
+    // #lizard forgives the length
+
     controller.initialize();
 
     auto tca9548a = ::picolibrary::Texas_Instruments::TCA9548A::Driver{

--- a/include/picolibrary/testing/interactive/texas_instruments/tca9548a.h
+++ b/include/picolibrary/testing/interactive/texas_instruments/tca9548a.h
@@ -23,10 +23,64 @@
 #ifndef PICOLIBRARY_TESTING_INTERACTIVE_TEXAS_INSTRUMENTS_TCA9548A_H
 #define PICOLIBRARY_TESTING_INTERACTIVE_TEXAS_INSTRUMENTS_TCA9548A_H
 
+#include <cstdint>
+#include <limits>
+#include <utility>
+
+#include "picolibrary/error.h"
+#include "picolibrary/format.h"
+#include "picolibrary/i2c.h"
+#include "picolibrary/rom.h"
+#include "picolibrary/stream.h"
+#include "picolibrary/texas_instruments/tca9548a.h"
+
 /**
  * \brief Texas Instruments TCA9548A interactive testing facilities.
  */
 namespace picolibrary::Testing::Interactive::Texas_Instruments::TCA9548A {
+
+/**
+ * \brief Driver scan interactive test helper.
+ *
+ * \tparam Controller The type of controller used to communicate with devices on the bus.
+ *
+ * \param[in] stream The output stream to write the scan results to.
+ * \param[in] controller The controller used to communicate with devices on the bus.
+ * \param[in] tca9548a_address the TCA9548A's address.
+ */
+template<typename Controller>
+void scan(
+    Reliable_Output_Stream &                                        stream,
+    Controller                                                      controller,
+    ::picolibrary::Texas_Instruments::TCA9548A::Address_Transmitted tca9548a_address ) noexcept
+{
+    controller.initialize();
+
+    auto tca9548a = ::picolibrary::Texas_Instruments::TCA9548A::Driver{
+        I2C::Bus_Multiplexer_Aligner{}, controller, std::move( tca9548a_address ), Generic_Error::NONRESPONSIVE_DEVICE
+    };
+
+    for ( auto channel = std::uint_fast8_t{ 0 }; channel < std::numeric_limits<std::uint8_t>::digits;
+          ++channel ) {
+        tca9548a.write_control( 1 << channel );
+
+        stream.print(
+            PICOLIBRARY_ROM_STRING( "channel " ), Format::Dec{ channel }, ":\n" );
+
+        I2C::scan( controller, [ &stream ]( I2C::Address_Numeric address, auto operation, auto response ) noexcept {
+            if ( response == I2C::Response::ACK ) {
+                stream.print(
+                    Format::Hex{ static_cast<std::uint8_t>( address.as_unsigned_integer() ) },
+                    PICOLIBRARY_ROM_STRING( " (" ),
+                    operation == I2C::Operation::READ ? 'R' : 'W',
+                    PICOLIBRARY_ROM_STRING( ")\n" ) );
+            } // if
+        } );
+    } // for
+
+    stream.flush();
+}
+
 } // namespace picolibrary::Testing::Interactive::Texas_Instruments::TCA9548A
 
 #endif // PICOLIBRARY_TESTING_INTERACTIVE_TEXAS_INSTRUMENTS_TCA9548A_H


### PR DESCRIPTION
Resolves #2344 (Add Texas Instruments TCA9548A driver scan interactive test helper).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
