### PR TITLE
Add UDP over IP socket support to IP network stack concept

### DIFF
--- a/docs/network/ip.md
+++ b/docs/network/ip.md
@@ -114,6 +114,8 @@ header/source file pair.
   `make_tcp_client()` member function.
 - To construct a TCP server socket, use a network stack implementation's
   `make_tcp_server()` member function.
+- To construct a UDP socket, use a network stack implementation's `make_udp_socket()`
+  member function.
 
 The `::picolibrary::Testing::Automated::IP::Mock_Network_Stack` mock IP network stack
 class is available if the `PICOLIBRARY_ENABLE_AUTOMATED_TESTING` project configuration

--- a/include/picolibrary/ip/network_stack.h
+++ b/include/picolibrary/ip/network_stack.h
@@ -24,6 +24,7 @@
 #define PICOLIBRARY_IP_NETWORK_STACK_H
 
 #include "picolibrary/ip/tcp.h"
+#include "picolibrary/ip/udp.h"
 
 namespace picolibrary::IP {
 
@@ -43,6 +44,11 @@ class Network_Stack_Concept {
      *        stack.
      */
     using TCP_Server = TCP::Server_Concept;
+
+    /**
+     * \brief The type of UDP socket that is used to interact with the network stack.
+     */
+    using UDP_Socket = UDP::Socket_Concept;
 
     /**
      * \brief Constructor.
@@ -91,6 +97,15 @@ class Network_Stack_Concept {
      * \return The constructed TCP server socket.
      */
     auto make_tcp_server() noexcept -> TCP_Server;
+
+    /**
+     * \brief Construct a UDP socket.
+     *
+     * \pre sufficient resources are available to create the socket
+     *
+     * \return The constructed UDP socket.
+     */
+    auto make_udp_socket() noexcept -> UDP_Socket;
 };
 
 } // namespace picolibrary::IP

--- a/include/picolibrary/testing/automated/ip/network_stack.h
+++ b/include/picolibrary/testing/automated/ip/network_stack.h
@@ -24,6 +24,7 @@
 #define PICOLIBRARY_TESTING_AUTOMATED_IP_NETWORK_STACK_H
 
 #include "picolibrary/testing/automated/ip/tcp.h"
+#include "picolibrary/testing/automated/ip/udp.h"
 
 namespace picolibrary::Testing::Automated::IP {
 
@@ -35,6 +36,8 @@ class Mock_Network_Stack {
     using TCP_Client = TCP::Mock_Client::Handle;
 
     using TCP_Server = TCP::Mock_Server::Handle;
+
+    using UDP_Socket = UDP::Mock_Socket::Handle;
 
     Mock_Network_Stack() = default;
 
@@ -51,6 +54,8 @@ class Mock_Network_Stack {
     MOCK_METHOD( TCP_Client, make_tcp_client, () );
 
     MOCK_METHOD( TCP_Server, make_tcp_server, () );
+
+    MOCK_METHOD( UDP_Socket, make_udp_socket, () );
 };
 
 } // namespace picolibrary::Testing::Automated::IP


### PR DESCRIPTION
Resolves #2462 (Add UDP over IP socket support to IP network stack concept).

This pull request:
- [ ] Implements a bug fix
- [x] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
