### PR TITLE
Fix hex dump output formatter usage example formatting

### DIFF
--- a/docs/io.md
+++ b/docs/io.md
@@ -357,3 +357,4 @@ void foo( ::picolibrary::Reliable_Output_Stream & stream ) noexcept
     // assuming std::size_t is 64-bit
     stream.print( ::picolibrary::Format::Hex_Dump{ data.begin(), data.end() } );
 }
+```


### PR DESCRIPTION
Resolves #2511 (Fix hex dump output formatter usage example formatting).

Resolves #.

This pull request:
- [x] Implements a bug fix
- [ ] Implements an enhancement to an existing feature
- [ ] Implements a new feature
- [ ] Performs a refactoring

Please mark the pull request as "Ready for review" and request a review when the pull
request is ready for a review.
If changes are requested, please discuss and/or address the review findings before
requesting a new review.

@apcountryman
