### PR TITLE
Add GPIO internally pulled-down input pin concept

### DIFF
--- a/docs/gpio.md
+++ b/docs/gpio.md
@@ -9,6 +9,7 @@ header/source file pair.
 1. [Initial Pin State Identification](#initial-pin-state-identification)
 1. [Input Pin](#input-pin)
 1. [Internally Pulled-Up Input Pin](#internally-pulled-up-input-pin)
+1. [Internally Pulled-Down Input Pin](#internally-pulled-down-input-pin)
 1. [Output Pin](#output-pin)
 1. [I/O Pin](#io-pin)
 
@@ -109,6 +110,49 @@ source file.
 
 The `::picolibrary::Testing::Automated::GPIO::Mock_Internally_Pulled_Up_Input_Pin` mock
 GPIO internally pulled-up input pin class is available if the
+`PICOLIBRARY_ENABLE_AUTOMATED_TESTING` project configuration option is `ON`.
+The mock is defined in the
+[`include/picolibrary/testing/automated/gpio.h`](https://github.com/apcountryman/picolibrary/blob/main/include/picolibrary/testing/automated/gpio.h)/[`source/picolibrary/testing/automated/gpio.cc`](https://github.com/apcountryman/picolibrary/blob/main/source/picolibrary/testing/automated/gpio.cc)
+header/source file pair.
+
+The `::picolibrary::Testing::Interactive::GPIO::state()` interactive test helper is
+available if the `PICOLIBRARY_ENABLE_INTERACTIVE_TESTING` project configuration option is
+`ON`.
+The interactive test helper is defined in the
+[`include/picolibrary/testing/interactive/gpio.h`](https://github.com/apcountryman/picolibrary/blob/main/include/picolibrary/testing/interactive/gpio.h)/[`source/picolibrary/testing/interactive/gpio.cc`](https://github.com/apcountryman/picolibrary/blob/main/source/picolibrary/testing/interactive/gpio.cc)
+header/source file pair.
+
+## Internally Pulled-Down Input Pin
+The `::picolibrary::GPIO::Internally_Pulled_Down_Input_Pin_Concept` concept class defines
+the expected interface of a GPIO internally pulled-down input pin.
+- To initialize an internally pulled-down input pin's hardware, use an internally
+  pulled-down input pin implementation's `initialize()` member function.
+- To check if an internally pulled-down input pin's internal pull-down resistor is
+  disabled, use an internally pulled-down input pin implementation's
+  `pull_down_is_disabled()` member function.
+- To check if an internally pulled-down input pin's internal pull-down resistor is
+  enabled, use an internally pulled-down input pin implementation's
+  `pull_down_is_enabled()` member function.
+- To disable an internally pulled-down input pin's internal pull-down resistor, use an
+  internally pulled-down input pin implementation's `disable_pull_down()` member function.
+- To enable an internally pulled-down input pin's internal pull-down resistor, use an
+  internally pulled-down input pin implementation's `enable_pull_down()` member function.
+- To check if an internally pulled-down input pin is in the low state, use an internally
+  pulled-down input pin implementation's `is_low()` member function.
+- To check if an internally pulled-down input pin is in the high state, use an internally
+  pulled-down input pin implementation's `is_high()` member function.
+
+picolibrary assumes that the high pin/signals state is the active pin/signal state.
+All internally pulled-down input pin implementations should use this assumption.
+If the high pin/signal state is not the active pin/signal state, the
+`::picolibrary::GPIO::Active_Low_Input_Pin` template class can be used to invert an
+internally pulled-down input pin implementation's behavior.
+`::picolibrary::GPIO::Active_Low_Input_Pin` automated tests are defined in the
+[`test/automated/picolibrary/gpio/active_low_input_pin/main.cc`](https://github.com/apcountryman/picolibrary/blob/main/test/automated/picolibrary/gpio/active_low_input_pin/main.cc)
+source file.
+
+The `::picolibrary::Testing::Automated::GPIO::Mock_Internally_Pulled_Down_Input_Pin` mock
+GPIO internally pulled-down input pin class is available if the
 `PICOLIBRARY_ENABLE_AUTOMATED_TESTING` project configuration option is `ON`.
 The mock is defined in the
 [`include/picolibrary/testing/automated/gpio.h`](https://github.com/apcountryman/picolibrary/blob/main/include/picolibrary/testing/automated/gpio.h)/[`source/picolibrary/testing/automated/gpio.cc`](https://github.com/apcountryman/picolibrary/blob/main/source/picolibrary/testing/automated/gpio.cc)

--- a/include/picolibrary/gpio.h
+++ b/include/picolibrary/gpio.h
@@ -211,6 +211,99 @@ class Internally_Pulled_Up_Input_Pin_Concept {
 };
 
 /**
+ * \brief Internally pulled-down input pin concept.
+ *
+ * \attention picolibrary assumes that the high pin/signal state is the active pin/signal
+ *            state. All input pin implementations should use this assumption. If the high
+ *            pin/signal state is not the active pin/signal state,
+ *            picolibrary::GPIO::Active_Low_Input_Pin can be used to invert an input pin
+ *            implementation's behavior.
+ */
+class Internally_Pulled_Down_Input_Pin_Concept {
+  public:
+    /**
+     * \brief Constructor.
+     */
+    Internally_Pulled_Down_Input_Pin_Concept() noexcept;
+
+    /**
+     * \brief Constructor.
+     *
+     * \param[in] source The source of the move.
+     */
+    Internally_Pulled_Down_Input_Pin_Concept( Internally_Pulled_Down_Input_Pin_Concept && source ) noexcept;
+
+    Internally_Pulled_Down_Input_Pin_Concept( Internally_Pulled_Down_Input_Pin_Concept const & ) = delete;
+
+    /**
+     * \brief Destructor.
+     */
+    ~Internally_Pulled_Down_Input_Pin_Concept() noexcept;
+
+    /**
+     * \brief Assignment operator.
+     *
+     * \param[in] expression The expression to be assigned.
+     *
+     * \return The assigned to object.
+     */
+    auto operator=( Internally_Pulled_Down_Input_Pin_Concept && expression ) noexcept
+        -> Internally_Pulled_Down_Input_Pin_Concept &;
+
+    auto operator=( Internally_Pulled_Down_Input_Pin_Concept const & ) = delete;
+
+    /**
+     * \brief Initialize the pin's hardware.
+     *
+     * \param[in] initial_pull_down_state The initial state of the pin's internal
+     *            pull-down resistor.
+     */
+    void initialize( Initial_Pull_Down_State initial_pull_down_state = Initial_Pull_Down_State::DISABLED ) noexcept;
+
+    /**
+     * \brief Check if the pin's internal pull-down resistor is disabled.
+     *
+     * \return true if the pin's internal pull-down resistor is disabled.
+     * \return false if the pin's internal pull-down resistor is not disabled.
+     */
+    auto pull_down_is_disabled() const noexcept -> bool;
+
+    /**
+     * \brief Check if the pin's internal pull-down resistor is enabled.
+     *
+     * \return true if the pin's internal pull-down resistor is enabled.
+     * \return false if the pin's internal pull-down resistor is not enabled.
+     */
+    auto pull_down_is_enabled() const noexcept -> bool;
+
+    /**
+     * \brief Disable the pin's internal pull-down resistor.
+     */
+    void disable_pull_down() noexcept;
+
+    /**
+     * \brief Enable the pin's internal pull-down resistor.
+     */
+    void enable_pull_down() noexcept;
+
+    /**
+     * \brief Check if the pin is in the low state.
+     *
+     * \return true if the pin is in the low state.
+     * \return false if the pin is not in the low state.
+     */
+    auto is_low() const noexcept -> bool;
+
+    /**
+     * \brief Check if the pin is in the high state.
+     *
+     * \return true if the pin is in the high state.
+     * \return false if the pin is not in the high state.
+     */
+    auto is_high() const noexcept -> bool;
+};
+
+/**
  * \brief Output pin concept.
  *
  * \attention picolibrary assumes that the high pin/signal state is the active pin/signal

--- a/include/picolibrary/testing/automated/gpio.h
+++ b/include/picolibrary/testing/automated/gpio.h
@@ -274,6 +274,99 @@ class Mock_Internally_Pulled_Up_Input_Pin : public Mock_Input_Pin {
 };
 
 /**
+ * \brief Mock internally pull-down input pin.
+ */
+class Mock_Internally_Pulled_Down_Input_Pin : public Mock_Input_Pin {
+  public:
+    class Handle : public Mock_Input_Pin::Handle {
+      public:
+        constexpr Handle() noexcept = default;
+
+        constexpr Handle( Mock_Internally_Pulled_Down_Input_Pin & mock ) noexcept :
+            Mock_Input_Pin::Handle{ mock }
+        {
+        }
+
+        constexpr Handle( Handle && source ) noexcept = default;
+
+        Handle( Handle const & ) = delete;
+
+        ~Handle() noexcept = default;
+
+        constexpr auto operator=( Handle && expression ) noexcept -> Handle & = default;
+
+        auto operator=( Handle const & ) = delete;
+
+        auto mock() noexcept -> Mock_Internally_Pulled_Down_Input_Pin &
+        {
+            return static_cast<Mock_Internally_Pulled_Down_Input_Pin &>(
+                Mock_Input_Pin::Handle::mock() );
+        }
+
+        auto mock() const noexcept -> Mock_Internally_Pulled_Down_Input_Pin const &
+        {
+            return static_cast<Mock_Internally_Pulled_Down_Input_Pin const &>(
+                Mock_Input_Pin::Handle::mock() );
+        }
+
+        using Mock_Input_Pin::Handle::initialize;
+
+        void initialize( ::picolibrary::GPIO::Initial_Pull_Down_State initial_pull_down_state )
+        {
+            mock().initialize( initial_pull_down_state );
+        }
+
+        auto pull_down_is_disabled() const -> bool
+        {
+            return mock().pull_down_is_disabled();
+        }
+
+        auto pull_down_is_enabled() const -> bool
+        {
+            return mock().pull_down_is_enabled();
+        }
+
+        void disable_pull_down()
+        {
+            mock().disable_pull_down();
+        }
+
+        void enable_pull_down()
+        {
+            mock().enable_pull_down();
+        }
+    };
+
+    Mock_Internally_Pulled_Down_Input_Pin() = default;
+
+    Mock_Internally_Pulled_Down_Input_Pin( Mock_Internally_Pulled_Down_Input_Pin && ) = delete;
+
+    Mock_Internally_Pulled_Down_Input_Pin( Mock_Internally_Pulled_Down_Input_Pin const & ) = delete;
+
+    ~Mock_Internally_Pulled_Down_Input_Pin() noexcept = default;
+
+    auto operator=( Mock_Internally_Pulled_Down_Input_Pin && ) = delete;
+
+    auto operator=( Mock_Internally_Pulled_Down_Input_Pin const & ) = delete;
+
+    auto handle() noexcept -> Handle
+    {
+        return Handle{ *this };
+    }
+
+    using Mock_Input_Pin::gmock_initialize;
+    using Mock_Input_Pin::initialize;
+
+    MOCK_METHOD( void, initialize, ( ::picolibrary::GPIO::Initial_Pull_Down_State ) );
+
+    MOCK_METHOD( bool, pull_down_is_disabled, (), ( const ) );
+    MOCK_METHOD( bool, pull_down_is_enabled, (), ( const ) );
+
+    MOCK_METHOD( void, disable_pull_down, () );
+    MOCK_METHOD( void, enable_pull_down, () );
+};
+
+/**
  * \brief Mock output pin.
  */
 class Mock_Output_Pin {


### PR DESCRIPTION
Resolves #2502 (Add GPIO internally pulled-down input pin concept).

This pull request:
- [ ] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [x] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
