### PR TITLE
Fix WIZnet W5500 IP network stack ping interactive test helper parameter types

### DIFF
--- a/include/picolibrary/testing/interactive/wiznet/w5500/ip/network_stack.h
+++ b/include/picolibrary/testing/interactive/wiznet/w5500/ip/network_stack.h
@@ -64,18 +64,18 @@ namespace picolibrary::Testing::Interactive::WIZnet::W5500::IP {
 template<typename Controller, typename Device_Selector>
 // NOLINTNEXTLINE(readability-function-size)
 [[noreturn]] void ping(
-    Reliable_Output_Stream &                   stream,
-    Controller &                               controller,
-    typename Controller::Configuration const & configuration,
-    Device_Selector                            device_selector,
-    ::picolibrary::WIZnet::W5500::PHY_Mode     phy_mode,
-    ::picolibrary::WIZnet::W5500::ARP_Forcing  arp_forcing_configuration,
-    std::uint16_t                              retransmission_retry_time,
-    std::uint8_t                               retransmission_retry_count,
-    MAC_Address const &                        mac_address,
-    IPv4::Address const &                      ipv4_address,
-    IPv4::Address const &                      ipv4_gateway_address,
-    IPv4::Address const &                      ipv4_subnet_mask ) noexcept
+    Reliable_Output_Stream &                  stream,
+    Controller                                controller,
+    typename Controller::Configuration        configuration,
+    Device_Selector                           device_selector,
+    ::picolibrary::WIZnet::W5500::PHY_Mode    phy_mode,
+    ::picolibrary::WIZnet::W5500::ARP_Forcing arp_forcing_configuration,
+    std::uint16_t                             retransmission_retry_time,
+    std::uint8_t                              retransmission_retry_count,
+    MAC_Address                               mac_address,
+    IPv4::Address                             ipv4_address,
+    IPv4::Address                             ipv4_gateway_address,
+    IPv4::Address                             ipv4_subnet_mask ) noexcept
 {
     // #lizard forgives the length
     // #lizard forgives the parameter count


### PR DESCRIPTION
Resolves #2375 (Fix WIZnet W5500 IP network stack ping interactive test helper parameter types).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
