### PR TITLE
Fix WIZnet W5500 TCP over IP client socket move constructor

### DIFF
--- a/include/picolibrary/wiznet/w5500/ip/tcp.h
+++ b/include/picolibrary/wiznet/w5500/ip/tcp.h
@@ -109,7 +109,7 @@ class Client {
     constexpr Client( Client && source ) noexcept :
         m_state{ source.m_state },
         m_network_stack{ source.m_network_stack },
-        m_socket_id{ source.socket_id },
+        m_socket_id{ source.m_socket_id },
         m_is_transmitting{ source.m_is_transmitting }
     {
         source.m_state         = State::UNINITIALIZED;


### PR DESCRIPTION
Resolves #2384 (Fix WIZnet W5500 TCP over IP client socket move constructor).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
