### PR TITLE
Fix WIZnet W5500 broadcast blocking configuration documentation typo

### DIFF
--- a/docs/device/wiznet/w5500.md
+++ b/docs/device/wiznet/w5500.md
@@ -411,7 +411,7 @@ The insertion operator is defined in the
 [`include/picolibrary/testing/automated/wiznet/w5500.h`](https://github.com/apcountryman/picolibrary/blob/main/include/picolibrary/testing/automated/wiznet/w5500.h)/[`source/picolibrary/testing/automated/wiznet/w5500.cc`](https://github.com/apcountryman/picolibrary/blob/main/source/picolibrary/testing/automated/wiznet/w5500.cc)
 header/source file pair.
 
-## Boradcast Blocking Configuration Identification
+## Broadcast Blocking Configuration Identification
 The `::picolibrary::WIZnet::W5500::Broadcast_Blocking` enum class is used to identify
 WIZnet W5500 broadcast blocking configurations.
 


### PR DESCRIPTION
Resolves #2480 (Fix WIZnet W5500 broadcast blocking configuration documentation typo).

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
