### PR TITLE
Add WIZnet W5500 IP network stack ping interactive test helper

### DIFF
--- a/docs/device/wiznet/w5500/ip.md
+++ b/docs/device/wiznet/w5500/ip.md
@@ -126,3 +126,10 @@ project configuration option is `ON`.
 The mock is defined in the
 [`include/picolibrary/testing/automated/wiznet/w5500/ip/network_stack.h`](https://github.com/apcountryman/picolibrary/blob/main/include/picolibrary/testing/automated/wiznet/w5500/ip/network_stack.h)/[`source/picolibrary/testing/automated/wiznet/w5500/ip/network_stack.cc`](https://github.com/apcountryman/picolibrary/blob/main/source/picolibrary/testing/automated/wiznet/w5500/ip/network_stack.cc)
 header/source file pair.
+
+The `::picolibrary::Testing::Interactive::WIZnet::W5500::IP::ping()` interactive test
+helper is available if the `PICOLIBRARY_ENABLE_INTERACTIVE_TESTING` project configuration
+option is `ON`.
+The interactive test helper is defined in the
+[`include/picolibrary/testing/interactive/wiznet/w5500/ip/network_stack.h`](https://github.com/apcountryman/picolibrary/blob/main/include/picolibrary/testing/interactive/wiznet/w5500/ip/network_stack.h)/[`source/picolibrary/testing/interactive/wiznet/w5500/ip/network_stack.cc`](https://github.com/apcountryman/picolibrary/blob/main/source/picolibrary/testing/interactive/wiznet/w5500/ip/network_stack.cc)
+header/source file pair.

--- a/include/picolibrary/testing/interactive/wiznet/w5500/ip/network_stack.h
+++ b/include/picolibrary/testing/interactive/wiznet/w5500/ip/network_stack.h
@@ -1,0 +1,155 @@
+/**
+ * picolibrary
+ *
+ * Copyright 2020-2023, Andrew Countryman <apcountryman@gmail.com> and the picolibrary
+ * contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/**
+ * \file
+ * \brief picolibrary::Testing::Interactive::WIZnet::W5500::IP::Network_Stack interface.
+ */
+
+#ifndef PICOLIBRARY_TESTING_INTERACTIVE_WIZNET_W5500_IP_NETWORK_STACK_H
+#define PICOLIBRARY_TESTING_INTERACTIVE_WIZNET_W5500_IP_NETWORK_STACK_H
+
+#include <cstdint>
+#include <utility>
+
+#include "picolibrary/error.h"
+#include "picolibrary/ipv4.h"
+#include "picolibrary/mac_address.h"
+#include "picolibrary/precondition.h"
+#include "picolibrary/rom.h"
+#include "picolibrary/stream.h"
+#include "picolibrary/wiznet/w5500.h"
+#include "picolibrary/wiznet/w5500/ip.h"
+#include "picolibrary/wiznet/w5500/ip/network_stack.h"
+
+namespace picolibrary::Testing::Interactive::WIZnet::W5500::IP {
+
+/**
+ * \brief Network stack ping interactive test helper.
+ *
+ * \tparam Controller The type of controller used to communicate with the W5500.
+ * \tparam Device_Selector The type of device selector used to select and deselect the
+ *         W5500.
+ *
+ * \param[in] stream The stream to write information to.
+ * \param[in] controller The controller used to communicate with the W5500.
+ * \param[in] configuration The controller clock and data exchange bit order configuration
+ *            that meets the W5500's communication requirements.
+ * \param[in] device_selector The device selector used to select and deselect the W5500.
+ * \param[in] phy_mode The desired PHY mode.
+ * \param[in] arp_forcing_configuration The desired ARP forcing configuration.
+ * \param[in] retransmission_retry_time The desired retransmission retry time (RTR
+ *            register value).
+ * \param[in] retransmission_retry_count The desired retransmission retry count (RCR
+ *            register value).
+ * \param[in] mac_address The desired MAC address.
+ * \param[in] ipv4_address The desired IPv4 address.
+ * \param[in] ipv4_gateway_address The desired IPv4 gateway address.
+ * \param[in] ipv4_subnet_mask The desired IPv4 subnet mask.
+ */
+template<typename Controller, typename Device_Selector>
+[[noreturn]] void ping(
+    Reliable_Output_Stream &                   stream,
+    Controller &                               controller,
+    typename Controller::Configuration const & configuration,
+    Device_Selector                            device_selector,
+    ::picolibrary::WIZnet::W5500::PHY_Mode     phy_mode,
+    ::picolibrary::WIZnet::W5500::ARP_Forcing  arp_forcing_configuration,
+    std::uint16_t                              retransmission_retry_time,
+    std::uint8_t                               retransmission_retry_count,
+    MAC_Address const &                        mac_address,
+    IPv4::Address const &                      ipv4_address,
+    IPv4::Address const &                      ipv4_gateway_address,
+    IPv4::Address const &                      ipv4_subnet_mask ) noexcept
+{
+    controller.initialize();
+
+    auto network_stack = ::picolibrary::WIZnet::W5500::IP::Network_Stack{
+        controller,
+        configuration,
+        std::move( device_selector ),
+        Generic_Error::NONRESPONSIVE_DEVICE,
+        ::picolibrary::WIZnet::W5500::IP::Unsupported_Protocol_Port_Allocator{},
+        ::picolibrary::WIZnet::W5500::IP::Unsupported_Protocol_Port_Allocator{}
+    };
+
+    network_stack.initialize(
+        phy_mode,
+        ::picolibrary::WIZnet::W5500::Ping_Blocking::DISABLED,
+        arp_forcing_configuration,
+        retransmission_retry_time,
+        retransmission_retry_count,
+        mac_address,
+        ipv4_address,
+        ipv4_gateway_address,
+        ipv4_subnet_mask,
+        ::picolibrary::WIZnet::W5500::INTLEVEL::RESET,
+        ::picolibrary::WIZnet::W5500::Socket_Buffer_Size::_2_KiB );
+
+    PICOLIBRARY_EXPECT(
+        network_stack.w5500_is_responsive(), network_stack.nonresponsive_device_error() );
+
+    stream.put( PICOLIBRARY_ROM_STRING( "waiting for link to be established\n" ) );
+    stream.flush();
+
+    while ( network_stack.link_status() != ::picolibrary::WIZnet::W5500::Link_Status::UP ) {} // while
+
+    auto const link_speed = [ &network_stack ]() -> ROM::String {
+        switch ( network_stack.link_speed() ) {
+                // clang-format off
+
+            case ::picolibrary::WIZnet::W5500::Link_Speed::_10_MbPs:  return PICOLIBRARY_ROM_STRING(  "10 Mb/s" );
+            case ::picolibrary::WIZnet::W5500::Link_Speed::_100_MbPs: return PICOLIBRARY_ROM_STRING( "100 Mb/s" );
+
+                // clang-format on
+        } // switch
+
+        return PICOLIBRARY_ROM_STRING( "UNKNOWN" );
+    };
+
+    auto const link_mode = [ &network_stack ]() -> ROM::String {
+        switch ( network_stack.link_mode() ) {
+                // clang-format off
+
+            case ::picolibrary::WIZnet::W5500::Link_Mode::HALF_DUPLEX: return PICOLIBRARY_ROM_STRING( "half duplex" );
+            case ::picolibrary::WIZnet::W5500::Link_Mode::FULL_DUPLEX: return PICOLIBRARY_ROM_STRING( "full duplex" );
+
+                // clang-format on
+        } // switch
+
+        return PICOLIBRARY_ROM_STRING( "UNKNOWN" );
+    };
+
+    // clang-format off
+    stream.print(
+        PICOLIBRARY_ROM_STRING( "link established:" ),
+        PICOLIBRARY_ROM_STRING( "\n    speed: " ), link_speed(),
+        PICOLIBRARY_ROM_STRING( "\n    mode: " ), link_mode(),
+        PICOLIBRARY_ROM_STRING( "\nMAC address: " ), network_stack.mac_address(),
+        PICOLIBRARY_ROM_STRING( "\nIPv4 address: " ), network_stack.ipv4_address(),
+        PICOLIBRARY_ROM_STRING( "\nIPv4 gateway address: " ), network_stack.ipv4_gateway_address(),
+        PICOLIBRARY_ROM_STRING( "\nIPv4 subnet mask: " ), network_stack.ipv4_subnet_mask(),
+        '\n' );
+    // clang-format on
+    stream.flush();
+
+    for ( ;; ) {} // for
+}
+
+} // namespace picolibrary::Testing::Interactive::WIZnet::W5500::IP
+
+#endif // PICOLIBRARY_TESTING_INTERACTIVE_WIZNET_W5500_IP_NETWORK_STACK_H

--- a/include/picolibrary/testing/interactive/wiznet/w5500/ip/network_stack.h
+++ b/include/picolibrary/testing/interactive/wiznet/w5500/ip/network_stack.h
@@ -62,6 +62,7 @@ namespace picolibrary::Testing::Interactive::WIZnet::W5500::IP {
  * \param[in] ipv4_subnet_mask The desired IPv4 subnet mask.
  */
 template<typename Controller, typename Device_Selector>
+// NOLINTNEXTLINE(readability-function-size)
 [[noreturn]] void ping(
     Reliable_Output_Stream &                   stream,
     Controller &                               controller,
@@ -76,6 +77,9 @@ template<typename Controller, typename Device_Selector>
     IPv4::Address const &                      ipv4_gateway_address,
     IPv4::Address const &                      ipv4_subnet_mask ) noexcept
 {
+    // #lizard forgives the length
+    // #lizard forgives the parameter count
+
     controller.initialize();
 
     auto network_stack = ::picolibrary::WIZnet::W5500::IP::Network_Stack{

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -146,6 +146,7 @@ if( ${PICOLIBRARY_ENABLE_INTERACTIVE_TESTING} )
         "picolibrary/testing/interactive/wiznet.cc"
         "picolibrary/testing/interactive/wiznet/w5500.cc"
         "picolibrary/testing/interactive/wiznet/w5500/ip.cc"
+        "picolibrary/testing/interactive/wiznet/w5500/ip/network_stack.cc"
         "picolibrary/testing/interactive/wiznet/w5500/ip/tcp.cc"
     )
 endif( ${PICOLIBRARY_ENABLE_INTERACTIVE_TESTING} )

--- a/source/picolibrary/testing/interactive/wiznet/w5500/ip/network_stack.cc
+++ b/source/picolibrary/testing/interactive/wiznet/w5500/ip/network_stack.cc
@@ -1,0 +1,24 @@
+/**
+ * picolibrary
+ *
+ * Copyright 2020-2023, Andrew Countryman <apcountryman@gmail.com> and the picolibrary
+ * contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/**
+ * \file
+ * \brief picolibrary::Testing::Interactive::WIZnet::W5500::IP::Network_Stack
+ *        implementation.
+ */
+
+#include "picolibrary/testing/interactive/wiznet/w5500/ip/network_stack.h"


### PR DESCRIPTION
Resolves #2370 (Add WIZnet W5500 IP network stack ping interactive test helper).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
