### PR TITLE
Fix WIZnet W5500 TCP over IP server socket constructor access

### DIFF
--- a/include/picolibrary/wiznet/w5500/ip/tcp.h
+++ b/include/picolibrary/wiznet/w5500/ip/tcp.h
@@ -798,7 +798,7 @@ class Server {
      * \param[in] acceptor The acceptor socket the socket is associated with.
      * \param[in] socket_id The socket's hardware socket ID.
      */
-    constexpr Server( Socket_Construction_Key, Network_Stack & network_stack, Acceptor & acceptor, Socket_ID socket_id ) noexcept
+    constexpr Server( Server_Construction_Key, Network_Stack & network_stack, Acceptor & acceptor, Socket_ID socket_id ) noexcept
         :
         m_state{ State::CONNECTED },
         m_network_stack{ &network_stack },


### PR DESCRIPTION
Resolves #2420 (Fix WIZnet W5500 TCP over IP server socket constructor access).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
