### PR TITLE
Use modulo for WIZnet W5500 TCP over IP server socket connection acceptance index wrap around calculation

### DIFF
--- a/include/picolibrary/wiznet/w5500/ip/tcp.h
+++ b/include/picolibrary/wiznet/w5500/ip/tcp.h
@@ -1843,11 +1843,8 @@ class Server {
      * \return picolibrary::Generic_Error::WOULD_BLOCK if an incoming connection request
      *         could not be accepted without blocking.
      */
-    // NOLINTNEXTLINE(readability-function-size)
     auto accept() noexcept -> Result<Connection_Handler>
     {
-        // #lizard forgives the length
-
         PICOLIBRARY_EXPECT( m_state == State::LISTENING, Generic_Error::LOGIC_ERROR );
 
         auto & driver = m_network_stack->driver( {} );
@@ -1855,10 +1852,7 @@ class Server {
         for ( auto n = std::uint_fast8_t{}; n < m_sockets.size(); ++n ) {
             auto & socket = m_sockets[ m_accept_i ];
 
-            ++m_accept_i;
-            if ( m_accept_i >= m_sockets.size() ) {
-                m_accept_i = 0;
-            } // if
+            m_accept_i = ( m_accept_i + 1 ) % m_sockets.size();
 
             if ( socket.status == Socket::Status::AVAILABLE_FOR_ALLOCATION ) {
                 switch ( driver.read_sn_sr( socket.id ) ) {

--- a/include/picolibrary/wiznet/w5500/ip/tcp.h
+++ b/include/picolibrary/wiznet/w5500/ip/tcp.h
@@ -1843,8 +1843,11 @@ class Server {
      * \return picolibrary::Generic_Error::WOULD_BLOCK if an incoming connection request
      *         could not be accepted without blocking.
      */
+    // NOLINTNEXTLINE(readability-function-size)
     auto accept() noexcept -> Result<Connection_Handler>
     {
+        // #lizard forgives the length
+
         PICOLIBRARY_EXPECT( m_state == State::LISTENING, Generic_Error::LOGIC_ERROR );
 
         auto & driver = m_network_stack->driver( {} );


### PR DESCRIPTION
Resolves #2424 (Use modulo for WIZnet W5500 TCP over IP server socket connection acceptance index wrap around calculation).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [x] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
