### PR TITLE
Add TCP over IP acceptor socket incoming connection request acceptance interactive testing helper

### DIFF
--- a/include/picolibrary/testing/interactive/ip/tcp.h
+++ b/include/picolibrary/testing/interactive/ip/tcp.h
@@ -216,6 +216,34 @@ auto connect( Client & client, ::picolibrary::IP::TCP::Endpoint const & endpoint
 }
 
 /**
+ * \brief Acceptor socket incoming connection request acceptance interactive testing
+ *        helper.
+ *
+ * \tparam Acceptor: The type of acceptor socket to use to accept the incoming connection
+ *         request.
+ *
+ * \param[in] acceptor The acceptor socket to use to accept the incoming connection
+ *            request.
+ *
+ * \return A server socket for handling the connection.
+ */
+template<typename Acceptor>
+auto accept( Acceptor & acceptor ) noexcept -> typename Acceptor::Server
+{
+    for ( ;; ) {
+        auto result = acceptor.accept();
+        if ( result.is_error() ) {
+            PICOLIBRARY_EXPECT(
+                result.error() == Generic_Error::WOULD_BLOCK
+                    or result.error() == Generic_Error::OPERATION_TIMEOUT,
+                Generic_Error::LOGIC_ERROR );
+        } else {
+            return std::move( result ).value();
+        } // else
+    }     // for
+}
+
+/**
  * \brief Client socket echo interactive test helper.
  *
  * \tparam Network_Stack The type of network stack to use to construct client sockets.

--- a/include/picolibrary/testing/interactive/ip/tcp.h
+++ b/include/picolibrary/testing/interactive/ip/tcp.h
@@ -219,7 +219,7 @@ auto connect( Client & client, ::picolibrary::IP::TCP::Endpoint const & endpoint
  * \brief Acceptor socket incoming connection request acceptance interactive testing
  *        helper.
  *
- * \tparam Acceptor: The type of acceptor socket to use to accept the incoming connection
+ * \tparam Acceptor The type of acceptor socket to use to accept the incoming connection
  *         request.
  *
  * \param[in] acceptor The acceptor socket to use to accept the incoming connection


### PR DESCRIPTION
Resolves #2413 (Add TCP over IP acceptor socket incoming connection request acceptance interactive testing helper).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
