### PR TITLE
Fix WIZnet W5500 IP network stack TCP server construction compilation error

### DIFF
--- a/include/picolibrary/wiznet/w5500/ip/network_stack.h
+++ b/include/picolibrary/wiznet/w5500/ip/network_stack.h
@@ -701,7 +701,7 @@ class Network_Stack {
      */
     auto make_tcp_server() noexcept -> TCP_Server
     {
-        return { {}, *this, allocate_sockets( 1 ) };
+        return { {}, *this, { allocate_socket() } };
     }
 
     /**


### PR DESCRIPTION
Resolves #2423 (Fix WIZnet W5500 IP network stack TCP server construction compilation error).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
