### PR TITLE
Add GPIO initial internal pull-down resistor state

### DIFF
--- a/docs/gpio.md
+++ b/docs/gpio.md
@@ -5,6 +5,7 @@ header/source file pair.
 
 ## Table of Contents
 1. [Initial Internal Pull-Up Resistor State Identification](#initial-internal-pull-up-resistor-state-identification)
+1. [Initial Internal Pull-Down Resistor State Identification](#initial-internal-pull-down-resistor-state-identification)
 1. [Initial Pin State Identification](#initial-pin-state-identification)
 1. [Input Pin](#input-pin)
 1. [Internally Pulled-Up Input Pin](#internally-pulled-up-input-pin)
@@ -18,6 +19,17 @@ internal pull-up resistor states.
 A `std::ostream` insertion operator is defined for
 `::picolibrary::GPIO::Initial_Pull_Up_State` if the `PICOLIBRARY_ENABLE_AUTOMATED_TESTING`
 project configuration option is `ON`.
+The insertion operator is defined in the
+[`include/picolibrary/testing/automated/gpio.h`](https://github.com/apcountryman/picolibrary/blob/main/include/picolibrary/testing/automated/gpio.h)/[`source/picolibrary/testing/automated/gpio.cc`](https://github.com/apcountryman/picolibrary/blob/main/source/picolibrary/testing/automated/gpio.cc)
+header/source file pair.
+
+## Initial Internal Pull-Down Resistor State Identification
+The `::picolibrary::GPIO::Initial_Pull_Down_State` enum class is used to identify initial
+internal pull-down resistor states.
+
+A `std::ostream` insertion operator is defined for
+`::picolibrary::GPIO::Initial_Pull_Down_State` if the
+`PICOLIBRARY_ENABLE_AUTOMATED_TESTING` project configuration option is `ON`.
 The insertion operator is defined in the
 [`include/picolibrary/testing/automated/gpio.h`](https://github.com/apcountryman/picolibrary/blob/main/include/picolibrary/testing/automated/gpio.h)/[`source/picolibrary/testing/automated/gpio.cc`](https://github.com/apcountryman/picolibrary/blob/main/source/picolibrary/testing/automated/gpio.cc)
 header/source file pair.

--- a/include/picolibrary/gpio.h
+++ b/include/picolibrary/gpio.h
@@ -39,6 +39,14 @@ enum class Initial_Pull_Up_State : std::uint_fast8_t {
 };
 
 /**
+ * \brief Initial internal pull-down resistor state.
+ */
+enum class Initial_Pull_Down_State : std::uint_fast8_t {
+    DISABLED, ///< Disabled.
+    ENABLED,  ///< Enabled.
+};
+
+/**
  * \brief Initial pin state.
  */
 enum class Initial_Pin_State : std::uint_fast8_t {

--- a/include/picolibrary/testing/automated/gpio.h
+++ b/include/picolibrary/testing/automated/gpio.h
@@ -61,6 +61,34 @@ inline auto operator<<( std::ostream & stream, Initial_Pull_Up_State initial_pul
 /**
  * \brief Insertion operator.
  *
+ * \param[in] stream The stream to write the picolibrary::GPIO::Initial_Pull_Down_State
+ *            to.
+ * \param[in] initial_pull_down_state The picolibrary::GPIO::Initial_Pull_Down_State to
+ *            write to the stream.
+ *
+ * \return stream
+ */
+inline auto operator<<( std::ostream & stream, Initial_Pull_Down_State initial_pull_down_state )
+    -> std::ostream &
+{
+    switch ( initial_pull_down_state ) {
+            // clang-format off
+
+        case Initial_Pull_Down_State::DISABLED: return stream << "::picolibrary::GPIO::Initial_Pull_Down_State::DISABLED";
+        case Initial_Pull_Down_State::ENABLED:  return stream << "::picolibrary::GPIO::Initial_Pull_Down_State::ENABLED";
+
+            // clang-format on
+    } // switch
+
+    throw std::invalid_argument{
+        "initial_pull_down_state is not a valid "
+        "::picolibrary::GPIO::Initial_Pull_Down_State"
+    };
+}
+
+/**
+ * \brief Insertion operator.
+ *
  * \param[in] stream The stream to write the picolibrary::GPIO::Initial_Pin_State to.
  * \param[in] initial_pin_state The picolibrary::GPIO::Initial_Pin_State to write to the
  *            stream.


### PR DESCRIPTION
Resolves #2501 (Add GPIO initial internal pull-down resistor state).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
