### PR TITLE
Fix WIZnet W5500 SN_CR register listen command spelling

### DIFF
--- a/include/picolibrary/wiznet/w5500.h
+++ b/include/picolibrary/wiznet/w5500.h
@@ -1197,7 +1197,7 @@ struct SN_CR {
      */
     enum COMMAND : Type {
         COMMAND_OPEN      = 0x01, ///< Open.
-        COMMADN_LISTEN    = 0x02, ///< Listen.
+        COMMAND_LISTEN    = 0x02, ///< Listen.
         COMMAND_CONNECT   = 0x04, ///< Connect.
         COMMAND_DISCON    = 0x08, ///< Disconnect.
         COMMAND_CLOSE     = 0x10, ///< Close.


### PR DESCRIPTION
Resolves #2390 (Fix WIZnet W5500 SN_CR register listen command spelling).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
