### PR TITLE
Rename WIZnet W5500 TCP over IP acceptor socket socket deallocation key

### DIFF
--- a/include/picolibrary/wiznet/w5500/ip/tcp.h
+++ b/include/picolibrary/wiznet/w5500/ip/tcp.h
@@ -1269,7 +1269,7 @@ class Acceptor {
      * \pre the socket has been allocated
      */
     // NOLINTNEXTLINE(readability-function-size)
-    void deallocate_socket( Acceptor_Server_Deallocation_Key, Socket_ID socket_id ) noexcept
+    void deallocate_socket( Acceptor_Socket_Deallocation_Key, Socket_ID socket_id ) noexcept
     {
         // #lizard forgives the length
 

--- a/include/picolibrary/wiznet/w5500/keys.h
+++ b/include/picolibrary/wiznet/w5500/keys.h
@@ -226,29 +226,28 @@ class Network_Stack_UDP_Port_Allocator_Access_Key {
 namespace picolibrary::WIZnet::W5500::IP::TCP {
 
 /**
- * \brief picolibrary::WIZnet::W5500::IP::TCP::Acceptor
- *        picolibrary::WIZnet::W5500::IP::TCP::Server deallocation key.
+ * \brief picolibrary::WIZnet::W5500::IP::TCP::Acceptor socket deallocation key.
  */
-class Acceptor_Server_Deallocation_Key {
+class Acceptor_Socket_Deallocation_Key {
   public:
-    Acceptor_Server_Deallocation_Key( Acceptor_Server_Deallocation_Key && ) = delete;
+    Acceptor_Socket_Deallocation_Key( Acceptor_Socket_Deallocation_Key && ) = delete;
 
-    Acceptor_Server_Deallocation_Key( Acceptor_Server_Deallocation_Key const & ) = delete;
+    Acceptor_Socket_Deallocation_Key( Acceptor_Socket_Deallocation_Key const & ) = delete;
 
     /**
      * \brief Destructor.
      */
-    ~Acceptor_Server_Deallocation_Key() noexcept = default;
+    ~Acceptor_Socket_Deallocation_Key() noexcept = default;
 
-    auto operator=( Acceptor_Server_Deallocation_Key && ) = delete;
+    auto operator=( Acceptor_Socket_Deallocation_Key && ) = delete;
 
-    auto operator=( Acceptor_Server_Deallocation_Key const & ) = delete;
+    auto operator=( Acceptor_Socket_Deallocation_Key const & ) = delete;
 
   private:
     /**
      * \brief Constructor.
      */
-    constexpr Acceptor_Server_Deallocation_Key() noexcept = default;
+    constexpr Acceptor_Socket_Deallocation_Key() noexcept = default;
 };
 
 /**


### PR DESCRIPTION
Resolves #2404 (Rename WIZnet W5500 TCP over IP acceptor socket socket deallocation key).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
