### PR TITLE
Add WIZnet W5500 UDP over IP interactive testing facilities namespace

### DIFF
--- a/include/picolibrary/testing/interactive/wiznet/w5500/ip/udp.h
+++ b/include/picolibrary/testing/interactive/wiznet/w5500/ip/udp.h
@@ -1,0 +1,32 @@
+/**
+ * picolibrary
+ *
+ * Copyright 2020-2023, Andrew Countryman <apcountryman@gmail.com> and the picolibrary
+ * contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/**
+ * \file
+ * \brief picolibrary::Testing::Interactive::WIZnet::W5500::IP::UDP interface.
+ */
+
+#ifndef PICOLIBRARY_TESTING_INTERACTIVE_WIZNET_W5500_IP_UDP_H
+#define PICOLIBRARY_TESTING_INTERACTIVE_WIZNET_W5500_IP_UDP_H
+
+/**
+ * \brief WIZnet W5500 UDP over IP interactive testing facilities.
+ */
+namespace picolibrary::Testing::Interactive::WIZnet::W5500::IP::UDP {
+} // namespace picolibrary::Testing::Interactive::WIZnet::W5500::IP::UDP
+
+#endif // PICOLIBRARY_TESTING_INTERACTIVE_WIZNET_W5500_IP_UDP_H

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -154,6 +154,7 @@ if( ${PICOLIBRARY_ENABLE_INTERACTIVE_TESTING} )
         "picolibrary/testing/interactive/wiznet/w5500/ip.cc"
         "picolibrary/testing/interactive/wiznet/w5500/ip/network_stack.cc"
         "picolibrary/testing/interactive/wiznet/w5500/ip/tcp.cc"
+        "picolibrary/testing/interactive/wiznet/w5500/ip/udp.cc"
     )
 endif( ${PICOLIBRARY_ENABLE_INTERACTIVE_TESTING} )
 

--- a/source/picolibrary/testing/interactive/wiznet/w5500/ip/udp.cc
+++ b/source/picolibrary/testing/interactive/wiznet/w5500/ip/udp.cc
@@ -1,0 +1,23 @@
+/**
+ * picolibrary
+ *
+ * Copyright 2020-2023, Andrew Countryman <apcountryman@gmail.com> and the picolibrary
+ * contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this
+ * file except in compliance with the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under
+ * the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/**
+ * \file
+ * \brief picolibrary::Testing::Interactive::WIZnet::W5500::IP::UDP implementation.
+ */
+
+#include "picolibrary/testing/interactive/wiznet/w5500/ip/udp.h"


### PR DESCRIPTION
Resolves #2467 (Add WIZnet W5500 UDP over IP interactive testing facilities namespace).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
