### PR TITLE
Fix mock WIZnet W5500 IP network stack TCP server is detached function signature

### DIFF
--- a/include/picolibrary/testing/automated/wiznet/w5500/ip/network_stack.h
+++ b/include/picolibrary/testing/automated/wiznet/w5500/ip/network_stack.h
@@ -139,7 +139,7 @@ class Mock_Network_Stack {
         ( (Fixed_Capacity_Vector<::picolibrary::WIZnet::W5500::Socket_ID, 8> const &)) );
 
     MOCK_METHOD( void, detach_tcp_server, ( std::uint_fast8_t, ::picolibrary::WIZnet::W5500::Socket_ID ) );
-    MOCK_METHOD( bool, tcp_server_is_detached, (), ( const ) );
+    MOCK_METHOD( bool, tcp_server_is_detached, ( ::picolibrary::WIZnet::W5500::Socket_ID ), ( const ) );
 
     MOCK_METHOD( Mock_Port_Allocator &, tcp_port_allocator, ( std::uint_fast8_t ) );
 


### PR DESCRIPTION
Resolves #2410 (Fix mock WIZnet W5500 IP network stack TCP server is detached function signature).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
